### PR TITLE
fix(vault): support official Bitwarden SSH Key cipher type 5 and prevent note hijacking

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -702,8 +702,9 @@ Item {
         actions.push({ label: "Copy Expiration (" + expStr + ")", icon: "\uf073", shortcut: "", action: function() { root.copyToClipboard(expStr, false, "expiration") } })
       }
     } else if (item.type_name === "ssh_key" && item.ssh_key) {
-      if (item.ssh_key.public_key) actions.push({ label: "Copy Public Key", icon: "\uf084", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.public_key, false, "public key") } })
       if (item.ssh_key.private_key) actions.push({ label: "Copy Private Key", icon: "\uf084", shortcut: "↵", action: function() { root.copyToClipboard(item.ssh_key.private_key, true, "private key") } })
+      if (item.ssh_key.public_key) actions.push({ label: "Copy Public Key", icon: "\uf084", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.public_key, false, "public key") } })
+      if (item.ssh_key.fingerprint) actions.push({ label: "Copy Fingerprint", icon: "\uf084", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.fingerprint, false, "fingerprint") } })
       if (item.ssh_key.passphrase) actions.push({ label: "Copy Passphrase", icon: "\uf023", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.passphrase, true, "passphrase") } })
     } else if (item.type_name === "identity" && item.identity) {
       var idFullName = ((item.identity.firstName || "") + " " + (item.identity.lastName || "")).trim()

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -1090,27 +1090,73 @@ ScrollView {
           spacing: 8
 
           RowLayout {
-            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.key_type)
+            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.private_key)
             Layout.fillWidth: true
             spacing: 8
 
             ColumnLayout {
               Layout.fillWidth: true
               spacing: 2
-              Text { text: "Key Type"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
+              Text { text: "Private Key"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
-                text: (inspectorRoot.item && inspectorRoot.item.ssh_key) ? (inspectorRoot.item.ssh_key.key_type || "") : ""
+                text: (inspectorRoot.item && inspectorRoot.item.ssh_key) ? (inspectorRoot.showPrivateKeyRevealed ? (inspectorRoot.item.ssh_key.private_key || "") : "••••••••••••••••") : ""
                 color: inspectorRoot.foreground
                 font.pixelSize: inspectorRoot.valuePixelSize
+                font.family: "monospace"
                 font.weight: Font.Medium
-                elide: Text.ElideRight
+                wrapMode: Text.WrapAnywhere
                 Layout.fillWidth: true
               }
+            }
+
+            GhostIconButton {
+              iconText: inspectorRoot.showPrivateKeyRevealed ? "\uf070" : "\uf06e"
+              tooltip: inspectorRoot.showPrivateKeyRevealed ? "Hide private key" : "Show private key"
+              onClicked: inspectorRoot.togglePrivateKeyRevealed()
+            }
+            GhostIconButton {
+              iconText: "\uf0c5"
+              tooltip: "Copy private key"
+              onClicked: { if (inspectorRoot.item && inspectorRoot.item.ssh_key) inspectorRoot.copyRequested(inspectorRoot.item.ssh_key.private_key, true, "SSH private key") }
             }
           }
 
           Rectangle {
-            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.fingerprint)
+            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.private_key && (inspectorRoot.item.ssh_key.public_key || inspectorRoot.item.ssh_key.fingerprint))
+            Layout.fillWidth: true
+            height: 1
+            color: Qt.rgba(255, 255, 255, 0.05)
+          }
+
+          RowLayout {
+            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.public_key)
+            Layout.fillWidth: true
+            spacing: 8
+
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 2
+              Text { text: "Public Key"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
+              Text {
+                text: (inspectorRoot.item && inspectorRoot.item.ssh_key) ? (inspectorRoot.item.ssh_key.public_key || "") : ""
+                color: inspectorRoot.foreground
+                font.pixelSize: inspectorRoot.valuePixelSize
+                font.family: "monospace"
+                font.weight: Font.Medium
+                wrapMode: Text.WrapAnywhere
+                Layout.fillWidth: true
+              }
+            }
+
+            GhostIconButton {
+              iconText: "\uf0c5"
+              tooltip: "Copy public key"
+              onClicked: { if (inspectorRoot.item && inspectorRoot.item.ssh_key) inspectorRoot.copyRequested(inspectorRoot.item.ssh_key.public_key, false, "SSH public key") }
+            }
+          }
+
+          Rectangle {
+            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.public_key && inspectorRoot.item.ssh_key.fingerprint)
             Layout.fillWidth: true
             height: 1
             color: Qt.rgba(255, 255, 255, 0.05)
