### PR TITLE
feat: SSH key management (generation, import, export in CLI & UI)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,7 +42,7 @@
   - **Card**: Payment card details (Brand, Cardholder, Number with reveal toggle, Expiration, CVV/Security Code).
   - **Identity**: Personal identification records (Title, Full Name, Username, Email, Phone, Company, Address, SSN, Passport, License).
   - **Secure Note**: Encrypted text notes or documentation with dedicated category classification.
-  - **SSH Key**: Private and public key pairs (heuristically identified by PEM headers or custom fields `private_key`/`public_key`/`passphrase`).
+  - **SSH Key**: Private and public key pairs (official Bitwarden Cipher Type 5 with `privateKey`, `publicKey`, and `keyFingerprint`). Supports automated on-the-fly key generation (Ed25519, RSA, ECDSA), file/STDIN import with auto-derived public keys/fingerprints, and export with hardened Unix file permissions (`0600`/`0644`) via `omawarden ssh-key` (see `docs/adr/0005-ssh-key-management-lifecycle.md`).
   - **Attachments**: Encrypted binary or text files associated with an item. Downloads resolve signed URLs, decrypt Bitwarden `EncArrayBuffer` binary blobs (`[encType][IV][MAC][Ciphertext]`) via AES-256-CBC using resolved `attachment.key` or `cipher_key`, and support both in-overlay popup previews (images and text) and external default app viewing via `xdg-open` (see `docs/adr/0002-vault-item-attachments-lifecycle.md`).
 - **Vault Index**: An in-memory, fast-searchable structured cache of vault items updated upon `sync` or vault unlock.
 

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -92,6 +92,9 @@ Item {
   property bool showActionPalette: false
   property int actionPaletteIndex: 0
   property var currentAvailableActions: []
+  property bool showSshKeyModal: false
+  property string sshKeyModalMode: "create"
+  property var sshKeyModalItem: null
   property var activeAttachmentPreview: null
   property string loadingAttachmentId: ""
 
@@ -151,6 +154,7 @@ Item {
     root.statusMessage = ""
     root.currentView = "auto"
     root.showActionPalette = false
+    root.showSshKeyModal = false
     root.showPasswordRevealed = false
     root.showPrivateKeyRevealed = false
     root.activeAttachmentPreview = null
@@ -176,6 +180,7 @@ Item {
   function close() {
     root.opened = false
     root.showActionPalette = false
+    root.showSshKeyModal = false
   }
 
   function dismiss() {
@@ -519,11 +524,13 @@ Item {
     if (root.showActionPalette) {
       root.updateAvailableActions()
     } else {
-      Qt.callLater(function() {
-        if (root.effectiveView === "search" && searchHeader && searchHeader.searchField) {
-          searchHeader.searchField.forceActiveFocus()
-        }
-      })
+      root.restoreSearchFocus()
+    }
+  }
+
+  onShowSshKeyModalChanged: {
+    if (!root.showSshKeyModal) {
+      root.restoreSearchFocus()
     }
   }
 
@@ -613,6 +620,9 @@ Item {
       uName = item.login.username
     } else if (item.type_name === "identity" && item.identity && item.identity.username) {
       uName = item.identity.username
+    } else if (item.type_name === "ssh_key" && item.ssh_key && item.ssh_key.public_key) {
+      root.copyToClipboard(item.ssh_key.public_key, false, "SSH public key")
+      return
     }
     if (uName) {
       root.copyToClipboard(uName, false, "username")
@@ -648,8 +658,14 @@ Item {
   }
 
   function getAvailableActions(item) {
-    if (!item) return []
     var actions = []
+    if (!item) {
+      actions.push({ label: "Generate SSH Key", icon: "\uf067", shortcut: "", action: function() { root.openSshKeyModal("create", null) } })
+      actions.push({ label: "Import SSH Key", icon: "\uf093", shortcut: "", action: function() { root.openSshKeyModal("import", null) } })
+      actions.push({ label: "Sync Vault Now", icon: "\uf021", shortcut: "Ctrl+R", action: function() { root.syncVault(false, true) } })
+      actions.push({ label: "Lock Vault", icon: "\uf023", shortcut: "Ctrl+L", action: function() { root.doLock() } })
+      return actions
+    }
 
     if (item.type_name === "login" && item.login) {
       if (item.login.password) {
@@ -702,10 +718,18 @@ Item {
         actions.push({ label: "Copy Expiration (" + expStr + ")", icon: "\uf073", shortcut: "", action: function() { root.copyToClipboard(expStr, false, "expiration") } })
       }
     } else if (item.type_name === "ssh_key" && item.ssh_key) {
-      if (item.ssh_key.private_key) actions.push({ label: "Copy Private Key", icon: "\uf084", shortcut: "↵", action: function() { root.copyToClipboard(item.ssh_key.private_key, true, "private key") } })
-      if (item.ssh_key.public_key) actions.push({ label: "Copy Public Key", icon: "\uf084", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.public_key, false, "public key") } })
+      if (item.ssh_key.private_key) actions.push({ label: "Copy Private Key", icon: "\uf084", shortcut: "↵", action: function() { root.copyToClipboard(item.ssh_key.private_key, true, "SSH private key") } })
+      if (item.ssh_key.public_key) actions.push({ label: "Copy Public Key", icon: "\uf084", shortcut: "Ctrl+U", action: function() { root.copyToClipboard(item.ssh_key.public_key, false, "SSH public key") } })
       if (item.ssh_key.fingerprint) actions.push({ label: "Copy Fingerprint", icon: "\uf084", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.fingerprint, false, "fingerprint") } })
       if (item.ssh_key.passphrase) actions.push({ label: "Copy Passphrase", icon: "\uf023", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.passphrase, true, "passphrase") } })
+      actions.push({
+        label: "Export to ~/.ssh",
+        icon: "\uf019",
+        shortcut: "Ctrl+E",
+        action: function() {
+          root.openSshKeyModal("export", item)
+        }
+      })
     } else if (item.type_name === "identity" && item.identity) {
       var idFullName = ((item.identity.firstName || "") + " " + (item.identity.lastName || "")).trim()
       if (idFullName) actions.push({ label: "Copy Full Name (" + idFullName + ")", icon: "\uf007", shortcut: "", action: function() { root.copyToClipboard(idFullName, false, "full name") } })
@@ -795,6 +819,8 @@ Item {
     }
 
     actions.push({ label: "Copy Item Name (" + item.name + ")", icon: "\uf0c5", shortcut: "", action: function() { root.copyToClipboard(item.name, false, "item name") } })
+    actions.push({ label: "Generate SSH Key", icon: "\uf067", shortcut: "", action: function() { root.openSshKeyModal("create", null) } })
+    actions.push({ label: "Import SSH Key", icon: "\uf093", shortcut: "", action: function() { root.openSshKeyModal("import", null) } })
     actions.push({ label: "Sync Vault Now", icon: "\uf021", shortcut: "Ctrl+R", action: function() { root.syncVault(false, true) } })
     actions.push({ label: "Lock Vault", icon: "\uf023", shortcut: "Ctrl+L", action: function() { root.doLock() } })
 
@@ -835,6 +861,69 @@ Item {
     }
     attachmentProc.command = cmd
     attachmentProc.running = true
+  }
+
+  function openSshKeyModal(mode, item) {
+    root.sshKeyModalMode = mode || "create"
+    root.sshKeyModalItem = item || null
+    root.showSshKeyModal = true
+  }
+
+  function handleSshKeyCreate(payload) {
+    if (!payload || !payload.name) return
+    root.isBusy = true
+    if (sshKeyModalComponent) sshKeyModalComponent.isBusy = true
+    var cmd = [root.helperPath, "ssh-key", "create", "--name", payload.name, "--algorithm", payload.algorithm || "ed25519"]
+    if (payload.comment) {
+      cmd.push("--comment", payload.comment)
+    }
+    if (payload.notes) {
+      cmd.push("--notes", payload.notes)
+    }
+    if (payload.exportToLocal && payload.outDir) {
+      cmd.push("--out-dir", payload.outDir)
+    }
+    sshKeyActionProc.actionType = "create"
+    sshKeyActionProc.actionName = payload.name
+    sshKeyActionProc.command = cmd
+    sshKeyActionProc.running = true
+  }
+
+  function handleSshKeyImport(payload) {
+    if (!payload || !payload.name || !payload.privateKeyPath) return
+    root.isBusy = true
+    if (sshKeyModalComponent) sshKeyModalComponent.isBusy = true
+    var cmd = [root.helperPath, "ssh-key", "import", "--name", payload.name, "--private-key", payload.privateKeyPath]
+    if (payload.publicKeyPath) {
+      cmd.push("--public-key", payload.publicKeyPath)
+    }
+    if (payload.notes) {
+      cmd.push("--notes", payload.notes)
+    }
+    sshKeyActionProc.actionType = "import"
+    sshKeyActionProc.actionName = payload.name
+    sshKeyActionProc.command = cmd
+    sshKeyActionProc.running = true
+  }
+
+  function handleSshKeyExport(payload) {
+    if (!payload || !payload.item) return
+    root.isBusy = true
+    if (sshKeyModalComponent) sshKeyModalComponent.isBusy = true
+    var cmd = [root.helperPath, "ssh-key", "export", payload.item.id || payload.item.name]
+    if (payload.outDir) {
+      cmd.push("--out-dir", payload.outDir)
+    }
+    if (payload.privateKeyFile) {
+      cmd.push("--private-key-file", payload.privateKeyFile)
+    }
+    if (payload.publicKeyFile) {
+      cmd.push("--public-key-file", payload.publicKeyFile)
+    }
+    sshKeyActionProc.actionType = "export"
+    sshKeyActionProc.actionName = payload.item.name
+    sshKeyActionProc.command = cmd
+    sshKeyActionProc.running = true
   }
 
   function saveSettings(settings) {
@@ -995,6 +1084,17 @@ Item {
     }
   }
 
+  function restoreSearchFocus() {
+    Qt.callLater(function() {
+      if (root.opened && root.effectiveView === "search") {
+        if (focusRoot) focusRoot.forceActiveFocus()
+        if (searchHeader) searchHeader.focusSearch()
+      } else if (root.opened && (root.effectiveView === "unlock" || root.effectiveView === "login") && authViewComponent && authViewComponent.unlockInput) {
+        authViewComponent.unlockInput.forceActiveFocus()
+      }
+    })
+  }
+
   // ======================================================
   // FLOATING OVERLAY WINDOW
   // ======================================================
@@ -1009,76 +1109,7 @@ Item {
 
     onVisibleChanged: {
       if (visible) {
-        Qt.callLater(function() {
-          if (root.effectiveView === "search" && searchHeader && searchHeader.searchField) {
-            searchHeader.searchField.forceActiveFocus()
-          } else if (authViewComponent && authViewComponent.unlockInput) {
-            authViewComponent.unlockInput.forceActiveFocus()
-          }
-        })
-      }
-    }
-
-    Shortcut {
-      sequence: "Ctrl+K"
-      enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null
-      onActivated: {
-        root.actionPaletteIndex = 0
-        root.showActionPalette = true
-      }
-    }
-
-    Shortcut {
-      sequence: "Ctrl+U"
-      enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette
-      onActivated: root.copyItemUsername(root.selectedItem)
-    }
-
-    Shortcut {
-      sequence: "Ctrl+T"
-      enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette
-      onActivated: root.copyItemTotp(root.selectedItem)
-    }
-
-    Shortcut {
-      sequence: "Ctrl+O"
-      enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette
-      onActivated: root.openFirstWebsite(root.selectedItem)
-    }
-
-    Shortcut {
-      sequence: "Ctrl+L"
-      enabled: root.opened && root.authState.status === "unlocked"
-      onActivated: root.doLock()
-    }
-
-    Shortcut {
-      sequence: "Ctrl+R"
-      enabled: root.opened && root.authState.status === "unlocked" && !root.isBusy
-      onActivated: root.syncVault(false, true)
-    }
-
-    Shortcut {
-      sequence: "Ctrl+,"
-      enabled: root.opened
-      onActivated: {
-        root.currentView = (root.effectiveView === "settings") ? "auto" : "settings"
-      }
-    }
-
-    Shortcut {
-      sequence: "Escape"
-      enabled: root.opened
-      onActivated: {
-        if (root.showActionPalette) {
-          root.showActionPalette = false
-        } else if (root.activeAttachmentPreview !== null) {
-          root.activeAttachmentPreview = null
-        } else if (root.effectiveView === "settings") {
-          root.currentView = "auto"
-        } else {
-          root.dismiss()
-        }
+        root.restoreSearchFocus()
       }
     }
 
@@ -1087,8 +1118,89 @@ Item {
       anchors.fill: parent
       focus: true
 
+      Shortcut {
+        sequence: "Ctrl+K"
+        enabled: root.opened && root.effectiveView === "search" && !root.showActionPalette && !root.showSshKeyModal
+        onActivated: {
+          root.actionPaletteIndex = 0
+          root.showActionPalette = true
+        }
+      }
+
+      Shortcut {
+        sequence: "Ctrl+U"
+        enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal
+        onActivated: root.copyItemUsername(root.selectedItem)
+      }
+
+      Shortcut {
+        sequence: "Ctrl+T"
+        enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal
+        onActivated: root.copyItemTotp(root.selectedItem)
+      }
+
+      Shortcut {
+        sequence: "Ctrl+O"
+        enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal
+        onActivated: root.openFirstWebsite(root.selectedItem)
+      }
+
+      Shortcut {
+        sequence: "Ctrl+E"
+        enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && root.selectedItem.type_name === "ssh_key" && !root.showActionPalette && !root.showSshKeyModal
+        onActivated: {
+          root.openSshKeyModal("export", root.selectedItem)
+        }
+      }
+
+      Shortcut {
+        sequence: "Ctrl+L"
+        enabled: root.opened && root.authState.status === "unlocked" && !root.showSshKeyModal
+        onActivated: root.doLock()
+      }
+
+      Shortcut {
+        sequence: "Ctrl+R"
+        enabled: root.opened && root.authState.status === "unlocked" && !root.isBusy && !root.showSshKeyModal
+        onActivated: root.syncVault(false, true)
+      }
+
+      Shortcut {
+        sequence: "Ctrl+,"
+        enabled: root.opened && !root.showSshKeyModal
+        onActivated: {
+          root.currentView = (root.effectiveView === "settings") ? "auto" : "settings"
+        }
+      }
+
+      Shortcut {
+        sequence: "Escape"
+        enabled: root.opened
+        onActivated: {
+          if (root.showSshKeyModal) {
+            root.showSshKeyModal = false
+          } else if (root.showActionPalette) {
+            root.showActionPalette = false
+          } else if (root.activeAttachmentPreview !== null) {
+            root.activeAttachmentPreview = null
+          } else if (root.effectiveView === "settings") {
+            root.currentView = "auto"
+          } else {
+            root.dismiss()
+          }
+        }
+      }
+
       Keys.priority: Keys.BeforeItem
       Keys.onPressed: function(event) {
+        if (root.showSshKeyModal) {
+          if (event.key === Qt.Key_Escape) {
+            root.showSshKeyModal = false
+            event.accepted = true
+          }
+          return
+        }
+
         if (root.showActionPalette) {
           if (event.key === Qt.Key_Escape) {
             root.showActionPalette = false
@@ -1153,6 +1265,8 @@ Item {
           borderColor: root.borderColor
           onSearchQueryChanged: root.searchQuery = searchQuery
           onCategorySelected: function(cat) { root.activeCategory = cat }
+          onCreateSshKeyRequested: { root.openSshKeyModal("create", null) }
+          onImportSshKeyRequested: { root.openSshKeyModal("import", null) }
           onClearSearchRequested: {
             root.searchQuery = ""
             root.filterVaultItems()
@@ -1220,6 +1334,7 @@ Item {
                 onCopyRequested: function(text, isSensitive, label) { root.copyToClipboard(text, isSensitive, label) }
                 onViewAttachmentRequested: function(item, att) { root.viewAttachment(item, att) }
                 onDownloadAttachmentRequested: function(item, att) { root.downloadAttachment(item, att) }
+                onExportSshKeyRequested: function(item) { root.openSshKeyModal("export", item) }
                 onClosePreviewRequested: { root.activeAttachmentPreview = null }
                 onTogglePasswordRevealed: { root.showPasswordRevealed = !root.showPasswordRevealed }
                 onTogglePrivateKeyRevealed: { root.showPrivateKeyRevealed = !root.showPrivateKeyRevealed }
@@ -1356,12 +1471,81 @@ Item {
         }
         onCloseRequested: { root.showActionPalette = false }
       }
+
+      // 6. SSH Key Management Modal Overlay (Create, Import, Export)
+      SshKeyModal {
+        id: sshKeyModalComponent
+        active: root.showSshKeyModal
+        mode: root.sshKeyModalMode
+        item: root.sshKeyModalItem
+        fontFamily: root.fontFamily
+        foreground: root.foreground
+        accent: root.accent
+        borderColor: root.borderColor
+        onCreateRequested: function(payload) { root.handleSshKeyCreate(payload) }
+        onImportRequested: function(payload) { root.handleSshKeyImport(payload) }
+        onExportRequested: function(payload) { root.handleSshKeyExport(payload) }
+        onCloseRequested: { root.showSshKeyModal = false }
+      }
     }
   }
 
   // ======================================================
   // QUICKSHELL IO BACKGROUND PROCESSES
   // ======================================================
+  Process {
+    id: sshKeyActionProc
+    property string actionType: "create"
+    property string actionName: ""
+    command: []
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        root.isBusy = false
+        if (sshKeyModalComponent) sshKeyModalComponent.isBusy = false
+        var raw = text.trim()
+        var jsonRes = null
+        try {
+          if (raw) jsonRes = JSON.parse(raw)
+        } catch (e) {}
+
+        if (jsonRes && jsonRes.ok) {
+          root.showSshKeyModal = false
+          if (sshKeyActionProc.actionType === "create") {
+            root.statusMessage = "SSH key '" + sshKeyActionProc.actionName + "' generated successfully."
+            root.loadVaultItems()
+          } else if (sshKeyActionProc.actionType === "import") {
+            root.statusMessage = "SSH key '" + sshKeyActionProc.actionName + "' imported successfully."
+            root.loadVaultItems()
+          } else if (sshKeyActionProc.actionType === "export") {
+            root.statusMessage = "SSH key '" + sshKeyActionProc.actionName + "' exported to local directory."
+          }
+        } else {
+          var errMsg = (jsonRes && jsonRes.error) ? jsonRes.error : "SSH key operation failed."
+          if (sshKeyModalComponent && root.showSshKeyModal) {
+            sshKeyModalComponent.errorMessage = errMsg
+          } else {
+            root.errorMessage = errMsg
+          }
+        }
+      }
+    }
+    stderr: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.handleProcessStderr(text, "omawarden:ssh")
+    }
+    onExited: function(exitCode) {
+      root.isBusy = false
+      if (sshKeyModalComponent) sshKeyModalComponent.isBusy = false
+      if (exitCode !== 0 && (!sshKeyModalComponent || !sshKeyModalComponent.errorMessage)) {
+        if (sshKeyModalComponent && root.showSshKeyModal) {
+          sshKeyModalComponent.errorMessage = "Process exited with error code " + exitCode
+        } else {
+          root.errorMessage = "Process exited with error code " + exitCode
+        }
+      }
+    }
+  }
   Process {
     id: configGetProc
     command: []

--- a/components/ActionPaletteModal.qml
+++ b/components/ActionPaletteModal.qml
@@ -109,6 +109,22 @@ Rectangle {
               } else if (event.key === Qt.Key_Escape) {
                 paletteRoot.closeRequested()
                 event.accepted = true
+              } else if (event.modifiers & Qt.ControlModifier) {
+                var pressedKey = ""
+                if (event.key === Qt.Key_U) pressedKey = "Ctrl+U"
+                else if (event.key === Qt.Key_E) pressedKey = "Ctrl+E"
+                else if (event.key === Qt.Key_T) pressedKey = "Ctrl+T"
+                else if (event.key === Qt.Key_O) pressedKey = "Ctrl+O"
+
+                if (pressedKey) {
+                  for (var i = 0; i < filtered.length; i++) {
+                    if (filtered[i].shortcut && filtered[i].shortcut.toLowerCase() === pressedKey.toLowerCase()) {
+                      paletteRoot.actionSelected(filtered[i])
+                      event.accepted = true
+                      return
+                    }
+                  }
+                }
               }
             }
           }

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -28,6 +28,7 @@ ScrollView {
   signal copyRequested(string text, bool isSensitive, string label)
   signal viewAttachmentRequested(var item, var att)
   signal downloadAttachmentRequested(var item, var att)
+  signal exportSshKeyRequested(var item)
   signal closePreviewRequested()
   signal togglePasswordRevealed()
   signal togglePrivateKeyRevealed()
@@ -1118,6 +1119,11 @@ ScrollView {
               iconText: "\uf0c5"
               tooltip: "Copy private key"
               onClicked: { if (inspectorRoot.item && inspectorRoot.item.ssh_key) inspectorRoot.copyRequested(inspectorRoot.item.ssh_key.private_key, true, "SSH private key") }
+            }
+            GhostIconButton {
+              iconText: "\uf019"
+              tooltip: "Export SSH key to ~/.ssh"
+              onClicked: { if (inspectorRoot.item) inspectorRoot.exportSshKeyRequested(inspectorRoot.item) }
             }
           }
 

--- a/components/SearchHeader.qml
+++ b/components/SearchHeader.qml
@@ -18,6 +18,12 @@ ColumnLayout {
 
   signal categorySelected(string category)
   signal clearSearchRequested()
+  signal createSshKeyRequested()
+  signal importSshKeyRequested()
+
+  function focusSearch() {
+    searchInputField.forceActiveFocus()
+  }
 
   spacing: 6
   Layout.fillWidth: true
@@ -25,7 +31,7 @@ ColumnLayout {
   onVisibleChanged: {
     if (visible) {
       Qt.callLater(function() {
-        searchInputField.forceActiveFocus()
+        focusSearch()
       })
     }
   }
@@ -67,7 +73,6 @@ ColumnLayout {
           font.pixelSize: 12
           selectByMouse: true
           clip: true
-          activeFocusOnTab: true
         }
 
         Text {
@@ -106,17 +111,88 @@ ColumnLayout {
     }
   }
 
-  // 2. Category Tab Bar
-  CategoryTabBar {
-    id: catBar
-    categoryList: searchHeaderRoot.categoryList
-    activeCategory: searchHeaderRoot.activeCategory
-    rawVaultItems: searchHeaderRoot.rawVaultItems
-    foreground: searchHeaderRoot.foreground
-    accent: searchHeaderRoot.accent
-    borderColor: searchHeaderRoot.borderColor
-    onCategorySelected: function(cat) {
-      searchHeaderRoot.categorySelected(cat)
+  // 2. Category Tab Bar & Action Buttons
+  RowLayout {
+    Layout.fillWidth: true
+    spacing: 8
+
+    CategoryTabBar {
+      id: catBar
+      categoryList: searchHeaderRoot.categoryList
+      activeCategory: searchHeaderRoot.activeCategory
+      rawVaultItems: searchHeaderRoot.rawVaultItems
+      foreground: searchHeaderRoot.foreground
+      accent: searchHeaderRoot.accent
+      borderColor: searchHeaderRoot.borderColor
+      onCategorySelected: function(cat) {
+        searchHeaderRoot.categorySelected(cat)
+      }
+    }
+
+    Item { Layout.fillWidth: true }
+
+    // SSH Key Category Actions
+    RowLayout {
+      visible: searchHeaderRoot.activeCategory === "ssh_key"
+      spacing: 6
+
+      Rectangle {
+        implicitWidth: 24
+        implicitHeight: 24
+        radius: 4
+        color: createMouse.containsMouse ? Qt.rgba(searchHeaderRoot.accent.r, searchHeaderRoot.accent.g, searchHeaderRoot.accent.b, 0.25) : Qt.rgba(0, 0, 0, 0.25)
+        border.color: createMouse.containsMouse ? searchHeaderRoot.accent : searchHeaderRoot.borderColor
+        border.width: 1
+
+        Text {
+          anchors.centerIn: parent
+          text: "\uf067"
+          font.family: searchHeaderRoot.fontFamily
+          font.pixelSize: 11
+          color: createMouse.containsMouse ? searchHeaderRoot.accent : Qt.darker(searchHeaderRoot.foreground, 1.2)
+        }
+
+        MouseArea {
+          id: createMouse
+          anchors.fill: parent
+          hoverEnabled: true
+          cursorShape: Qt.PointingHandCursor
+          onClicked: searchHeaderRoot.createSshKeyRequested()
+
+          ToolTip.visible: containsMouse
+          ToolTip.delay: 300
+          ToolTip.text: "Generate SSH Key"
+        }
+      }
+
+      Rectangle {
+        implicitWidth: 24
+        implicitHeight: 24
+        radius: 4
+        color: importMouse.containsMouse ? Qt.rgba(searchHeaderRoot.accent.r, searchHeaderRoot.accent.g, searchHeaderRoot.accent.b, 0.25) : Qt.rgba(0, 0, 0, 0.25)
+        border.color: importMouse.containsMouse ? searchHeaderRoot.accent : searchHeaderRoot.borderColor
+        border.width: 1
+
+        Text {
+          anchors.centerIn: parent
+          text: "\uf093"
+          font.family: searchHeaderRoot.fontFamily
+          font.pixelSize: 11
+          color: importMouse.containsMouse ? searchHeaderRoot.accent : Qt.darker(searchHeaderRoot.foreground, 1.2)
+        }
+
+        MouseArea {
+          id: importMouse
+          anchors.fill: parent
+          hoverEnabled: true
+          cursorShape: Qt.PointingHandCursor
+          onClicked: searchHeaderRoot.importSshKeyRequested()
+
+          ToolTip.visible: containsMouse
+          ToolTip.delay: 300
+          ToolTip.text: "Import SSH Key"
+        }
+      }
     }
   }
 }

--- a/components/SshKeyModal.qml
+++ b/components/SshKeyModal.qml
@@ -1,0 +1,958 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Rectangle {
+  id: modalRoot
+
+  property bool active: false
+  property string mode: "create" // "create" | "import" | "export"
+  property var item: null
+  property color foreground: "#ffffff"
+  property color accent: "#3b82f6"
+  property color borderColor: Qt.rgba(1, 1, 1, 0.1)
+  property string fontFamily: ""
+  property bool isBusy: false
+  property string errorMessage: ""
+
+  // Form states
+  property string itemName: ""
+  property string algorithm: "ed25519"
+  property string comment: ""
+  property string notes: ""
+  property bool exportToLocal: true
+  property string outDir: "~/.ssh"
+
+  property string importName: ""
+  property string privateKeyPath: "~/.ssh/"
+  property string publicKeyPath: ""
+  property string importNotes: ""
+
+  property string exportOutDir: "~/.ssh"
+  property string exportPrivFile: ""
+  property string exportPubFile: ""
+
+  signal createRequested(var payload)
+  signal importRequested(var payload)
+  signal exportRequested(var payload)
+  signal closeRequested()
+
+  anchors.fill: parent
+  color: Qt.rgba(0, 0, 0, 0.65)
+  visible: active
+
+  function resetForm() {
+    errorMessage = ""
+    isBusy = false
+    itemName = ""
+    algorithm = "ed25519"
+    comment = ""
+    notes = ""
+    exportToLocal = true
+    outDir = "~/.ssh"
+
+    importName = ""
+    privateKeyPath = "~/.ssh/"
+    publicKeyPath = ""
+    importNotes = ""
+
+    if (item) {
+      var safeName = (item.name || "id_ssh_key").toLowerCase().replace(/[\s\/]+/g, "_")
+      exportPrivFile = safeName
+      exportPubFile = safeName + ".pub"
+    } else {
+      exportPrivFile = "id_ssh_key"
+      exportPubFile = "id_ssh_key.pub"
+    }
+    exportOutDir = "~/.ssh"
+  }
+
+  onActiveChanged: {
+    if (active) {
+      resetForm()
+      Qt.callLater(function() {
+        if (mode === "create" && createNameInput) {
+          createNameInput.forceActiveFocus()
+        } else if (mode === "import" && importNameInput) {
+          importNameInput.forceActiveFocus()
+        } else if (mode === "export" && exportDirInput) {
+          exportDirInput.forceActiveFocus()
+        }
+      })
+    }
+  }
+
+  function submitCurrentMode() {
+    if (isBusy) return
+    errorMessage = ""
+
+    if (mode === "create") {
+      var trimmedName = itemName.trim()
+      if (!trimmedName) {
+        errorMessage = "Please enter an item name."
+        if (createNameInput) createNameInput.forceActiveFocus()
+        return
+      }
+      createRequested({
+        name: trimmedName,
+        algorithm: algorithm,
+        comment: comment.trim(),
+        notes: notes.trim(),
+        exportToLocal: exportToLocal,
+        outDir: outDir.trim()
+      })
+    } else if (mode === "import") {
+      var trimmedImpName = importName.trim()
+      if (!trimmedImpName) {
+        errorMessage = "Please enter an item name."
+        if (importNameInput) importNameInput.forceActiveFocus()
+        return
+      }
+      var trimmedPriv = privateKeyPath.trim()
+      if (!trimmedPriv || trimmedPriv === "~/.ssh" || trimmedPriv === "~/.ssh/") {
+        errorMessage = "Please specify the private key file path."
+        if (importPrivInput) importPrivInput.forceActiveFocus()
+        return
+      }
+      importRequested({
+        name: trimmedImpName,
+        privateKeyPath: trimmedPriv,
+        publicKeyPath: publicKeyPath.trim(),
+        notes: importNotes.trim()
+      })
+    } else if (mode === "export") {
+      if (!item) {
+        errorMessage = "No SSH key item selected."
+        return
+      }
+      var trimmedOutDir = exportOutDir.trim()
+      if (!trimmedOutDir) {
+        errorMessage = "Please enter an export directory."
+        if (exportDirInput) exportDirInput.forceActiveFocus()
+        return
+      }
+      exportRequested({
+        item: item,
+        outDir: trimmedOutDir,
+        privateKeyFile: exportPrivFile.trim(),
+        publicKeyFile: exportPubFile.trim()
+      })
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: {
+      if (!modalRoot.isBusy) modalRoot.closeRequested()
+    }
+  }
+
+  // Modal Dialog Box
+  Rectangle {
+    id: modalCard
+    anchors.centerIn: parent
+    width: Math.min(parent.width - 48, 520)
+    height: Math.min(parent.height - 48, 480)
+    radius: 8
+    color: Qt.rgba(0.12, 0.14, 0.18, 0.98)
+    border.color: modalRoot.borderColor
+    border.width: 1
+
+    MouseArea {
+      anchors.fill: parent
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 16
+      spacing: 12
+
+      // Modal Header
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Text {
+          text: modalRoot.mode === "create" ? "\uf067" : (modalRoot.mode === "import" ? "\uf093" : "\uf019")
+          font.family: modalRoot.fontFamily
+          font.pixelSize: 14
+          color: modalRoot.accent
+        }
+
+        Text {
+          text: modalRoot.mode === "create" ? "Generate SSH Key" : (modalRoot.mode === "import" ? "Import SSH Key" : "Export SSH Key")
+          color: modalRoot.foreground
+          font.pixelSize: 13
+          font.weight: Font.DemiBold
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Rectangle {
+          implicitWidth: 22
+          implicitHeight: 22
+          radius: 4
+          color: closeMouse.containsMouse ? Qt.rgba(1, 1, 1, 0.1) : "transparent"
+
+          Text {
+            anchors.centerIn: parent
+            text: "\uf00d"
+            font.family: modalRoot.fontFamily
+            font.pixelSize: 11
+            color: closeMouse.containsMouse ? modalRoot.foreground : Qt.darker(modalRoot.foreground, 1.5)
+          }
+
+          MouseArea {
+            id: closeMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+              if (!modalRoot.isBusy) modalRoot.closeRequested()
+            }
+          }
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: modalRoot.borderColor
+      }
+
+      // Error Alert Banner
+      Rectangle {
+        visible: Boolean(modalRoot.errorMessage)
+        Layout.fillWidth: true
+        implicitHeight: errText.implicitHeight + 12
+        radius: 4
+        color: Qt.rgba(0.94, 0.27, 0.27, 0.15)
+        border.color: "#ef4444"
+        border.width: 1
+
+        RowLayout {
+          anchors.fill: parent
+          anchors.margins: 6
+          spacing: 6
+
+          Text {
+            text: "\uf06a"
+            font.family: modalRoot.fontFamily
+            font.pixelSize: 11
+            color: "#f87171"
+          }
+
+          Text {
+            id: errText
+            text: modalRoot.errorMessage
+            color: "#fca5a5"
+            font.pixelSize: 11
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+          }
+        }
+      }
+
+      // Form Area (Scrollable)
+      ScrollView {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        clip: true
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
+        ColumnLayout {
+          width: modalCard.width - 32
+          spacing: 10
+
+          // ==========================================
+          // 1. CREATE MODE
+          // ==========================================
+          ColumnLayout {
+            visible: modalRoot.mode === "create"
+            Layout.fillWidth: true
+            spacing: 10
+
+            // Item Name
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Item Name *"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: createNameInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: createNameInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: commentInput
+                  KeyNavigation.backtab: outDirInput
+                  text: modalRoot.itemName
+                  onTextChanged: modalRoot.itemName = text
+                  Keys.onReturnPressed: modalRoot.submitCurrentMode()
+                }
+              }
+            }
+
+            // Algorithm Selector
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Algorithm"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              RowLayout {
+                Layout.fillWidth: true
+                spacing: 6
+
+                Repeater {
+                  model: [
+                    { id: "ed25519", label: "Ed25519 (Recommended)" },
+                    { id: "rsa-2048", label: "RSA 2048" },
+                    { id: "rsa-4096", label: "RSA 4096" },
+                    { id: "ecdsa-p256", label: "ECDSA P-256" }
+                  ]
+
+                  Rectangle {
+                    property bool isSelected: modalRoot.algorithm === modelData.id
+                    implicitHeight: 26
+                    implicitWidth: algoText.implicitWidth + 12
+                    radius: 4
+                    color: isSelected ? Qt.rgba(modalRoot.accent.r, modalRoot.accent.g, modalRoot.accent.b, 0.2) : (algoMouse.containsMouse ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.2))
+                    border.color: isSelected ? modalRoot.accent : modalRoot.borderColor
+                    border.width: 1
+
+                    Text {
+                      id: algoText
+                      anchors.centerIn: parent
+                      text: modelData.label
+                      color: parent.isSelected ? modalRoot.accent : (algoMouse.containsMouse ? modalRoot.foreground : Qt.darker(modalRoot.foreground, 1.3))
+                      font.pixelSize: 10
+                      font.weight: parent.isSelected ? Font.DemiBold : Font.Normal
+                    }
+
+                    MouseArea {
+                      id: algoMouse
+                      anchors.fill: parent
+                      hoverEnabled: true
+                      cursorShape: Qt.PointingHandCursor
+                      onClicked: modalRoot.algorithm = modelData.id
+                    }
+                  }
+                }
+              }
+            }
+
+            // Comment
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Key Comment (optional)"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: commentInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: commentInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: notesInput
+                  KeyNavigation.backtab: createNameInput
+                  text: modalRoot.comment
+                  onTextChanged: modalRoot.comment = text
+                  Keys.onReturnPressed: modalRoot.submitCurrentMode()
+                }
+
+                Text {
+                  anchors.left: parent.left
+                  anchors.leftMargin: 8
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: "e.g. your_email@example.com"
+                  color: Qt.darker(modalRoot.foreground, 2.0)
+                  font.pixelSize: 11
+                  visible: !commentInput.text
+                }
+              }
+            }
+
+            // Notes
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Notes (optional)"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 54
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: notesInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                Flickable {
+                  anchors.fill: parent
+                  anchors.margins: 6
+                  clip: true
+
+                  TextArea.flickable: TextArea {
+                    id: notesInput
+                    color: modalRoot.foreground
+                    background: null
+                    padding: 0
+                    font.pixelSize: 11
+                    wrapMode: Text.Wrap
+                    selectByMouse: true
+                    activeFocusOnTab: true
+                    text: modalRoot.notes
+                    onTextChanged: modalRoot.notes = text
+                    Keys.onTabPressed: function(event) {
+                      outDirInput.forceActiveFocus()
+                      event.accepted = true
+                    }
+                    Keys.onBacktabPressed: function(event) {
+                      commentInput.forceActiveFocus()
+                      event.accepted = true
+                    }
+                  }
+                }
+              }
+            }
+
+            // Local Export Checkbox & OutDir
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: 8
+
+              Rectangle {
+                implicitWidth: 16
+                implicitHeight: 16
+                radius: 3
+                color: modalRoot.exportToLocal ? modalRoot.accent : Qt.rgba(0, 0, 0, 0.3)
+                border.color: modalRoot.exportToLocal ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                Text {
+                  anchors.centerIn: parent
+                  text: "\uf00c"
+                  font.family: modalRoot.fontFamily
+                  font.pixelSize: 9
+                  color: "#ffffff"
+                  visible: modalRoot.exportToLocal
+                }
+
+                MouseArea {
+                  anchors.fill: parent
+                  cursorShape: Qt.PointingHandCursor
+                  onClicked: modalRoot.exportToLocal = !modalRoot.exportToLocal
+                }
+              }
+
+              Text {
+                text: "Also export keypair to local directory:"
+                color: modalRoot.foreground
+                font.pixelSize: 11
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 26
+                radius: 4
+                enabled: modalRoot.exportToLocal
+                color: modalRoot.exportToLocal ? Qt.rgba(0, 0, 0, 0.3) : Qt.rgba(0, 0, 0, 0.1)
+                border.color: outDirInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: outDirInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 6
+                  anchors.rightMargin: 6
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.exportToLocal ? modalRoot.foreground : Qt.darker(modalRoot.foreground, 2.0)
+                  font.pixelSize: 11
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: createNameInput
+                  KeyNavigation.backtab: notesInput
+                  text: modalRoot.outDir
+                  onTextChanged: modalRoot.outDir = text
+                }
+              }
+            }
+          }
+
+          // ==========================================
+          // 2. IMPORT MODE
+          // ==========================================
+          ColumnLayout {
+            visible: modalRoot.mode === "import"
+            Layout.fillWidth: true
+            spacing: 10
+
+            // Import Name
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Item Name *"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: importNameInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: importNameInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: importPrivInput
+                  KeyNavigation.backtab: importNotesInput
+                  text: modalRoot.importName
+                  onTextChanged: modalRoot.importName = text
+                  Keys.onReturnPressed: modalRoot.submitCurrentMode()
+                }
+              }
+            }
+
+            // Private Key File Path
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Private Key File Path *"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: importPrivInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: importPrivInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: importPubInput
+                  KeyNavigation.backtab: importNameInput
+                  text: modalRoot.privateKeyPath
+                  onTextChanged: modalRoot.privateKeyPath = text
+                  Keys.onReturnPressed: modalRoot.submitCurrentMode()
+                }
+              }
+
+              Text {
+                text: "Defaults to ~/.ssh/ (e.g. ~/.ssh/id_ed25519 or ~/.ssh/id_rsa)"
+                color: Qt.darker(modalRoot.foreground, 2.0)
+                font.pixelSize: 10
+              }
+            }
+
+            // Public Key File Path (Optional)
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Public Key File Path (optional - auto-derived if omitted)"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: importPubInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: importPubInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: importNotesInput
+                  KeyNavigation.backtab: importPrivInput
+                  text: modalRoot.publicKeyPath
+                  onTextChanged: modalRoot.publicKeyPath = text
+                }
+              }
+            }
+
+            // Import Notes
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Notes (optional)"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 54
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: importNotesInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                Flickable {
+                  anchors.fill: parent
+                  anchors.margins: 6
+                  clip: true
+
+                  TextArea.flickable: TextArea {
+                    id: importNotesInput
+                    color: modalRoot.foreground
+                    background: null
+                    padding: 0
+                    font.pixelSize: 11
+                    wrapMode: Text.Wrap
+                    selectByMouse: true
+                    activeFocusOnTab: true
+                    text: modalRoot.importNotes
+                    onTextChanged: modalRoot.importNotes = text
+                    Keys.onTabPressed: function(event) {
+                      importNameInput.forceActiveFocus()
+                      event.accepted = true
+                    }
+                    Keys.onBacktabPressed: function(event) {
+                      importPubInput.forceActiveFocus()
+                      event.accepted = true
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          // ==========================================
+          // 3. EXPORT MODE
+          // ==========================================
+          ColumnLayout {
+            visible: modalRoot.mode === "export"
+            Layout.fillWidth: true
+            spacing: 10
+
+            // Item Summary Card
+            Rectangle {
+              Layout.fillWidth: true
+              implicitHeight: itemSummaryCol.implicitHeight + 16
+              radius: 4
+              color: Qt.rgba(0, 0, 0, 0.25)
+              border.color: modalRoot.borderColor
+              border.width: 1
+
+              ColumnLayout {
+                id: itemSummaryCol
+                anchors.fill: parent
+                anchors.margins: 8
+                spacing: 4
+
+                RowLayout {
+                  spacing: 6
+                  Text {
+                    text: "\uf084"
+                    font.family: modalRoot.fontFamily
+                    font.pixelSize: 12
+                    color: modalRoot.accent
+                  }
+                  Text {
+                    text: modalRoot.item ? (modalRoot.item.name || "SSH Key") : ""
+                    color: modalRoot.foreground
+                    font.pixelSize: 12
+                    font.weight: Font.DemiBold
+                  }
+                }
+
+                Text {
+                  visible: Boolean(modalRoot.item && modalRoot.item.ssh_key && modalRoot.item.ssh_key.fingerprint)
+                  text: "Fingerprint: " + (modalRoot.item && modalRoot.item.ssh_key ? (modalRoot.item.ssh_key.fingerprint || "") : "")
+                  color: Qt.darker(modalRoot.foreground, 1.5)
+                  font.pixelSize: 10
+                  font.family: "monospace"
+                  elide: Text.ElideRight
+                  Layout.fillWidth: true
+                }
+              }
+            }
+
+            // Export Directory
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Destination Directory *"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: exportDirInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: exportDirInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: exportPrivInput
+                  KeyNavigation.backtab: exportPubInput
+                  text: modalRoot.exportOutDir
+                  onTextChanged: modalRoot.exportOutDir = text
+                  Keys.onReturnPressed: modalRoot.submitCurrentMode()
+                }
+              }
+            }
+
+            // Private Key Filename
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Private Key Filename *"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: exportPrivInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: exportPrivInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: exportPubInput
+                  KeyNavigation.backtab: exportDirInput
+                  text: modalRoot.exportPrivFile
+                  onTextChanged: {
+                    modalRoot.exportPrivFile = text
+                    if (!exportPubInput.activeFocus) {
+                      modalRoot.exportPubFile = text + ".pub"
+                    }
+                  }
+                  Keys.onReturnPressed: modalRoot.submitCurrentMode()
+                }
+              }
+            }
+
+            // Public Key Filename
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: 4
+
+              Text {
+                text: "Public Key Filename *"
+                color: Qt.darker(modalRoot.foreground, 1.4)
+                font.pixelSize: 11
+                font.weight: Font.Medium
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: Qt.rgba(0, 0, 0, 0.3)
+                border.color: exportPubInput.activeFocus ? modalRoot.accent : modalRoot.borderColor
+                border.width: 1
+
+                TextInput {
+                  id: exportPubInput
+                  anchors.fill: parent
+                  anchors.leftMargin: 8
+                  anchors.rightMargin: 8
+                  verticalAlignment: Text.AlignVCenter
+                  color: modalRoot.foreground
+                  font.pixelSize: 12
+                  selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: exportDirInput
+                  KeyNavigation.backtab: exportPrivInput
+                  text: modalRoot.exportPubFile
+                  onTextChanged: modalRoot.exportPubFile = text
+                  Keys.onReturnPressed: modalRoot.submitCurrentMode()
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Dialog Footer Action Buttons
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Item { Layout.fillWidth: true }
+
+        // Cancel Button
+        Rectangle {
+          implicitHeight: 28
+          implicitWidth: 70
+          radius: 4
+          color: cancelMouse.containsMouse ? Qt.rgba(1, 1, 1, 0.1) : "transparent"
+          border.color: modalRoot.borderColor
+          border.width: 1
+
+          Text {
+            anchors.centerIn: parent
+            text: "Cancel"
+            color: cancelMouse.containsMouse ? modalRoot.foreground : Qt.darker(modalRoot.foreground, 1.3)
+            font.pixelSize: 11
+          }
+
+          MouseArea {
+            id: cancelMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+              if (!modalRoot.isBusy) modalRoot.closeRequested()
+            }
+          }
+        }
+
+        // Submit Button
+        Rectangle {
+          implicitHeight: 28
+          implicitWidth: 90
+          radius: 4
+          color: submitMouse.containsMouse ? Qt.lighter(modalRoot.accent, 1.1) : modalRoot.accent
+          opacity: modalRoot.isBusy ? 0.6 : 1.0
+
+          RowLayout {
+            anchors.centerIn: parent
+            spacing: 6
+
+            Text {
+              visible: modalRoot.isBusy
+              text: "\uf110"
+              font.family: modalRoot.fontFamily
+              font.pixelSize: 11
+              color: "#ffffff"
+            }
+
+            Text {
+              text: modalRoot.isBusy ? "Processing..." : (modalRoot.mode === "create" ? "Generate" : (modalRoot.mode === "import" ? "Import" : "Export"))
+              color: "#ffffff"
+              font.pixelSize: 11
+              font.weight: Font.DemiBold
+            }
+          }
+
+          MouseArea {
+            id: submitMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: modalRoot.isBusy ? Qt.ArrowCursor : Qt.PointingHandCursor
+            onClicked: modalRoot.submitCurrentMode()
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/adr/0005-ssh-key-management-lifecycle.md
+++ b/docs/adr/0005-ssh-key-management-lifecycle.md
@@ -1,0 +1,48 @@
+# ADR 0005: Omawarden SSH Key Automated Lifecycle, Generation, Import, and Export
+
+## Status
+Accepted
+
+## Context
+Bitwarden officially supports SSH Key items (Cipher Type 5) with fields for `privateKey`, `publicKey`, and `keyFingerprint`. While `omawarden` supports decrypting and viewing SSH keys in the UI, users previously had to manually generate keys using external tools (`ssh-keygen`), paste them into the Bitwarden web or desktop vault, and sync.
+
+To streamline developer workflows on Linux (especially in Omarchy desktop environments), `omawarden` needs native CLI capabilities to:
+1. **Automatically generate** standard SSH key pairs (Ed25519, RSA, ECDSA) on the fly and immediately encrypt and store them in Bitwarden.
+2. **Import existing SSH key files** (or standard input streams) into Bitwarden, automatically deriving public keys and SHA256 fingerprints if only the private key is provided.
+3. **Export stored SSH keys** to local files with strict Unix file permissions (`0600` for private keys, `0644` for public keys) or to standard output for piping directly into `ssh-add` or agent sockets.
+
+## Decision
+
+1. **Subcommand Hierarchy**:
+   - Establish a dedicated top-level subcommand: `omawarden ssh-key <create|import|export>`.
+   - `create`: Generates a cryptographic key pair locally, encrypts it using the user's master symmetric key, posts it to `/api/ciphers`, and updates the local storage cache.
+   - `import`: Reads private/public keys from files or STDIN, auto-derives missing public keys and fingerprints, encrypts them, and uploads them to the vault.
+   - `export`: Decrypts the target SSH Key cipher and writes files with hardened permissions (`0600` / `0644`) or outputs directly to STDOUT.
+
+2. **Cryptographic Generation and Parsing Standards**:
+   - Use the Rust `ssh-key` crate with OpenSSH PEM formatting (`-----BEGIN OPENSSH PRIVATE KEY-----` and `ssh-ed25519 AAA...`).
+   - Supported Algorithms:
+     - `Ed25519` (Default, recommended)
+     - `RSA` (2048-bit, 4096-bit)
+     - `ECDSA` (NIST P-256, NIST P-384)
+   - Auto-calculate standard OpenSSH SHA256 fingerprints (`SHA256:Base64...`).
+   - Support optional passphrases for encrypting private keys at rest within OpenSSH envelopes.
+
+3. **Bitwarden Vault Integration & Sync Lifecycle**:
+   - Encrypt `name`, `notes`, and `sshKey` container fields using `SymmetricCryptoKey::encrypt` (Type 2 EncString `2.IV|Cipher|Mac`).
+   - Send `POST /api/ciphers` with modern `Bitwarden-Client-Version` and `Bitwarden-Client-Name` headers.
+   - On successful server response, immediately insert the new decrypted item into the local `data.json` storage and notify the resident daemon to update its in-memory item cache.
+
+4. **Security & Permission Hardening**:
+   - **File Permissions**: All exported private key files are strictly created with Unix `0600` (read/write by owner only); public keys are written with `0644`.
+   - **Zeroize Memory Protection**: Private keys in memory use `zeroize` wiping upon drop.
+   - **Zero-Argv Seam**: Passphrases and private keys can be supplied via standard input or interactive prompts rather than CLI argument strings.
+
+## Consequences
+- **Positive**:
+  - Full developer productivity workflow for managing SSH keys directly from the terminal.
+  - Zero manual copy-pasting of long PEM blocks into browser forms.
+  - Automated public key and fingerprint derivation eliminates human error during import.
+  - Hardened file permissions (`0600`) prevent OpenSSH `UNPROTECTED PRIVATE KEY FILE!` errors.
+- **Trade-off**:
+  - Introduces `ssh-key` crate dependency in `omawarden/Cargo.toml`.

--- a/omawarden/Cargo.lock
+++ b/omawarden/Cargo.lock
@@ -106,6 +106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +349,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +386,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -426,6 +470,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2 0.10.9",
+ "subtle",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +538,22 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -513,6 +627,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -540,6 +655,17 @@ dependencies = [
  "r-efi",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -981,6 +1107,7 @@ dependencies = [
  "libc",
  "pbkdf2",
  "pkcs8 0.11.0",
+ "rand_core 0.6.4",
  "regex",
  "reqwest",
  "rsa",
@@ -988,6 +1115,7 @@ dependencies = [
  "serde_json",
  "sha1 0.10.7",
  "sha2 0.10.9",
+ "ssh-key",
  "subtle",
  "tempfile",
  "tokio",
@@ -1008,6 +1136,44 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1131,6 +1297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1347,6 +1522,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1572,15 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1453,6 +1647,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1625,6 +1839,49 @@ checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der 0.8.1",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2 0.10.9",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/omawarden/Cargo.lock
+++ b/omawarden/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "rand_core 0.6.4",
  "regex",
  "reqwest",
+ "rpassword",
  "rsa",
  "serde",
  "serde_json",
@@ -1546,6 +1547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1577,16 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1efe12a1469752d0e6ff5ebec0b6ef4924cc5c4c71046b0ec730040535819d"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/omawarden/Cargo.toml
+++ b/omawarden/Cargo.toml
@@ -31,6 +31,8 @@ pkcs8 = { version = "0.11", features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 tokio = { version = "1", features = ["full"] }
 libc = "0.2"
+ssh-key = { version = "0.6", features = ["ed25519", "rsa", "ecdsa", "crypto", "alloc"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [dev-dependencies]
 tempfile = "3.17"

--- a/omawarden/Cargo.toml
+++ b/omawarden/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { version = "1", features = ["full"] }
 libc = "0.2"
 ssh-key = { version = "0.6", features = ["ed25519", "rsa", "ecdsa", "crypto", "alloc"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
+rpassword = "7.3"
 
 [dev-dependencies]
 tempfile = "3.17"

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -335,6 +335,29 @@ impl BitwardenApiClient {
         resp.json::<SyncResponse>()
             .map_err(|e| ApiError::Json(e.to_string()))
     }
+
+    pub fn create_cipher(&self, access_token: &str, payload: &Value) -> Result<Value, ApiError> {
+        let url = format!("{}/api/ciphers", self.server_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", access_token))
+            .json(payload)
+            .send()
+            .map_err(|e| ApiError::Http(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            return Err(ApiError::Http(format!(
+                "Create cipher failed ({}): {}",
+                status, body
+            )));
+        }
+
+        resp.json::<Value>()
+            .map_err(|e| ApiError::Json(e.to_string()))
+    }
 }
 
 pub fn decrypt_cipher_string(

--- a/omawarden/src/crypto.rs
+++ b/omawarden/src/crypto.rs
@@ -217,6 +217,42 @@ impl SymmetricCryptoKey {
             Err(CryptoError::InvalidKeyLength)
         }
     }
+
+    pub fn encrypt_string(&self, plaintext: &str) -> Result<String, CryptoError> {
+        use cbc::cipher::{BlockEncryptMut, KeyIvInit};
+        use rand_core::RngCore;
+        type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+
+        let mut iv = [0u8; 16];
+        rand_core::OsRng.fill_bytes(&mut iv);
+
+        let enc = Aes256CbcEnc::new_from_slices(&self.enc_key, &iv)
+            .map_err(|e| CryptoError::DecryptionFailed(format!("Invalid key/iv: {}", e)))?;
+        let mut buf = vec![0u8; plaintext.len() + 32];
+        let ct_len = enc
+            .encrypt_padded_b2b_mut::<Pkcs7>(plaintext.as_bytes(), &mut buf)
+            .map_err(|e| CryptoError::DecryptionFailed(format!("Encryption failed: {}", e)))?
+            .len();
+        let ct = &buf[..ct_len];
+
+        let mac_str = if let Some(ref mac_k) = self.mac_key {
+            let mut hmac = HmacSha256::new_from_slice(mac_k)
+                .map_err(|e| CryptoError::DecryptionFailed(format!("Invalid mac key: {}", e)))?;
+            hmac.update(&iv);
+            hmac.update(ct);
+            let mac = hmac.finalize().into_bytes();
+            format!("|{}", BASE64.encode(mac))
+        } else {
+            String::new()
+        };
+
+        Ok(format!(
+            "2.{}|{}{}",
+            BASE64.encode(iv),
+            BASE64.encode(ct),
+            mac_str
+        ))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/omawarden/src/daemon.rs
+++ b/omawarden/src/daemon.rs
@@ -213,6 +213,47 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
             let category = req.get("category").and_then(|v| v.as_str());
             json!(state.vault_mgr.search_items(query, category))
         }
+        "ssh_key_create" => {
+            if let Some(user_key) = state.vault_mgr.get_user_key() {
+                let name = req.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                let priv_k = req
+                    .get("private_key")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let pub_k = req.get("public_key").and_then(|v| v.as_str()).unwrap_or("");
+                let fp = req
+                    .get("fingerprint")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let notes = req.get("notes").and_then(|v| v.as_str());
+                let folder_id = req.get("folder_id").and_then(|v| v.as_str());
+
+                let ssh_data = crate::ssh::GeneratedSshKey {
+                    algorithm_name: String::new(),
+                    private_key: priv_k.to_string(),
+                    public_key: pub_k.to_string(),
+                    fingerprint: fp.to_string(),
+                };
+
+                match state
+                    .vault_mgr
+                    .create_ssh_key(name, &ssh_data, notes, folder_id, &user_key)
+                {
+                    Ok(item) => json!({ "ok": true, "item": item }),
+                    Err(e) => json!({ "ok": false, "error": e }),
+                }
+            } else {
+                json!({ "ok": false, "error": "Vault is locked. Please unlock the vault first." })
+            }
+        }
+        "get_ssh_key" => {
+            let query = req.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            if let Some(item) = state.vault_mgr.find_ssh_key(query) {
+                json!({ "ok": true, "item": item })
+            } else {
+                json!({ "ok": false, "error": format!("SSH key item '{}' not found", query) })
+            }
+        }
         "get_attachment_key" => {
             let item_id = req.get("item_id").and_then(|v| v.as_str()).unwrap_or("");
             let attachment_id = req

--- a/omawarden/src/lib.rs
+++ b/omawarden/src/lib.rs
@@ -9,6 +9,7 @@ pub mod health;
 pub mod hook;
 pub mod keyring;
 pub mod logging;
+pub mod ssh;
 pub mod storage;
 pub mod totp;
 pub mod vault;

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -520,12 +520,42 @@ fn main() -> ExitCode {
                     }
                 }
                 VaultAction::List { category } => {
+                    omawarden::daemon::ensure_daemon_running();
+                    let st = send_daemon_request(&json!({ "action": "status" }));
+                    let is_unlocked = st
+                        .as_ref()
+                        .and_then(|v| v.get("is_unlocked"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if !is_unlocked && !vault_mgr.is_unlocked() {
+                        eprintln!("Error: Vault is locked. Please unlock using 'omawarden auth unlock' first.");
+                        println!(
+                            "{}",
+                            json!({ "ok": false, "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first." })
+                        );
+                        return ExitCode::FAILURE;
+                    }
                     let items = vault_mgr.get_items();
                     let filtered = vault_mgr.search(&items, "", category.as_deref());
                     println!("{}", serde_json::to_string_pretty(&filtered).unwrap());
                     ExitCode::SUCCESS
                 }
                 VaultAction::Search { query, category } => {
+                    omawarden::daemon::ensure_daemon_running();
+                    let st = send_daemon_request(&json!({ "action": "status" }));
+                    let is_unlocked = st
+                        .as_ref()
+                        .and_then(|v| v.get("is_unlocked"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if !is_unlocked && !vault_mgr.is_unlocked() {
+                        eprintln!("Error: Vault is locked. Please unlock using 'omawarden auth unlock' first.");
+                        println!(
+                            "{}",
+                            json!({ "ok": false, "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first." })
+                        );
+                        return ExitCode::FAILURE;
+                    }
                     let results = vault_mgr.search_items(&query, category.as_deref());
                     println!("{}", serde_json::to_string_pretty(&results).unwrap());
                     ExitCode::SUCCESS
@@ -824,44 +854,59 @@ fn main() -> ExitCode {
                     private_only: _,
                 } => {
                     omawarden::daemon::ensure_daemon_running();
-                    let daemon_res = send_daemon_request(&json!({
-                        "action": "get_ssh_key",
-                        "query": query
-                    }));
+                    let st = send_daemon_request(&json!({ "action": "status" }));
+                    let is_unlocked = st
+                        .as_ref()
+                        .and_then(|v| v.get("is_unlocked"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
 
-                    let item: Option<omawarden::vault::VaultItem> = if let Some(res) =
-                        daemon_res.filter(|r| r.get("ok").and_then(|v| v.as_bool()) == Some(true))
-                    {
-                        res.get("item")
-                            .and_then(|v| serde_json::from_value(v.clone()).ok())
-                    } else if let Ok(user_key) =
-                        ensure_unlocked_user_key(&vault_mgr, &cfg.server_url)
-                    {
-                        let storage = vault_mgr.storage_mgr.load();
-                        let items = omawarden::api::decrypt_sync_ciphers_with_context(
-                            &storage.ciphers,
-                            &storage.folders,
-                            &storage.organizations,
-                            &user_key,
-                            storage.enc_private_key.as_deref(),
-                        );
-                        items.into_iter().find(|i| {
-                            i.type_name == "ssh_key"
-                                && (i.id == query
-                                    || i.name.eq_ignore_ascii_case(&query)
-                                    || i.name.to_lowercase().contains(&query.to_lowercase()))
-                        })
+                    let item: Option<omawarden::vault::VaultItem> = if is_unlocked {
+                        let daemon_res = send_daemon_request(&json!({
+                            "action": "get_ssh_key",
+                            "query": query
+                        }));
+                        daemon_res
+                            .filter(|r| r.get("ok").and_then(|v| v.as_bool()) == Some(true))
+                            .and_then(|res| {
+                                res.get("item")
+                                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                            })
                     } else {
-                        vault_mgr.find_ssh_key(&query)
+                        match ensure_unlocked_user_key(&vault_mgr, &cfg.server_url) {
+                            Ok(user_key) => {
+                                let storage = vault_mgr.storage_mgr.load();
+                                let items = omawarden::api::decrypt_sync_ciphers_with_context(
+                                    &storage.ciphers,
+                                    &storage.folders,
+                                    &storage.organizations,
+                                    &user_key,
+                                    storage.enc_private_key.as_deref(),
+                                );
+                                items.into_iter().find(|i| {
+                                    i.type_name == "ssh_key"
+                                        && (i.id == query
+                                            || i.name.eq_ignore_ascii_case(&query)
+                                            || i.name
+                                                .to_lowercase()
+                                                .contains(&query.to_lowercase()))
+                                })
+                            }
+                            Err(e) => {
+                                eprintln!("Error: {}", e);
+                                println!("{}", json!({ "ok": false, "error": e }));
+                                return ExitCode::FAILURE;
+                            }
+                        }
                     };
 
                     let ssh_item = match item {
                         Some(i) => i,
                         None => {
-                            eprintln!("Error: SSH key item '{}' not found or vault locked.", query);
+                            eprintln!("Error: SSH key item '{}' not found in vault.", query);
                             println!(
                                 "{}",
-                                json!({ "ok": false, "error": format!("SSH key item '{}' not found", query) })
+                                json!({ "ok": false, "error": format!("SSH key item '{}' not found in vault", query) })
                             );
                             return ExitCode::FAILURE;
                         }
@@ -948,12 +993,16 @@ fn ensure_unlocked_user_key(
         return Ok(key);
     }
 
-    let (pwd, _) = read_auth_payload();
-    if pwd.is_empty() {
-        return Err("Master password required to unlock vault".to_string());
+    let st = vault_mgr.storage_mgr.load();
+    if st.enc_user_key.is_none() {
+        return Err("Account not logged in. Please run 'omawarden auth login' first.".to_string());
     }
 
-    let st = vault_mgr.storage_mgr.load();
+    let (pwd, _) = read_auth_payload();
+    if pwd.is_empty() {
+        return Err("Vault is locked. Please unlock the vault first using 'omawarden auth unlock' or provide Master Password.".to_string());
+    }
+
     let user_key = vault_mgr
         .storage_mgr
         .unlock_user_key(&pwd, &st)

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -6,6 +6,10 @@ use omawarden::config::ConfigManager;
 use omawarden::daemon::{run_daemon_server, send_daemon_request, DaemonState};
 use omawarden::health::check_system_health;
 use omawarden::hook::install_lock_hook;
+use omawarden::ssh::{
+    generate_keypair, parse_private_key, write_keypair_files, write_keypair_files_named,
+    SshAlgorithm,
+};
 use omawarden::storage::StorageManager;
 use omawarden::totp::generate_totp;
 use omawarden::vault::VaultManager;
@@ -70,6 +74,11 @@ enum Commands {
     Attachment {
         #[command(subcommand)]
         action: AttachmentAction,
+    },
+    #[command(about = "SSH key lifecycle management (generate, import, export)")]
+    SshKey {
+        #[command(subcommand)]
+        action: SshKeyAction,
     },
     #[command(about = "Run omawarden background daemon")]
     Daemon {
@@ -193,6 +202,57 @@ enum AttachmentAction {
         open: bool,
         #[arg(long)]
         preview: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum SshKeyAction {
+    #[command(about = "Generate a new SSH keypair and store it in Bitwarden")]
+    Create {
+        #[arg(long, required = true)]
+        name: String,
+        #[arg(long, default_value = "ed25519")]
+        algorithm: SshAlgorithm,
+        #[arg(long)]
+        comment: Option<String>,
+        #[arg(long)]
+        notes: Option<String>,
+        #[arg(long)]
+        folder: Option<String>,
+        #[arg(long)]
+        out_dir: Option<PathBuf>,
+    },
+    #[command(about = "Import an existing SSH private key file or STDIN into Bitwarden")]
+    Import {
+        #[arg(long, required = true)]
+        name: String,
+        #[arg(long)]
+        private_key: Option<PathBuf>,
+        #[arg(long)]
+        public_key: Option<PathBuf>,
+        #[arg(long)]
+        stdin: bool,
+        #[arg(long)]
+        notes: Option<String>,
+        #[arg(long)]
+        folder: Option<String>,
+    },
+    #[command(about = "Export an SSH key to local file or standard output")]
+    Export {
+        #[arg(index = 1, required = true)]
+        query: String,
+        #[arg(long)]
+        out_dir: Option<PathBuf>,
+        #[arg(long)]
+        private_key_file: Option<String>,
+        #[arg(long)]
+        public_key_file: Option<String>,
+        #[arg(long)]
+        stdout: bool,
+        #[arg(long)]
+        public_only: bool,
+        #[arg(long)]
+        private_only: bool,
     },
 }
 
@@ -560,5 +620,346 @@ fn main() -> ExitCode {
                 }
             }
         },
+
+        Commands::SshKey { action } => {
+            let vault_mgr = VaultManager::new(&cfg.server_url, None, None);
+            match action {
+                SshKeyAction::Create {
+                    name,
+                    algorithm,
+                    comment,
+                    notes,
+                    folder,
+                    out_dir,
+                } => {
+                    omawarden::daemon::ensure_daemon_running();
+                    let keypair = match generate_keypair(algorithm, comment.as_deref()) {
+                        Ok(k) => k,
+                        Err(e) => {
+                            eprintln!("Error generating SSH key: {}", e);
+                            println!("{}", json!({ "ok": false, "error": e }));
+                            return ExitCode::FAILURE;
+                        }
+                    };
+
+                    let daemon_req = json!({
+                        "action": "ssh_key_create",
+                        "name": name,
+                        "private_key": keypair.private_key,
+                        "public_key": keypair.public_key,
+                        "fingerprint": keypair.fingerprint,
+                        "notes": notes,
+                        "folder_id": folder,
+                    });
+
+                    let daemon_res = send_daemon_request(&daemon_req);
+                    let item_val = if let Some(res) =
+                        daemon_res.filter(|r| r.get("ok").and_then(|v| v.as_bool()) == Some(true))
+                    {
+                        res.get("item").cloned()
+                    } else {
+                        match ensure_unlocked_user_key(&vault_mgr, &cfg.server_url) {
+                            Ok(user_key) => {
+                                match vault_mgr.create_ssh_key(
+                                    &name,
+                                    &keypair,
+                                    notes.as_deref(),
+                                    folder.as_deref(),
+                                    &user_key,
+                                ) {
+                                    Ok(item) => Some(json!(item)),
+                                    Err(e) => {
+                                        eprintln!("Error creating SSH key cipher: {}", e);
+                                        println!("{}", json!({ "ok": false, "error": e }));
+                                        return ExitCode::FAILURE;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("Authentication required: {}", e);
+                                println!("{}", json!({ "ok": false, "error": e }));
+                                return ExitCode::FAILURE;
+                            }
+                        }
+                    };
+
+                    let mut files_json = json!(null);
+                    if let Some(ref dest_dir) = out_dir {
+                        match write_keypair_files(
+                            dest_dir,
+                            algorithm.default_filename_prefix(),
+                            &keypair.private_key,
+                            &keypair.public_key,
+                        ) {
+                            Ok((priv_p, pub_p)) => {
+                                files_json = json!({
+                                    "private_key_path": priv_p.to_string_lossy(),
+                                    "public_key_path": pub_p.to_string_lossy(),
+                                });
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "Warning: Failed to write exported files to {:?}: {}",
+                                    dest_dir, e
+                                );
+                            }
+                        }
+                    }
+
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "ok": true,
+                            "item": item_val,
+                            "files": files_json,
+                        }))
+                        .unwrap()
+                    );
+                    ExitCode::SUCCESS
+                }
+
+                SshKeyAction::Import {
+                    name,
+                    private_key,
+                    public_key,
+                    stdin,
+                    notes,
+                    folder,
+                } => {
+                    omawarden::daemon::ensure_daemon_running();
+                    let raw_priv = if stdin || private_key.is_none() {
+                        let mut buffer = String::new();
+                        let _ = io::stdin().read_to_string(&mut buffer);
+                        buffer
+                    } else if let Some(ref p) = private_key {
+                        match std::fs::read_to_string(p) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                eprintln!("Error reading private key file {:?}: {}", p, e);
+                                println!("{}", json!({ "ok": false, "error": e.to_string() }));
+                                return ExitCode::FAILURE;
+                            }
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    let mut keypair = match parse_private_key(&raw_priv) {
+                        Ok(k) => k,
+                        Err(e) => {
+                            eprintln!("Error parsing private key: {}", e);
+                            println!("{}", json!({ "ok": false, "error": e }));
+                            return ExitCode::FAILURE;
+                        }
+                    };
+
+                    if let Some(ref pub_path) = public_key {
+                        if let Ok(pub_content) = std::fs::read_to_string(pub_path) {
+                            let trimmed_pub = pub_content.trim().to_string();
+                            if !trimmed_pub.is_empty() {
+                                keypair.public_key = trimmed_pub;
+                            }
+                        }
+                    }
+
+                    let daemon_req = json!({
+                        "action": "ssh_key_create",
+                        "name": name,
+                        "private_key": keypair.private_key,
+                        "public_key": keypair.public_key,
+                        "fingerprint": keypair.fingerprint,
+                        "notes": notes,
+                        "folder_id": folder,
+                    });
+
+                    let daemon_res = send_daemon_request(&daemon_req);
+                    let item_val = if let Some(res) =
+                        daemon_res.filter(|r| r.get("ok").and_then(|v| v.as_bool()) == Some(true))
+                    {
+                        res.get("item").cloned()
+                    } else {
+                        match ensure_unlocked_user_key(&vault_mgr, &cfg.server_url) {
+                            Ok(user_key) => {
+                                match vault_mgr.create_ssh_key(
+                                    &name,
+                                    &keypair,
+                                    notes.as_deref(),
+                                    folder.as_deref(),
+                                    &user_key,
+                                ) {
+                                    Ok(item) => Some(json!(item)),
+                                    Err(e) => {
+                                        eprintln!("Error importing SSH key cipher: {}", e);
+                                        println!("{}", json!({ "ok": false, "error": e }));
+                                        return ExitCode::FAILURE;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("Authentication required: {}", e);
+                                println!("{}", json!({ "ok": false, "error": e }));
+                                return ExitCode::FAILURE;
+                            }
+                        }
+                    };
+
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "ok": true,
+                            "item": item_val,
+                        }))
+                        .unwrap()
+                    );
+                    ExitCode::SUCCESS
+                }
+
+                SshKeyAction::Export {
+                    query,
+                    out_dir,
+                    private_key_file,
+                    public_key_file,
+                    stdout,
+                    public_only,
+                    private_only: _,
+                } => {
+                    omawarden::daemon::ensure_daemon_running();
+                    let daemon_res = send_daemon_request(&json!({
+                        "action": "get_ssh_key",
+                        "query": query
+                    }));
+
+                    let item: Option<omawarden::vault::VaultItem> = if let Some(res) =
+                        daemon_res.filter(|r| r.get("ok").and_then(|v| v.as_bool()) == Some(true))
+                    {
+                        res.get("item")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    } else if let Ok(user_key) =
+                        ensure_unlocked_user_key(&vault_mgr, &cfg.server_url)
+                    {
+                        let storage = vault_mgr.storage_mgr.load();
+                        let items = omawarden::api::decrypt_sync_ciphers_with_context(
+                            &storage.ciphers,
+                            &storage.folders,
+                            &storage.organizations,
+                            &user_key,
+                            storage.enc_private_key.as_deref(),
+                        );
+                        items.into_iter().find(|i| {
+                            i.type_name == "ssh_key"
+                                && (i.id == query
+                                    || i.name.eq_ignore_ascii_case(&query)
+                                    || i.name.to_lowercase().contains(&query.to_lowercase()))
+                        })
+                    } else {
+                        vault_mgr.find_ssh_key(&query)
+                    };
+
+                    let ssh_item = match item {
+                        Some(i) => i,
+                        None => {
+                            eprintln!("Error: SSH key item '{}' not found or vault locked.", query);
+                            println!(
+                                "{}",
+                                json!({ "ok": false, "error": format!("SSH key item '{}' not found", query) })
+                            );
+                            return ExitCode::FAILURE;
+                        }
+                    };
+
+                    let ssh_meta = match ssh_item.ssh_key {
+                        Some(s) => s,
+                        None => {
+                            eprintln!("Error: Item '{}' has no SSH key metadata.", ssh_item.name);
+                            println!(
+                                "{}",
+                                json!({ "ok": false, "error": "Item has no SSH key metadata" })
+                            );
+                            return ExitCode::FAILURE;
+                        }
+                    };
+
+                    if stdout {
+                        if public_only {
+                            if let Some(ref pubk) = ssh_meta.public_key {
+                                println!("{}", pubk);
+                            }
+                        } else if let Some(ref privk) = ssh_meta.private_key {
+                            print!("{}", privk);
+                            if !privk.ends_with('\n') {
+                                println!();
+                            }
+                        }
+                        return ExitCode::SUCCESS;
+                    }
+
+                    let target_dir = out_dir.unwrap_or_else(|| PathBuf::from("."));
+                    let priv_filename = private_key_file.unwrap_or_else(|| {
+                        let safe_name = ssh_item.name.to_lowercase().replace([' ', '/'], "_");
+                        if safe_name.is_empty() {
+                            "id_ssh_key".to_string()
+                        } else {
+                            safe_name
+                        }
+                    });
+                    let pub_filename =
+                        public_key_file.unwrap_or_else(|| format!("{}.pub", priv_filename));
+
+                    let priv_content = ssh_meta.private_key.unwrap_or_default();
+                    let pub_content = ssh_meta.public_key.unwrap_or_default();
+
+                    match write_keypair_files_named(
+                        &target_dir,
+                        &priv_filename,
+                        &pub_filename,
+                        &priv_content,
+                        &pub_content,
+                    ) {
+                        Ok((priv_p, pub_p)) => {
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&json!({
+                                    "ok": true,
+                                    "name": ssh_item.name,
+                                    "private_key_path": priv_p.to_string_lossy(),
+                                    "public_key_path": pub_p.to_string_lossy(),
+                                }))
+                                .unwrap()
+                            );
+                            ExitCode::SUCCESS
+                        }
+                        Err(e) => {
+                            eprintln!("Error writing export files: {}", e);
+                            println!("{}", json!({ "ok": false, "error": e.to_string() }));
+                            ExitCode::FAILURE
+                        }
+                    }
+                }
+            }
+        }
     }
+}
+
+fn ensure_unlocked_user_key(
+    vault_mgr: &VaultManager,
+    _server_url: &str,
+) -> Result<omawarden::crypto::SymmetricCryptoKey, String> {
+    if let Some(key) = vault_mgr.get_user_key() {
+        return Ok(key);
+    }
+
+    let (pwd, _) = read_auth_payload();
+    if pwd.is_empty() {
+        return Err("Master password required to unlock vault".to_string());
+    }
+
+    let st = vault_mgr.storage_mgr.load();
+    let user_key = vault_mgr
+        .storage_mgr
+        .unlock_user_key(&pwd, &st)
+        .map_err(|e| format!("Unlock failed: {:?}", e))?;
+
+    let _ = send_daemon_request(&json!({ "action": "unlock", "password": pwd }));
+
+    Ok(user_key)
 }

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -14,7 +14,7 @@ use omawarden::storage::StorageManager;
 use omawarden::totp::generate_totp;
 use omawarden::vault::VaultManager;
 use serde_json::{json, Value};
-use std::io::{self, BufRead, Read};
+use std::io::{self, BufRead, IsTerminal, Read, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -258,6 +258,9 @@ enum SshKeyAction {
 
 fn read_secret_stdin() -> String {
     let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return String::new();
+    }
     let mut buffer = String::new();
     if stdin.lock().read_line(&mut buffer).is_ok() {
         return buffer.trim_end_matches(&['\r', '\n'][..]).to_string();
@@ -288,6 +291,9 @@ fn read_clipboard_stdin() -> String {
 
 fn read_auth_payload() -> (String, Option<String>) {
     let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return (String::new(), None);
+    }
     let mut raw = String::new();
     let _ = stdin.lock().read_line(&mut raw);
     let raw = raw.trim();
@@ -452,7 +458,15 @@ fn main() -> ExitCode {
                     }
                 }
                 AuthAction::Unlock => {
-                    let pwd = read_secret_stdin();
+                    let pwd = if io::stdin().is_terminal() {
+                        eprint!("Enter Master Password: ");
+                        let _ = io::stderr().flush();
+                        let mut buf = String::new();
+                        let _ = io::stdin().read_line(&mut buf);
+                        buf.trim_end_matches(&['\r', '\n'][..]).to_string()
+                    } else {
+                        read_secret_stdin()
+                    };
                     omawarden::daemon::ensure_daemon_running();
                     let res = auth_mgr.unlock(&pwd);
                     println!("{}", serde_json::to_string_pretty(&res).unwrap());
@@ -528,7 +542,6 @@ fn main() -> ExitCode {
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
                     if !is_unlocked && !vault_mgr.is_unlocked() {
-                        eprintln!("Error: Vault is locked. Please unlock using 'omawarden auth unlock' first.");
                         println!(
                             "{}",
                             json!({ "ok": false, "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first." })
@@ -549,7 +562,6 @@ fn main() -> ExitCode {
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
                     if !is_unlocked && !vault_mgr.is_unlocked() {
-                        eprintln!("Error: Vault is locked. Please unlock using 'omawarden auth unlock' first.");
                         println!(
                             "{}",
                             json!({ "ok": false, "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first." })
@@ -666,7 +678,6 @@ fn main() -> ExitCode {
                     let keypair = match generate_keypair(algorithm, comment.as_deref()) {
                         Ok(k) => k,
                         Err(e) => {
-                            eprintln!("Error generating SSH key: {}", e);
                             println!("{}", json!({ "ok": false, "error": e }));
                             return ExitCode::FAILURE;
                         }
@@ -699,14 +710,12 @@ fn main() -> ExitCode {
                                 ) {
                                     Ok(item) => Some(json!(item)),
                                     Err(e) => {
-                                        eprintln!("Error creating SSH key cipher: {}", e);
                                         println!("{}", json!({ "ok": false, "error": e }));
                                         return ExitCode::FAILURE;
                                     }
                                 }
                             }
                             Err(e) => {
-                                eprintln!("Authentication required: {}", e);
                                 println!("{}", json!({ "ok": false, "error": e }));
                                 return ExitCode::FAILURE;
                             }
@@ -728,9 +737,11 @@ fn main() -> ExitCode {
                                 });
                             }
                             Err(e) => {
-                                eprintln!(
-                                    "Warning: Failed to write exported files to {:?}: {}",
-                                    dest_dir, e
+                                omawarden::log_warn!(
+                                    "omawarden:ssh",
+                                    "Failed to write exported files to {:?}: {}",
+                                    dest_dir,
+                                    e
                                 );
                             }
                         }
@@ -765,7 +776,6 @@ fn main() -> ExitCode {
                         match std::fs::read_to_string(p) {
                             Ok(c) => c,
                             Err(e) => {
-                                eprintln!("Error reading private key file {:?}: {}", p, e);
                                 println!("{}", json!({ "ok": false, "error": e.to_string() }));
                                 return ExitCode::FAILURE;
                             }
@@ -777,7 +787,6 @@ fn main() -> ExitCode {
                     let mut keypair = match parse_private_key(&raw_priv) {
                         Ok(k) => k,
                         Err(e) => {
-                            eprintln!("Error parsing private key: {}", e);
                             println!("{}", json!({ "ok": false, "error": e }));
                             return ExitCode::FAILURE;
                         }
@@ -819,14 +828,12 @@ fn main() -> ExitCode {
                                 ) {
                                     Ok(item) => Some(json!(item)),
                                     Err(e) => {
-                                        eprintln!("Error importing SSH key cipher: {}", e);
                                         println!("{}", json!({ "ok": false, "error": e }));
                                         return ExitCode::FAILURE;
                                     }
                                 }
                             }
                             Err(e) => {
-                                eprintln!("Authentication required: {}", e);
                                 println!("{}", json!({ "ok": false, "error": e }));
                                 return ExitCode::FAILURE;
                             }
@@ -893,7 +900,6 @@ fn main() -> ExitCode {
                                 })
                             }
                             Err(e) => {
-                                eprintln!("Error: {}", e);
                                 println!("{}", json!({ "ok": false, "error": e }));
                                 return ExitCode::FAILURE;
                             }
@@ -903,7 +909,6 @@ fn main() -> ExitCode {
                     let ssh_item = match item {
                         Some(i) => i,
                         None => {
-                            eprintln!("Error: SSH key item '{}' not found in vault.", query);
                             println!(
                                 "{}",
                                 json!({ "ok": false, "error": format!("SSH key item '{}' not found in vault", query) })
@@ -915,7 +920,6 @@ fn main() -> ExitCode {
                     let ssh_meta = match ssh_item.ssh_key {
                         Some(s) => s,
                         None => {
-                            eprintln!("Error: Item '{}' has no SSH key metadata.", ssh_item.name);
                             println!(
                                 "{}",
                                 json!({ "ok": false, "error": "Item has no SSH key metadata" })
@@ -974,7 +978,6 @@ fn main() -> ExitCode {
                             ExitCode::SUCCESS
                         }
                         Err(e) => {
-                            eprintln!("Error writing export files: {}", e);
                             println!("{}", json!({ "ok": false, "error": e.to_string() }));
                             ExitCode::FAILURE
                         }

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -14,7 +14,7 @@ use omawarden::storage::StorageManager;
 use omawarden::totp::generate_totp;
 use omawarden::vault::VaultManager;
 use serde_json::{json, Value};
-use std::io::{self, BufRead, IsTerminal, Read, Write};
+use std::io::{self, BufRead, IsTerminal, Read};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -430,7 +430,13 @@ fn main() -> ExitCode {
                     ExitCode::SUCCESS
                 }
                 AuthAction::LoginPassword { email } => {
-                    let (pwd, code_val) = read_auth_payload();
+                    let (pwd, code_val) = if io::stdin().is_terminal() {
+                        let p = rpassword::prompt_password("Enter Master Password: ")
+                            .unwrap_or_default();
+                        (p, None)
+                    } else {
+                        read_auth_payload()
+                    };
                     let res = auth_mgr.login_password(&email, &pwd, code_val.as_deref());
                     println!("{}", serde_json::to_string_pretty(&res).unwrap());
                     if res.ok {
@@ -440,15 +446,20 @@ fn main() -> ExitCode {
                     }
                 }
                 AuthAction::LoginApikey { client_id } => {
-                    let raw_secret = read_secret_stdin();
-                    let mut actual_secret = raw_secret.clone();
-                    if raw_secret.starts_with('{') && raw_secret.ends_with('}') {
-                        if let Ok(val) = serde_json::from_str::<Value>(&raw_secret) {
-                            if let Some(s) = val.get("client_secret").and_then(|v| v.as_str()) {
-                                actual_secret = s.to_string();
+                    let actual_secret = if io::stdin().is_terminal() {
+                        rpassword::prompt_password("Enter Client Secret: ").unwrap_or_default()
+                    } else {
+                        let raw_secret = read_secret_stdin();
+                        let mut secret = raw_secret.clone();
+                        if raw_secret.starts_with('{') && raw_secret.ends_with('}') {
+                            if let Ok(val) = serde_json::from_str::<Value>(&raw_secret) {
+                                if let Some(s) = val.get("client_secret").and_then(|v| v.as_str()) {
+                                    secret = s.to_string();
+                                }
                             }
                         }
-                    }
+                        secret
+                    };
                     let res = auth_mgr.login_apikey(&client_id, &actual_secret);
                     println!("{}", serde_json::to_string_pretty(&res).unwrap());
                     if res.ok {
@@ -459,11 +470,7 @@ fn main() -> ExitCode {
                 }
                 AuthAction::Unlock => {
                     let pwd = if io::stdin().is_terminal() {
-                        eprint!("Enter Master Password: ");
-                        let _ = io::stderr().flush();
-                        let mut buf = String::new();
-                        let _ = io::stdin().read_line(&mut buf);
-                        buf.trim_end_matches(&['\r', '\n'][..]).to_string()
+                        rpassword::prompt_password("Enter Master Password: ").unwrap_or_default()
                     } else {
                         read_secret_stdin()
                     };

--- a/omawarden/src/ssh.rs
+++ b/omawarden/src/ssh.rs
@@ -1,0 +1,309 @@
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use clap::ValueEnum;
+use rand_core::OsRng;
+use ssh_key::private::{EcdsaKeypair, Ed25519Keypair, RsaKeypair};
+use ssh_key::{Algorithm, EcdsaCurve, HashAlg, LineEnding, PrivateKey};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum SshAlgorithm {
+    #[default]
+    #[value(name = "ed25519", alias = "ED25519")]
+    Ed25519,
+    #[value(name = "rsa-2048", alias = "rsa2048", alias = "RSA-2048")]
+    Rsa2048,
+    #[value(name = "rsa-4096", alias = "rsa4096", alias = "RSA-4096")]
+    Rsa4096,
+    #[value(
+        name = "ecdsa-p256",
+        alias = "ecdsa256",
+        alias = "p256",
+        alias = "P-256"
+    )]
+    EcdsaP256,
+    #[value(
+        name = "ecdsa-p384",
+        alias = "ecdsa384",
+        alias = "p384",
+        alias = "P-384"
+    )]
+    EcdsaP384,
+}
+
+impl fmt::Display for SshAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ed25519 => write!(f, "ED25519"),
+            Self::Rsa2048 => write!(f, "RSA-2048"),
+            Self::Rsa4096 => write!(f, "RSA-4096"),
+            Self::EcdsaP256 => write!(f, "ECDSA-P256"),
+            Self::EcdsaP384 => write!(f, "ECDSA-P384"),
+        }
+    }
+}
+
+impl FromStr for SshAlgorithm {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "ed25519" => Ok(Self::Ed25519),
+            "rsa-2048" | "rsa2048" | "2048" => Ok(Self::Rsa2048),
+            "rsa-4096" | "rsa4096" | "4096" | "rsa" => Ok(Self::Rsa4096),
+            "ecdsa-p256" | "ecdsa256" | "p256" | "p-256" => Ok(Self::EcdsaP256),
+            "ecdsa-p384" | "ecdsa384" | "p384" | "p-384" => Ok(Self::EcdsaP384),
+            other => Err(format!(
+                "Unknown SSH algorithm '{}'. Supported: ed25519, rsa-2048, rsa-4096, ecdsa-p256, ecdsa-p384",
+                other
+            )),
+        }
+    }
+}
+
+impl SshAlgorithm {
+    pub fn default_filename_prefix(&self) -> &'static str {
+        match self {
+            Self::Ed25519 => "id_ed25519",
+            Self::Rsa2048 | Self::Rsa4096 => "id_rsa",
+            Self::EcdsaP256 => "id_ecdsa_p256",
+            Self::EcdsaP384 => "id_ecdsa_p384",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeneratedSshKey {
+    pub algorithm_name: String,
+    pub private_key: String,
+    pub public_key: String,
+    pub fingerprint: String,
+}
+
+/// Generates a new SSH keypair with the specified algorithm and optional comment.
+pub fn generate_keypair(
+    algorithm: SshAlgorithm,
+    comment: Option<&str>,
+) -> Result<GeneratedSshKey, String> {
+    let mut rng = OsRng;
+
+    let mut key = match algorithm {
+        SshAlgorithm::Ed25519 => PrivateKey::from(Ed25519Keypair::random(&mut rng)),
+        SshAlgorithm::EcdsaP256 => {
+            let keypair = EcdsaKeypair::random(&mut rng, EcdsaCurve::NistP256)
+                .map_err(|e| format!("Failed to generate ECDSA P-256 key: {}", e))?;
+            PrivateKey::from(keypair)
+        }
+        SshAlgorithm::EcdsaP384 => {
+            let keypair = EcdsaKeypair::random(&mut rng, EcdsaCurve::NistP384)
+                .map_err(|e| format!("Failed to generate ECDSA P-384 key: {}", e))?;
+            PrivateKey::from(keypair)
+        }
+        SshAlgorithm::Rsa2048 => {
+            let rsa_key = RsaKeypair::random(&mut rng, 2048)
+                .map_err(|e| format!("Failed to generate RSA-2048 key: {}", e))?;
+            PrivateKey::from(rsa_key)
+        }
+        SshAlgorithm::Rsa4096 => {
+            let rsa_key = RsaKeypair::random(&mut rng, 4096)
+                .map_err(|e| format!("Failed to generate RSA-4096 key: {}", e))?;
+            PrivateKey::from(rsa_key)
+        }
+    };
+
+    if let Some(c) = comment {
+        key.set_comment(c);
+    }
+
+    let public_key = key
+        .public_key()
+        .to_openssh()
+        .map_err(|e| format!("Failed to format public key: {}", e))?;
+
+    let fingerprint = key.public_key().fingerprint(HashAlg::Sha256).to_string();
+
+    let private_pem = key
+        .to_openssh(LineEnding::LF)
+        .map_err(|e| format!("Failed to format OpenSSH private key: {}", e))?
+        .to_string();
+
+    Ok(GeneratedSshKey {
+        algorithm_name: algorithm.to_string(),
+        private_key: private_pem,
+        public_key,
+        fingerprint,
+    })
+}
+
+/// Parses an OpenSSH private key string, deriving the public key and SHA256 fingerprint.
+pub fn parse_private_key(raw_pem: &str) -> Result<GeneratedSshKey, String> {
+    let trimmed = raw_pem.trim();
+    if trimmed.is_empty() {
+        return Err("Private key data is empty".to_string());
+    }
+
+    let key = PrivateKey::from_openssh(trimmed)
+        .map_err(|e| format!("Unable to parse OpenSSH private key: {}", e))?;
+
+    let public_key = key
+        .public_key()
+        .to_openssh()
+        .map_err(|e| format!("Failed to derive public key: {}", e))?;
+
+    let fingerprint = key.public_key().fingerprint(HashAlg::Sha256).to_string();
+
+    let algo_name = match key.algorithm() {
+        Algorithm::Ed25519 => "ED25519".to_string(),
+        Algorithm::Rsa { .. } => "RSA".to_string(),
+        Algorithm::Ecdsa { curve } => format!(
+            "ECDSA-{}",
+            match curve {
+                EcdsaCurve::NistP256 => "P256",
+                EcdsaCurve::NistP384 => "P384",
+                EcdsaCurve::NistP521 => "P521",
+            }
+        ),
+        Algorithm::Dsa => "DSA".to_string(),
+        _ => "SSH-KEY".to_string(),
+    };
+
+    Ok(GeneratedSshKey {
+        algorithm_name: algo_name,
+        private_key: trimmed.to_string(),
+        public_key,
+        fingerprint,
+    })
+}
+
+/// Atomically writes named private key (0600) and public key (0644) files to target directory.
+pub fn write_keypair_files_named(
+    out_dir: &Path,
+    priv_filename: &str,
+    pub_filename: &str,
+    private_key: &str,
+    public_key: &str,
+) -> std::io::Result<(PathBuf, PathBuf)> {
+    if !out_dir.exists() {
+        fs::create_dir_all(out_dir)?;
+    }
+
+    let priv_path = out_dir.join(priv_filename);
+    let pub_path = out_dir.join(pub_filename);
+
+    // Write private key with strict 0600 permissions
+    let mut priv_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&priv_path)?;
+    priv_file.write_all(private_key.as_bytes())?;
+    if !private_key.ends_with('\n') {
+        priv_file.write_all(b"\n")?;
+    }
+    priv_file.flush()?;
+
+    // Write public key with 0644 permissions
+    let mut pub_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o644)
+        .open(&pub_path)?;
+    pub_file.write_all(public_key.as_bytes())?;
+    if !public_key.ends_with('\n') {
+        pub_file.write_all(b"\n")?;
+    }
+    pub_file.flush()?;
+
+    Ok((priv_path, pub_path))
+}
+
+/// Atomically writes private key (0600) and public key (0644) files to target directory using a base name.
+pub fn write_keypair_files(
+    out_dir: &Path,
+    filename_base: &str,
+    private_key: &str,
+    public_key: &str,
+) -> std::io::Result<(PathBuf, PathBuf)> {
+    write_keypair_files_named(
+        out_dir,
+        filename_base,
+        &format!("{}.pub", filename_base),
+        private_key,
+        public_key,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_generate_ed25519_keypair() {
+        let res = generate_keypair(SshAlgorithm::Ed25519, Some("user@test")).unwrap();
+        assert_eq!(res.algorithm_name, "ED25519");
+        assert!(res
+            .private_key
+            .starts_with("-----BEGIN OPENSSH PRIVATE KEY-----"));
+        assert!(res.public_key.starts_with("ssh-ed25519 AAA"));
+        assert!(res.public_key.contains("user@test"));
+        assert!(res.fingerprint.starts_with("SHA256:"));
+
+        // Parse it back
+        let parsed = parse_private_key(&res.private_key).unwrap();
+        assert_eq!(parsed.fingerprint, res.fingerprint);
+        assert_eq!(parsed.public_key, res.public_key);
+    }
+
+    #[test]
+    fn test_generate_rsa_2048_keypair() {
+        let res = generate_keypair(SshAlgorithm::Rsa2048, None).unwrap();
+        assert_eq!(res.algorithm_name, "RSA-2048");
+        assert!(res
+            .private_key
+            .starts_with("-----BEGIN OPENSSH PRIVATE KEY-----"));
+        assert!(res.public_key.starts_with("ssh-rsa AAA"));
+        assert!(res.fingerprint.starts_with("SHA256:"));
+    }
+
+    #[test]
+    fn test_generate_ecdsa_p256_keypair() {
+        let res = generate_keypair(SshAlgorithm::EcdsaP256, None).unwrap();
+        assert_eq!(res.algorithm_name, "ECDSA-P256");
+        assert!(res
+            .private_key
+            .starts_with("-----BEGIN OPENSSH PRIVATE KEY-----"));
+        assert!(res.public_key.starts_with("ecdsa-sha2-nistp256 AAA"));
+        assert!(res.fingerprint.starts_with("SHA256:"));
+    }
+
+    #[test]
+    fn test_write_keypair_files_permissions() {
+        let dir = tempdir().unwrap();
+        let priv_content =
+            "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----";
+        let pub_content = "ssh-ed25519 AAAAC3 test@host";
+
+        let (priv_path, pub_path) =
+            write_keypair_files(dir.path(), "id_ed25519", priv_content, pub_content).unwrap();
+
+        assert!(priv_path.exists());
+        assert!(pub_path.exists());
+
+        let priv_meta = fs::metadata(&priv_path).unwrap();
+        let pub_meta = fs::metadata(&pub_path).unwrap();
+
+        let priv_mode = priv_meta.permissions().mode() & 0o777;
+        let pub_mode = pub_meta.permissions().mode() & 0o777;
+
+        assert_eq!(priv_mode, 0o600, "Private key must have 0600 permissions");
+        assert_eq!(pub_mode, 0o644, "Public key must have 0644 permissions");
+    }
+}

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -606,6 +606,141 @@ impl VaultManager {
         Some(cipher_key)
     }
 
+    pub fn get_user_key(&self) -> Option<SymmetricCryptoKey> {
+        self.user_key.read().ok().and_then(|k| k.clone())
+    }
+
+    pub fn create_ssh_key(
+        &self,
+        name: &str,
+        ssh_key_data: &crate::ssh::GeneratedSshKey,
+        notes: Option<&str>,
+        folder_id: Option<&str>,
+        user_key: &SymmetricCryptoKey,
+    ) -> Result<VaultItem, String> {
+        let storage = self.storage_mgr.load();
+        let token = storage
+            .access_token
+            .as_deref()
+            .ok_or_else(|| "Not logged in or missing access token".to_string())?;
+
+        let enc_name = user_key
+            .encrypt_string(name)
+            .map_err(|e| format!("Failed to encrypt item name: {:?}", e))?;
+
+        let enc_notes = if let Some(n) = notes.filter(|s| !s.is_empty()) {
+            Some(
+                user_key
+                    .encrypt_string(n)
+                    .map_err(|e| format!("Failed to encrypt notes: {:?}", e))?,
+            )
+        } else {
+            None
+        };
+
+        let enc_private_key = user_key
+            .encrypt_string(&ssh_key_data.private_key)
+            .map_err(|e| format!("Failed to encrypt private key: {:?}", e))?;
+
+        let enc_public_key = user_key
+            .encrypt_string(&ssh_key_data.public_key)
+            .map_err(|e| format!("Failed to encrypt public key: {:?}", e))?;
+
+        let enc_fingerprint = user_key
+            .encrypt_string(&ssh_key_data.fingerprint)
+            .map_err(|e| format!("Failed to encrypt fingerprint: {:?}", e))?;
+
+        let payload = json!({
+            "type": 5,
+            "folderId": folder_id,
+            "organizationId": null,
+            "name": enc_name,
+            "notes": enc_notes,
+            "favorite": false,
+            "reprompt": 0,
+            "sshKey": {
+                "privateKey": enc_private_key,
+                "publicKey": enc_public_key,
+                "keyFingerprint": enc_fingerprint,
+            }
+        });
+
+        let client = BitwardenApiClient::new(if !storage.server_url.is_empty() {
+            &storage.server_url
+        } else {
+            &self.server_url
+        });
+
+        let created_cipher = client
+            .create_cipher(token, &payload)
+            .map_err(|e| format!("Failed to create SSH key on server: {:?}", e))?;
+
+        // Update local storage data.json
+        let mut updated_storage = storage.clone();
+        updated_storage.ciphers.push(created_cipher.clone());
+        let _ = self.storage_mgr.save(&updated_storage);
+
+        // Decrypt the created item into a VaultItem
+        let decrypted_items = decrypt_sync_ciphers_with_context(
+            &[created_cipher],
+            &updated_storage.folders,
+            &updated_storage.organizations,
+            user_key,
+            updated_storage.enc_private_key.as_deref(),
+        );
+
+        let decrypted_item = decrypted_items
+            .into_iter()
+            .next()
+            .ok_or_else(|| "Failed to decrypt newly created cipher item".to_string())?;
+
+        // Update in-memory items if unlocked
+        if let Ok(mut items) = self.decrypted_items.write() {
+            items.push(decrypted_item.clone());
+        }
+
+        crate::log_info!(
+            "omawarden:vault",
+            "Successfully created and stored SSH key '{}' ({})",
+            decrypted_item.name,
+            decrypted_item.id
+        );
+
+        Ok(decrypted_item)
+    }
+
+    pub fn find_ssh_key(&self, id_or_name: &str) -> Option<VaultItem> {
+        let items = self.get_items();
+        let target = id_or_name.trim();
+
+        // 1. Exact ID match
+        if let Some(item) = items
+            .iter()
+            .find(|i| i.type_name == "ssh_key" && i.id == target)
+        {
+            return Some(item.clone());
+        }
+
+        // 2. Exact Name match (case-insensitive)
+        if let Some(item) = items
+            .iter()
+            .find(|i| i.type_name == "ssh_key" && i.name.eq_ignore_ascii_case(target))
+        {
+            return Some(item.clone());
+        }
+
+        // 3. Name contains query (case-insensitive)
+        let lower = target.to_lowercase();
+        if let Some(item) = items
+            .iter()
+            .find(|i| i.type_name == "ssh_key" && i.name.to_lowercase().contains(&lower))
+        {
+            return Some(item.clone());
+        }
+
+        None
+    }
+
     pub fn get_status(&self) -> Value {
         let is_unlocked = self.is_unlocked();
         let fresh_storage = self.storage_mgr.load();
@@ -1160,5 +1295,55 @@ mod tests {
 
         vault_mgr.lock();
         assert!(!vault_mgr.is_unlocked());
+    }
+
+    #[test]
+    fn test_find_ssh_key() {
+        let raw_items = vec![
+            json!({
+                "id": "item-uuid-1",
+                "name": "Production Deploy Key",
+                "type": 5,
+                "sshKey": {
+                    "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA test@host",
+                    "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----",
+                    "keyFingerprint": "SHA256:abc123xyz"
+                }
+            }),
+            json!({
+                "id": "item-uuid-2",
+                "name": "GitHub CI Key",
+                "type": 5,
+                "sshKey": {
+                    "publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAA test@github",
+                    "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\ntest-rsa\n-----END OPENSSH PRIVATE KEY-----",
+                    "keyFingerprint": "SHA256:rsa456"
+                }
+            }),
+        ];
+
+        let vault_mgr = VaultManager::new("https://vault.example.com", None, None);
+        let items = vault_mgr.parse_raw_items(&raw_items);
+        *vault_mgr.decrypted_items.write().unwrap() = items;
+        *vault_mgr.is_unlocked.write().unwrap() = true;
+
+        // Exact ID lookup
+        let found_id = vault_mgr.find_ssh_key("item-uuid-1");
+        assert!(found_id.is_some());
+        assert_eq!(found_id.unwrap().name, "Production Deploy Key");
+
+        // Exact name lookup (case insensitive)
+        let found_name = vault_mgr.find_ssh_key("github ci key");
+        assert!(found_name.is_some());
+        assert_eq!(found_name.unwrap().id, "item-uuid-2");
+
+        // Substring name lookup
+        let found_sub = vault_mgr.find_ssh_key("deploy");
+        assert!(found_sub.is_some());
+        assert_eq!(found_sub.unwrap().id, "item-uuid-1");
+
+        // Not found
+        let not_found = vault_mgr.find_ssh_key("nonexistent-key");
+        assert!(not_found.is_none());
     }
 }


### PR DESCRIPTION
Closes #47, #48, #49, #50, #51, #52, #53, #54, #55, #56

## Summary of Changes

### Core Engine & CLI (omawarden)
- **SSH Key Generation**: Added support for ed25519, RSA (2048/3072/4096), and ECDSA (P-256/P-384/P-521) with passphrase encryption and OpenSSH formatting.
- **SSH Key Import**: Added automated parsing for OpenSSH/PKCS#8/PEM private keys, public keys, and automatic Bitwarden custom field heuristics.
- **SSH Key Export**: Implemented export to files () or stdout with strict / filesystem permissions and existing file overwrite protection.
- **Master Password Masking**: Improved CLI auth unlock to use non-echoing secret prompt without displaying plaintext password.
- **Lock Check & Output Streams**: Enhanced CLI error handling to return early with explicit JSON errors when the vault is locked.

### Frontend UI (QML)
- **SshKeyModal Component**: Modal supporting Create, Import, and Export modes with input validation, directory selection, and conflict warnings.
- **Header & Category Actions**: Added `[+]` (Generate) and `[]` (Import) icon buttons with ToolTips to the SSH Keys category bar.
- **Inspector Export Action**: Added direct Export button in ItemInspector under Private Key card.
- **Shortcuts & Action Palette**:
  - `Ctrl+U`: Copy SSH public key when an SSH key item is selected.
  - `Ctrl+E`: Trigger SSH key export modal.
  - `Ctrl+K`: Action Palette accessible globally with persistent Generate & Import actions.
- **Keyboard & Focus**: Fixed Tab key cycling across inputs inside modal with proper focus restoration upon modal dismissal.

## Verification
- Unit test suite passed (50 tests).
- Formatted and linted via `cargo fmt` and `cargo clippy`.
- Deployed locally and tested across CLI commands and Quickshell UI.