### PR TITLE
feat(vault): add created_at and updated_at history to vault items

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -15,7 +15,13 @@ run = "cd omawarden && cargo build --release && mkdir -p ../bin && cp -f target/
 
 [tasks.dev-update-omarchy-plugin]
 description = "Update the Omarchy plugin in development mode"
-run = "cd ~/.config/omarchy/plugins/icyleaf.bitwarden && git pull"
+run = """
+BRANCH=$(git branch --show-current)
+cd ~/.config/omarchy/plugins/icyleaf.bitwarden
+git fetch origin
+git checkout "$BRANCH"
+git merge "origin/$BRANCH"
+"""
 
 [tasks.dev-restart-omarchy]
 description = "Restart the Omarchy plugin in development mode"

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -116,7 +116,7 @@ ScrollView {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i]
   }
 
-  function formatPasskeyDate(dateStr) {
+  function formatDateTime(dateStr) {
     if (!dateStr) return ""
     try {
       var d = new Date(dateStr)
@@ -640,7 +640,7 @@ ScrollView {
 
           Text {
             visible: Boolean(inspectorRoot.item && inspectorRoot.item.login && inspectorRoot.item.login.passkey_created_at)
-            text: "Created " + (inspectorRoot.item && inspectorRoot.item.login ? inspectorRoot.formatPasskeyDate(inspectorRoot.item.login.passkey_created_at) : "")
+            text: "Created " + (inspectorRoot.item && inspectorRoot.item.login ? inspectorRoot.formatDateTime(inspectorRoot.item.login.passkey_created_at) : "")
             color: Qt.darker(inspectorRoot.foreground, 1.4)
             font.pixelSize: 11
             elide: Text.ElideRight
@@ -1103,6 +1103,67 @@ ScrollView {
           }
         }
       }
+
+      // --------------------------------------------------
+      // ITEM HISTORY SECTION
+      // --------------------------------------------------
+      ColumnLayout {
+        visible: Boolean(inspectorRoot.item && (inspectorRoot.item.created_at || inspectorRoot.item.updated_at))
+        Layout.fillWidth: true
+        spacing: 8
+
+        Text {
+          text: "Item history"
+          color: Qt.darker(inspectorRoot.foreground, 1.5)
+          font.pixelSize: 11
+          font.weight: Font.Medium
+        }
+
+        // Created At
+        RowLayout {
+          visible: Boolean(inspectorRoot.item && inspectorRoot.item.created_at)
+          Layout.fillWidth: true
+          spacing: 8
+
+          Text {
+            text: "Created:"
+            color: Qt.darker(inspectorRoot.foreground, 1.5)
+            font.pixelSize: 11
+            Layout.preferredWidth: 80
+          }
+
+          Text {
+            text: (inspectorRoot.item && inspectorRoot.item.created_at) ? inspectorRoot.formatDateTime(inspectorRoot.item.created_at) : ""
+            color: inspectorRoot.foreground
+            font.pixelSize: 11
+            elide: Text.ElideRight
+            Layout.fillWidth: true
+          }
+        }
+
+        // Updated At
+        RowLayout {
+          visible: Boolean(inspectorRoot.item && inspectorRoot.item.updated_at)
+          Layout.fillWidth: true
+          spacing: 8
+
+          Text {
+            text: "Updated:"
+            color: Qt.darker(inspectorRoot.foreground, 1.5)
+            font.pixelSize: 11
+            Layout.preferredWidth: 80
+          }
+
+          Text {
+            text: (inspectorRoot.item && inspectorRoot.item.updated_at) ? inspectorRoot.formatDateTime(inspectorRoot.item.updated_at) : ""
+            color: inspectorRoot.foreground
+            font.pixelSize: 11
+            elide: Text.ElideRight
+            Layout.fillWidth: true
+          }
+        }
+      }
     }
   }
 }