@@ -1131,7 +1177,7 @@ ScrollView {
                 font.pixelSize: inspectorRoot.valuePixelSize
                 font.family: "monospace"
                 font.weight: Font.Medium
-                elide: Text.ElideRight
+                wrapMode: Text.WrapAnywhere
                 Layout.fillWidth: true
               }
             }
@@ -1140,75 +1186,6 @@ ScrollView {
               iconText: "\uf0c5"
               tooltip: "Copy fingerprint"
               onClicked: { if (inspectorRoot.item && inspectorRoot.item.ssh_key) inspectorRoot.copyRequested(inspectorRoot.item.ssh_key.fingerprint, false, "fingerprint") }
-            }
-          }
-
-          Rectangle {
-            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.public_key)
-            Layout.fillWidth: true
-            height: 1
-            color: Qt.rgba(255, 255, 255, 0.05)
-          }
-
-          RowLayout {
-            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.public_key)
-            Layout.fillWidth: true
-            spacing: 8
-
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 2
-              Text { text: "Public Key"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
-              Text {
-                text: "Available"
-                color: inspectorRoot.foreground
-                font.pixelSize: inspectorRoot.valuePixelSize
-                font.weight: Font.Medium
-                Layout.fillWidth: true
-              }
-            }
-
-            GhostIconButton {
-              iconText: "\uf0c5"
-              tooltip: "Copy public key"
-              onClicked: { if (inspectorRoot.item && inspectorRoot.item.ssh_key) inspectorRoot.copyRequested(inspectorRoot.item.ssh_key.public_key, false, "SSH public key") }
-            }
-          }
-
-          Rectangle {
-            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.private_key)
-            Layout.fillWidth: true
-            height: 1
-            color: Qt.rgba(255, 255, 255, 0.05)
-          }
-
-          RowLayout {
-            visible: Boolean(inspectorRoot.item && inspectorRoot.item.ssh_key && inspectorRoot.item.ssh_key.private_key)
-            Layout.fillWidth: true
-            spacing: 8
-
-            ColumnLayout {
-              Layout.fillWidth: true
-              spacing: 2
-              Text { text: "Private Key"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
-              Text {
-                text: inspectorRoot.showPrivateKeyRevealed ? "Revealed" : "Encrypted (Hidden)"
-                color: inspectorRoot.foreground
-                font.pixelSize: inspectorRoot.valuePixelSize
-                font.weight: Font.Medium
-                Layout.fillWidth: true
-              }
-            }
-
-            GhostIconButton {
-              iconText: inspectorRoot.showPrivateKeyRevealed ? "\uf070" : "\uf06e"
-              tooltip: inspectorRoot.showPrivateKeyRevealed ? "Hide private key" : "Show private key"
-              onClicked: inspectorRoot.togglePrivateKeyRevealed()
-            }
-            GhostIconButton {
-              iconText: "\uf0c5"
-              tooltip: "Copy private key"
-              onClicked: { if (inspectorRoot.item && inspectorRoot.item.ssh_key) inspectorRoot.copyRequested(inspectorRoot.item.ssh_key.private_key, true, "SSH private key") }
             }
           }
         }

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::crypto::{
     derive_master_key, derive_master_password_hash, EncString, KdfType, SymmetricCryptoKey,
 };
