### PR TITLE
fix(auth): downgrade unlock and login failure logs to warn level

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -1810,7 +1810,7 @@ Item {
             root.syncVault(true, true)
           } else {
             root.errorMessage = data.error || "Unlock failed."
-            root.logError("omarchy:auth", root.errorMessage)
+            root.logWarn("omarchy:auth", root.errorMessage)
           }
         } catch (e) {
           root.errorMessage = "Failed to parse unlock response."
@@ -1862,7 +1862,7 @@ Item {
             root.syncVault(true, true)
           } else {
             root.errorMessage = data.error || "Login failed."
-            root.logError("omarchy:auth", root.errorMessage)
+            root.logWarn("omarchy:auth", root.errorMessage)
             var errLower = (data.error || "").toLowerCase()
             if (errLower.indexOf("two-step") !== -1 || errLower.indexOf("two-factor") !== -1 || errLower.indexOf("code") !== -1) {
               root.show2FAField = true

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -164,7 +164,7 @@ impl AuthManager {
             Ok(r) => r,
             Err(e) => {
                 let err_msg = sanitize_auth_error(Some(&e.to_string()));
-                crate::log_error!("omawarden:auth", "Login failed for {}: {}", email, err_msg);
+                crate::log_warn!("omawarden:auth", "Login failed for {}: {}", email, err_msg);
                 return AuthResult {
                     ok: false,
                     status: Some("unauthenticated".to_string()),
@@ -235,7 +235,7 @@ impl AuthManager {
             Ok(r) => r,
             Err(e) => {
                 let err_msg = sanitize_auth_error(Some(&e.to_string()));
-                crate::log_error!("omawarden:auth", "API key login failed: {}", err_msg);
+                crate::log_warn!("omawarden:auth", "API key login failed: {}", err_msg);
                 return AuthResult {
                     ok: false,
                     status: Some("unauthenticated".to_string()),
@@ -286,7 +286,7 @@ impl AuthManager {
         crate::log_info!("omawarden:auth", "Unlocking vault with master password...");
         let storage = self.storage_mgr.load();
         if storage.enc_user_key.is_none() {
-            crate::log_error!("omawarden:auth", "Account is not logged in.");
+            crate::log_warn!("omawarden:auth", "Account is not logged in.");
             return AuthResult {
                 ok: false,
                 status: Some("unauthenticated".to_string()),
@@ -325,7 +325,7 @@ impl AuthManager {
             }
             Err(e) => {
                 let err_msg = sanitize_auth_error(Some(&e.to_string()));
-                crate::log_error!("omawarden:auth", "Unlock failed: {}", err_msg);
+                crate::log_warn!("omawarden:auth", "Unlock failed: {}", err_msg);
                 AuthResult {
                     ok: false,
                     status: Some("locked".to_string()),

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -326,7 +326,7 @@ impl VaultManager {
             .storage_mgr
             .unlock_user_key(password, &fresh_storage)
             .map_err(|e| {
-                crate::log_error!("omawarden:vault", "Unlock user key failed: {:?}", e);
+                crate::log_warn!("omawarden:vault", "Unlock user key failed: {:?}", e);
                 format!("Unlock failed: {:?}", e)
             })?;
 


### PR DESCRIPTION
## Summary of Changes
- Downgraded master password decryption/unlock failure logs from `ERROR` to `WARN` in omawarden backend and QML frontend.
- Downgraded password and API key login failure logs from `ERROR` to `WARN`.
- Preserved `ERROR` level for unexpected JSON parsing exceptions and unrecoverable system failures.