+

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -423,6 +423,18 @@ pub fn decrypt_sync_ciphers_with_context(
             .to_string();
         let item_type = c.get("type").and_then(|v| v.as_i64()).unwrap_or(1);
         let favorite = c.get("favorite").and_then(|v| v.as_bool()).unwrap_or(false);
+        let created_at = c
+            .get("creationDate")
+            .or_else(|| c.get("creation_date"))
+            .or_else(|| c.get("created_at"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let updated_at = c
+            .get("revisionDate")
+            .or_else(|| c.get("revision_date"))
+            .or_else(|| c.get("updated_at"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
 
         // Folder metadata
         let folder_id = c
@@ -740,6 +752,8 @@ pub fn decrypt_sync_ciphers_with_context(
             "type": item_type,
             "notes": notes,
             "favorite": favorite,
+            "created_at": created_at,
+            "updated_at": updated_at,
             "login": login_val,
             "card": card_val,
             "identity": identity_val,
@@ -774,6 +788,8 @@ pub fn decrypt_sync_ciphers_with_context(
                 sub_title,
                 notes,
                 favorite,
+                created_at,
+                updated_at,
                 folder_id,
                 folder_name,
                 organization_id: org_id_opt,
@@ -955,6 +971,8 @@ pub fn decrypt_sync_ciphers_with_context(
             sub_title,
             notes,
             favorite,
+            created_at,
+            updated_at,
             folder_id,
             folder_name,
             organization_id: org_id_opt,
@@ -1344,5 +1362,33 @@ mod tests {
             .get("passkey_created_at")
             .unwrap()
             .is_null());
+    }
+
+    #[test]
+    fn test_decrypt_ciphers_with_timestamps() {
+        let raw_user_key = [15u8; 64];
+        let user_key = SymmetricCryptoKey::from_raw_bytes(&raw_user_key).unwrap();
+
+        let ciphers = vec![json!({
+            "id": "cipher-timestamps",
+            "type": 1,
+            "name": encrypt_test_string("Item With Timestamps", &user_key),
+            "creationDate": "2024-01-15T08:20:00.000Z",
+            "revisionDate": "2024-06-20T11:45:00.000Z",
+            "login": {
+                "username": encrypt_test_string("alice", &user_key),
+            }
+        })];
+
+        let items = decrypt_sync_ciphers(&ciphers, &user_key);
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].created_at.as_deref(),
+            Some("2024-01-15T08:20:00.000Z")
+        );
+        assert_eq!(
+            items[0].updated_at.as_deref(),
+            Some("2024-06-20T11:45:00.000Z")
+        );
     }
 }

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -31,6 +31,10 @@ pub struct VaultItem {
     pub notes: Option<String>,
     pub favorite: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub folder_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub folder_name: Option<String>,
@@ -623,6 +627,18 @@ impl VaultManager {
                         .filter_map(|v| v.as_str().map(|s| s.to_string()))
                         .collect::<Vec<_>>()
                 });
+            let created_at = raw
+                .get("created_at")
+                .or_else(|| raw.get("creationDate"))
+                .or_else(|| raw.get("creation_date"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let updated_at = raw
+                .get("updated_at")
+                .or_else(|| raw.get("revisionDate"))
+                .or_else(|| raw.get("revision_date"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
 
             if let Some(ssh_meta) = detect_ssh_key_metadata(raw) {
                 let type_name = "ssh_key".to_string();
@@ -655,6 +671,8 @@ impl VaultManager {
                     sub_title,
                     notes,
                     favorite,
+                    created_at,
+                    updated_at,
                     folder_id,
                     folder_name: None,
                     organization_id,
@@ -708,6 +726,8 @@ impl VaultManager {
                 sub_title,
                 notes,
                 favorite,
+                created_at,
+                updated_at,
                 folder_id,
                 folder_name: None,
                 organization_id,


### PR DESCRIPTION
## Summary of Changes

- **VaultItem Model & Decryption**: Added `created_at` and `updated_at` fields to `VaultItem`, extracting Bitwarden cipher timestamps `creationDate` and `revisionDate`.
- **ItemInspector**: Extracted `formatPasskeyDate` into a generic `formatDateTime` helper function in `components/ItemInspector.qml`.
- **Item History UI**: Added a dedicated "Item history" section at the bottom of `ItemInspector` displaying formatted creation and update timestamps.
- **Dev Deployment Task**: Updated `dev-update-omarchy-plugin` in `.mise.toml` to automatically checkout the current development branch and merge origin in the target plugin directory.

## Testing Evidence
- All 44 unit tests passing (`XDG_RUNTIME_DIR=/tmp cargo test`).
- `cargo clippy` and `cargo fmt` checks clean.
- Verified in local Omarchy plugin environment via `mise run dev-deploy`.