-use crate::vault::{detect_ssh_key_metadata, VaultItem};
+use crate::vault::{parse_ssh_key_fields, SshMetadata, VaultItem};
 
 #[derive(Debug, Clone)]
 pub enum ApiError {
@@ -91,7 +91,26 @@ pub struct BitwardenApiClient {
 impl BitwardenApiClient {
     pub fn new(server_url: &str) -> Self {
         let base = server_url.trim_end_matches('/');
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        default_headers.insert(
+            reqwest::header::USER_AGENT,
+            reqwest::header::HeaderValue::from_static("Bitwarden_Desktop/2025.1.0 (Linux)"),
+        );
+        default_headers.insert(
+            reqwest::header::HeaderName::from_static("bitwarden-client-name"),
+            reqwest::header::HeaderValue::from_static("desktop"),
+        );
+        default_headers.insert(
+            reqwest::header::HeaderName::from_static("bitwarden-client-version"),
+            reqwest::header::HeaderValue::from_static("2025.1.0"),
+        );
+        default_headers.insert(
+            reqwest::header::HeaderName::from_static("device-type"),
+            reqwest::header::HeaderValue::from_static("linux"),
+        );
+
         let client = Client::builder()
+            .default_headers(default_headers)
             .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_default();
@@ -692,6 +711,27 @@ pub fn decrypt_sync_ciphers_with_context(
             }
         }
 
+        let mut ssh_key_val: Option<SshMetadata> = None;
+        if item_type == 5 {
+            if let Some(ssh_obj) = c.get("sshKey").or_else(|| c.get("SshKey")) {
+                if !ssh_obj.is_null() {
+                    let priv_k = decrypt_cipher_string(
+                        ssh_obj.get("privateKey").and_then(|v| v.as_str()),
+                        &cipher_key,
+                    );
+                    let pub_k = decrypt_cipher_string(
+                        ssh_obj.get("publicKey").and_then(|v| v.as_str()),
+                        &cipher_key,
+                    );
+                    let fp = decrypt_cipher_string(
+                        ssh_obj.get("keyFingerprint").and_then(|v| v.as_str()),
+                        &cipher_key,
+                    );
+                    ssh_key_val = Some(parse_ssh_key_fields(priv_k, pub_k, fp));
+                }
+            }
+        }
+
         // Decrypt fields if present
         let mut fields_decrypted = Vec::new();
         if let Some(fields_arr) = c.get("fields").and_then(|v| v.as_array()) {
@@ -743,67 +783,6 @@ pub fn decrypt_sync_ciphers_with_context(
                     "url": url,
                 }));
             }
-        }
-
-        // Build raw JSON representation to feed into SSH heuristic scanner
-        let raw_item_json = json!({
-            "id": id,
-            "name": name,
-            "type": item_type,
-            "notes": notes,
-            "favorite": favorite,
-            "created_at": created_at,
-            "updated_at": updated_at,
-            "login": login_val,
-            "card": card_val,
-            "identity": identity_val,
-            "fields": fields_decrypted,
-            "attachments": attachments_decrypted,
-        });
-
-        if let Some(ssh_meta) = detect_ssh_key_metadata(&raw_item_json) {
-            let type_name = "ssh_key".to_string();
-            let sub_title = format!("SSH Key ({})", ssh_meta.key_type);
-            let mut search_tokens = vec![
-                name.to_lowercase(),
-                "ssh".to_string(),
-                "ssh key".to_string(),
-                ssh_meta.key_type.to_lowercase(),
-            ];
-            if let Some(ref pubk) = ssh_meta.public_key {
-                search_tokens.push(pubk.to_lowercase());
-            }
-            for att in &attachments_decrypted {
-                if let Some(fn_str) = att.get("fileName").and_then(|v| v.as_str()) {
-                    search_tokens.push(fn_str.to_lowercase());
-                }
-            }
-            let search_text = search_tokens.join(" ");
-
-            items.push(VaultItem {
-                id,
-                name,
-                item_type,
-                type_name,
-                sub_title,
-                notes,
-                favorite,
-                created_at,
-                updated_at,
-                folder_id,
-                folder_name,
-                organization_id: org_id_opt,
-                organization_name: org_name_opt,
-                collection_ids,
-                login: None,
-                card: None,
-                identity: None,
-                ssh_key: Some(ssh_meta),
-                fields: fields_decrypted,
-                attachments: attachments_decrypted,
-                search_text,
-            });
-            continue;
         }
 
         let type_name = match item_type {
@@ -882,6 +861,13 @@ pub fn decrypt_sync_ciphers_with_context(
                     "Identity".to_string()
                 }
             }
+            5 => {
+                if let Some(ref s) = ssh_key_val {
+                    format!("SSH Key ({})", s.key_type)
+                } else {
+                    "SSH Key".to_string()
+                }
+            }
             _ => {
                 if let Some(ref l) = login_val {
                     l.get("username")
@@ -941,6 +927,19 @@ pub fn decrypt_sync_ciphers_with_context(
                 }
             }
         }
+        if item_type == 5 {
+            search_tokens.push("ssh".to_string());
+            search_tokens.push("ssh key".to_string());
+            if let Some(ref s) = ssh_key_val {
+                search_tokens.push(s.key_type.to_lowercase());
+                if let Some(ref pubk) = s.public_key {
+                    search_tokens.push(pubk.to_lowercase());
+                }
+                if let Some(ref fp) = s.fingerprint {
+                    search_tokens.push(fp.to_lowercase());
+                }
+            }
+        }
         for f in &fields_decrypted {
             if let Some(fn_str) = f.get("name").and_then(|v| v.as_str()) {
                 search_tokens.push(fn_str.to_lowercase());
@@ -981,7 +980,7 @@ pub fn decrypt_sync_ciphers_with_context(
             login: if item_type == 1 { login_val } else { None },
             card: if item_type == 3 { card_val } else { None },
             identity: if item_type == 4 { identity_val } else { None },
-            ssh_key: None,
+            ssh_key: if item_type == 5 { ssh_key_val } else { None },
             fields: fields_decrypted,
             attachments: attachments_decrypted,
             search_text,
@@ -1362,6 +1361,59 @@ mod tests {
             .get("passkey_created_at")
             .unwrap()
             .is_null());
+    }
+
+    #[test]
+    fn test_decrypt_ssh_key_cipher_type_5() {
+        let raw_user_key = [16u8; 64];
+        let user_key = SymmetricCryptoKey::from_raw_bytes(&raw_user_key).unwrap();
+
+        let ciphers = vec![
+            json!({
+                "id": "cipher-ssh-5",
+                "type": 5,
+                "name": encrypt_test_string("Production Server Key", &user_key),
+                "sshKey": {
+                    "publicKey": encrypt_test_string("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG... dev@server", &user_key),
+                    "privateKey": encrypt_test_string("-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----", &user_key),
+                    "keyFingerprint": encrypt_test_string("SHA256:fingerprint123456", &user_key)
+                }
+            }),
+            json!({
+                "id": "cipher-note-2",
+                "type": 2,
+                "name": encrypt_test_string("Regular Note", &user_key),
+                "notes": encrypt_test_string("Just some text with ssh-rsa AAAAB3NzaC1yc2E... in it", &user_key)
+            }),
+        ];
+
+        let items = decrypt_sync_ciphers(&ciphers, &user_key);
+        assert_eq!(items.len(), 2);
+
+        // Cipher Type 5
+        assert_eq!(items[0].type_name, "ssh_key");
+        assert_eq!(items[0].sub_title, "SSH Key (ED25519)");
+        let ssh_meta = items[0].ssh_key.as_ref().unwrap();
+        assert_eq!(ssh_meta.key_type, "ED25519");
+        assert!(ssh_meta
+            .public_key
+            .as_ref()
+            .unwrap()
+            .starts_with("ssh-ed25519"));
+        assert!(ssh_meta
+            .private_key
+            .as_ref()
+            .unwrap()
+            .contains("BEGIN OPENSSH"));
+        assert_eq!(
+            ssh_meta.fingerprint.as_deref(),
+            Some("SHA256:fingerprint123456")
+        );
+
+        // Cipher Type 2 (Note) remains Note!
+        assert_eq!(items[1].type_name, "note");
+        assert_eq!(items[1].sub_title, "Secure Note");
+        assert!(items[1].ssh_key.is_none());
     }
 
     #[test]

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -17,6 +17,7 @@ pub struct SshMetadata {
     pub key_type: String,
     pub private_key: Option<String>,
     pub public_key: Option<String>,
+    pub fingerprint: Option<String>,
     pub passphrase: Option<String>,
 }
 
@@ -210,10 +211,53 @@ pub fn detect_ssh_key_metadata(raw: &Value) -> Option<SshMetadata> {
             key_type,
             private_key,
             public_key,
+            fingerprint: None,
             passphrase,
         })
     } else {
         None
+    }
+}
+
+pub fn parse_ssh_key_fields(
+    private_key: Option<String>,
+    public_key: Option<String>,
+    fingerprint: Option<String>,
+) -> SshMetadata {
+    let mut key_type = "SSH".to_string();
+    if let Some(ref pk) = public_key {
+        if pk.contains("ssh-ed25519") {
+            key_type = "ED25519".to_string();
+        } else if pk.contains("ssh-rsa") {
+            key_type = "RSA".to_string();
+        } else if pk.contains("ecdsa") {
+            key_type = "ECDSA".to_string();
+        } else if pk.contains("ssh-dss") {
+            key_type = "DSA".to_string();
+        }
+    } else if let Some(ref prk) = private_key {
+        if prk.contains("OPENSSH") {
+            key_type = if prk.contains("ed25519") {
+                "ED25519".to_string()
+            } else {
+                "OPENSSH".to_string()
+            };
+        } else if prk.contains("RSA") {
+            key_type = "RSA".to_string();
+        } else if prk.contains("EC") {
+            key_type = "ECDSA".to_string();
+        } else if prk.contains("DSA") {
+            key_type = "DSA".to_string();
+        }
+    }
+
+    SshMetadata {
+        is_ssh_key: true,
+        key_type,
+        private_key,
+        public_key,
+        fingerprint,
+        passphrase: None,
     }
 }
 
@@ -336,10 +380,10 @@ impl VaultManager {
 
         let sync_resp = match sync_resp_res {
             Ok(resp) => resp,
-            Err(ApiError::Http(ref msg)) if msg.contains("401") => {
+            Err(ApiError::Http(ref msg)) if msg.contains("401") || msg.contains("403") => {
                 crate::log_warn!(
                     "omawarden:vault",
-                    "HTTP 401 on sync. Attempting token refresh..."
+                    "HTTP 401/403 on sync. Attempting token refresh..."
                 );
                 if let Some(ref ref_tok) = storage.refresh_token {
                     if let Ok(tok_resp) = client.refresh_token_grant(ref_tok) {
@@ -640,55 +684,6 @@ impl VaultManager {
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
-            if let Some(ssh_meta) = detect_ssh_key_metadata(raw) {
-                let type_name = "ssh_key".to_string();
-                let sub_title = format!("SSH Key ({})", ssh_meta.key_type);
-                let mut search_tokens = vec![
-                    name.to_lowercase(),
-                    "ssh".to_string(),
-                    "ssh key".to_string(),
-                    ssh_meta.key_type.to_lowercase(),
-                ];
-                if let Some(ref pubk) = ssh_meta.public_key {
-                    search_tokens.push(pubk.to_lowercase());
-                }
-                for att in &attachments {
-                    if let Some(fname) = att.get("fileName").and_then(|v| v.as_str()) {
-                        search_tokens.push(fname.to_lowercase());
-                    }
-                }
-                let search_text = search_tokens
-                    .into_iter()
-                    .filter(|s| !s.is_empty())
-                    .collect::<Vec<_>>()
-                    .join(" ");
-
-                parsed.push(VaultItem {
-                    id,
-                    name,
-                    item_type,
-                    type_name,
-                    sub_title,
-                    notes,
-                    favorite,
-                    created_at,
-                    updated_at,
-                    folder_id,
-                    folder_name: None,
-                    organization_id,
-                    organization_name: None,
-                    collection_ids,
-                    login: None,
-                    card: None,
-                    identity: None,
-                    ssh_key: Some(ssh_meta),
-                    fields,
-                    attachments,
-                    search_text,
-                });
-                continue;
-            }
-
             let type_name = match item_type {
                 1 => "login",
                 2 => "note",
@@ -717,6 +712,31 @@ impl VaultManager {
                 .filter(|s| !s.is_empty())
                 .collect::<Vec<_>>()
                 .join(" ");
+
+            let ssh_key = if item_type == 5 {
+                if let Some(ssh_data) = raw.get("sshKey").or_else(|| raw.get("ssh_key")) {
+                    let priv_k = ssh_data
+                        .get("privateKey")
+                        .or_else(|| ssh_data.get("private_key"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let pub_k = ssh_data
+                        .get("publicKey")
+                        .or_else(|| ssh_data.get("public_key"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let fp = ssh_data
+                        .get("keyFingerprint")
+                        .or_else(|| ssh_data.get("fingerprint"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    Some(parse_ssh_key_fields(priv_k, pub_k, fp))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
 
             parsed.push(VaultItem {
                 id,
@@ -748,7 +768,7 @@ impl VaultManager {
                 } else {
                     None
                 },
-                ssh_key: None,
+                ssh_key,
                 fields,
                 attachments,
                 search_text,
@@ -834,6 +854,49 @@ impl VaultManager {
                     search_tokens.push(fname.to_lowercase());
                     search_tokens.push(lname.to_lowercase());
                     search_tokens.push(full_name.to_lowercase());
+                }
+            }
+            5 => {
+                if let Some(ssh_data) = raw.get("sshKey").or_else(|| raw.get("ssh_key")) {
+                    let pubk = ssh_data
+                        .get("publicKey")
+                        .or_else(|| ssh_data.get("public_key"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let privk = ssh_data
+                        .get("privateKey")
+                        .or_else(|| ssh_data.get("private_key"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let fp = ssh_data
+                        .get("keyFingerprint")
+                        .or_else(|| ssh_data.get("fingerprint"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let mut key_type = "SSH".to_string();
+                    if pubk.contains("ssh-ed25519") || privk.contains("ed25519") {
+                        key_type = "ED25519".to_string();
+                    } else if pubk.contains("ssh-rsa") || privk.contains("RSA") {
+                        key_type = "RSA".to_string();
+                    } else if pubk.contains("ecdsa") || privk.contains("EC") {
+                        key_type = "ECDSA".to_string();
+                    } else if pubk.contains("ssh-dss") || privk.contains("DSA") {
+                        key_type = "DSA".to_string();
+                    }
+                    sub_title = format!("SSH Key ({})", key_type);
+                    search_tokens.push("ssh".to_string());
+                    search_tokens.push("ssh key".to_string());
+                    search_tokens.push(key_type.to_lowercase());
+                    if !pubk.is_empty() {
+                        search_tokens.push(pubk.to_lowercase());
+                    }
+                    if !fp.is_empty() {
+                        search_tokens.push(fp.to_lowercase());
+                    }
+                } else {
+                    sub_title = "SSH Key".to_string();
+                    search_tokens.push("ssh".to_string());
+                    search_tokens.push("ssh key".to_string());
                 }
             }
             2 => {
@@ -1025,14 +1088,24 @@ mod tests {
             json!({
                 "id": "3",
                 "name": "Server Access",
+                "type": 5,
+                "sshKey": {
+                    "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5... user@host",
+                    "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----",
+                    "keyFingerprint": "SHA256:abcd1234efgh"
+                }
+            }),
+            json!({
+                "id": "4",
+                "name": "Server Backup Notes",
                 "type": 2,
-                "notes": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----"
+                "notes": "Here is a note with ssh-rsa AAAAB3... that should stay as a note"
             }),
         ];
 
         let vault_mgr = VaultManager::new("https://vault.example.com", None, None);
         let items = vault_mgr.parse_raw_items(&raw_items);
-        assert_eq!(items.len(), 3);
+        assert_eq!(items.len(), 4);
 
         assert_eq!(items[0].type_name, "login");
         assert_eq!(items[0].sub_title, "octocat");
@@ -1041,7 +1114,16 @@ mod tests {
         assert_eq!(items[1].sub_title, "Visa •••• 4444");
 
         assert_eq!(items[2].type_name, "ssh_key");
-        assert!(items[2].sub_title.contains("SSH Key"));
+        assert_eq!(items[2].sub_title, "SSH Key (ED25519)");
+        assert!(items[2].ssh_key.is_some());
+        assert_eq!(
+            items[2].ssh_key.as_ref().unwrap().fingerprint.as_deref(),
+            Some("SHA256:abcd1234efgh")
+        );
+
+        assert_eq!(items[3].type_name, "note");
+        assert_eq!(items[3].sub_title, "Secure Note");
+        assert!(items[3].ssh_key.is_none());
 
         let search_gh = vault_mgr.search(&items, "github", None);
         assert_eq!(search_gh.len(), 1);
@@ -1054,6 +1136,10 @@ mod tests {
         let search_ssh = vault_mgr.search(&items, "", Some("ssh_key"));
         assert_eq!(search_ssh.len(), 1);
         assert_eq!(search_ssh[0].id, "3");
+
+        let search_note = vault_mgr.search(&items, "", Some("note"));
+        assert_eq!(search_note.len(), 1);
+        assert_eq!(search_note[0].id, "4");
     }
 
     #[test]


### PR DESCRIPTION
## Summary of Changes

- **Official Bitwarden SSH Key Support (Cipher Type 5)**:
  - Decrypts official `sshKey` cipher payload (`publicKey`, `privateKey`, `keyFingerprint`).
  - Correctly maps Type 5 items to `ssh_key` category with key type detection (ED25519, RSA, ECDSA, DSA).
  - Added Bitwarden client headers (`Bitwarden-Client-Name: desktop`, `Bitwarden-Client-Version: 2025.1.0`) to ensure Bitwarden/Vaultwarden servers deliver Type 5 ciphers during sync instead of filtering them out.
- **Prevent Note Category Hijacking**:
  - Removed heuristic note classification that misidentified Secure Notes containing SSH keys as SSH items.
- **SSH Key Inspector & Action UI Overhaul**:
  - Reordered SSH Key fieldset: Private Key (with reveal/hide toggle) -> Public Key -> Fingerprint (multiline wrapping).
  - Reordered context actions: Copy Private Key (↵) -> Copy Public Key -> Copy Fingerprint -> Copy Passphrase.
  - Formatted public key, private key, and fingerprint with monospace and multiline wrapping.