### PR TITLE
fix(auth): synchronize lock state and prevent syncing while locked

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -164,10 +164,6 @@ Item {
     root.refreshConfig()
     root.refreshAuthStatus()
     root.checkUpdates(false)
-    if (root.authState.status === "unlocked") {
-      if (!root.rawVaultItems || root.rawVaultItems.length === 0) root.loadVaultItems()
-      root.syncVault(true, false)
-    }
     Qt.callLater(function() {
       if (root.effectiveView === "search" && searchHeader && searchHeader.searchField) {
         searchHeader.searchField.forceActiveFocus()
@@ -275,6 +271,10 @@ Item {
   }
 
   function syncVault(isBackground, force) {
+    if (root.authState.status !== "unlocked") {
+      root.logWarn("omarchy:vault", "Cannot sync vault: vault is not unlocked.")
+      return
+    }
     if (vaultSyncProc.running) return
     var now = Date.now()
     if (isBackground && !force) {
@@ -1742,9 +1742,15 @@ Item {
           if (data && data.status) {
             var wasNotUnlocked = (root.authState.status !== "unlocked")
             root.authState = data
-            if (data.status === "unlocked" && (wasNotUnlocked || !root.rawVaultItems || root.rawVaultItems.length === 0)) {
-              root.loadVaultItems()
-              root.syncVault(true, false)
+            if (data.status === "unlocked") {
+              if (wasNotUnlocked || !root.rawVaultItems || root.rawVaultItems.length === 0) {
+                root.loadVaultItems()
+                root.syncVault(true, false)
+              }
+            } else {
+              root.rawVaultItems = []
+              root.filteredItems = []
+              root.lastVaultItemsRawText = ""
             }
             Qt.callLater(function() {
               if (root.opened && root.effectiveView === "search" && searchHeader && searchHeader.searchField && !root.showActionPalette) {

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -569,7 +569,11 @@ fn main() -> ExitCode {
                     if !is_unlocked && !vault_mgr.is_unlocked() {
                         println!(
                             "{}",
-                            json!({ "ok": false, "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first." })
+                            serde_json::to_string_pretty(&json!({
+                                "ok": false,
+                                "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first."
+                            }))
+                            .unwrap()
                         );
                         return ExitCode::FAILURE;
                     }
@@ -589,7 +593,11 @@ fn main() -> ExitCode {
                     if !is_unlocked && !vault_mgr.is_unlocked() {
                         println!(
                             "{}",
-                            json!({ "ok": false, "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first." })
+                            serde_json::to_string_pretty(&json!({
+                                "ok": false,
+                                "error": "Vault is locked. Please unlock using 'omawarden auth unlock' first."
+                            }))
+                            .unwrap()
                         );
                         return ExitCode::FAILURE;
                     }
@@ -703,7 +711,11 @@ fn main() -> ExitCode {
                     let keypair = match generate_keypair(algorithm, comment.as_deref()) {
                         Ok(k) => k,
                         Err(e) => {
-                            println!("{}", json!({ "ok": false, "error": e }));
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&json!({ "ok": false, "error": e }))
+                                    .unwrap()
+                            );
                             return ExitCode::FAILURE;
                         }
                     };
@@ -735,13 +747,27 @@ fn main() -> ExitCode {
                                 ) {
                                     Ok(item) => Some(json!(item)),
                                     Err(e) => {
-                                        println!("{}", json!({ "ok": false, "error": e }));
+                                        println!(
+                                            "{}",
+                                            serde_json::to_string_pretty(&json!({
+                                                "ok": false,
+                                                "error": e
+                                            }))
+                                            .unwrap()
+                                        );
                                         return ExitCode::FAILURE;
                                     }
                                 }
                             }
                             Err(e) => {
-                                println!("{}", json!({ "ok": false, "error": e }));
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(&json!({
+                                        "ok": false,
+                                        "error": e
+                                    }))
+                                    .unwrap()
+                                );
                                 return ExitCode::FAILURE;
                             }
                         }
@@ -801,7 +827,14 @@ fn main() -> ExitCode {
                         match std::fs::read_to_string(p) {
                             Ok(c) => c,
                             Err(e) => {
-                                println!("{}", json!({ "ok": false, "error": e.to_string() }));
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(&json!({
+                                        "ok": false,
+                                        "error": e.to_string()
+                                    }))
+                                    .unwrap()
+                                );
                                 return ExitCode::FAILURE;
                             }
                         }
@@ -812,7 +845,11 @@ fn main() -> ExitCode {
                     let mut keypair = match parse_private_key(&raw_priv) {
                         Ok(k) => k,
                         Err(e) => {
-                            println!("{}", json!({ "ok": false, "error": e }));
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&json!({ "ok": false, "error": e }))
+                                    .unwrap()
+                            );
                             return ExitCode::FAILURE;
                         }
                     };
@@ -853,13 +890,27 @@ fn main() -> ExitCode {
                                 ) {
                                     Ok(item) => Some(json!(item)),
                                     Err(e) => {
-                                        println!("{}", json!({ "ok": false, "error": e }));
+                                        println!(
+                                            "{}",
+                                            serde_json::to_string_pretty(&json!({
+                                                "ok": false,
+                                                "error": e
+                                            }))
+                                            .unwrap()
+                                        );
                                         return ExitCode::FAILURE;
                                     }
                                 }
                             }
                             Err(e) => {
-                                println!("{}", json!({ "ok": false, "error": e }));
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(&json!({
+                                        "ok": false,
+                                        "error": e
+                                    }))
+                                    .unwrap()
+                                );
                                 return ExitCode::FAILURE;
                             }
                         }
@@ -925,7 +976,14 @@ fn main() -> ExitCode {
                                 })
                             }
                             Err(e) => {
-                                println!("{}", json!({ "ok": false, "error": e }));
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(&json!({
+                                        "ok": false,
+                                        "error": e
+                                    }))
+                                    .unwrap()
+                                );
                                 return ExitCode::FAILURE;
                             }
                         }
@@ -936,7 +994,11 @@ fn main() -> ExitCode {
                         None => {
                             println!(
                                 "{}",
-                                json!({ "ok": false, "error": format!("SSH key item '{}' not found in vault", query) })
+                                serde_json::to_string_pretty(&json!({
+                                    "ok": false,
+                                    "error": format!("SSH key item '{}' not found in vault", query)
+                                }))
+                                .unwrap()
                             );
                             return ExitCode::FAILURE;
                         }
@@ -947,7 +1009,11 @@ fn main() -> ExitCode {
                         None => {
                             println!(
                                 "{}",
-                                json!({ "ok": false, "error": "Item has no SSH key metadata" })
+                                serde_json::to_string_pretty(&json!({
+                                    "ok": false,
+                                    "error": "Item has no SSH key metadata"
+                                }))
+                                .unwrap()
                             );
                             return ExitCode::FAILURE;
                         }
@@ -1003,7 +1069,14 @@ fn main() -> ExitCode {
                             ExitCode::SUCCESS
                         }
                         Err(e) => {
-                            println!("{}", json!({ "ok": false, "error": e.to_string() }));
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&json!({
+                                    "ok": false,
+                                    "error": e.to_string()
+                                }))
+                                .unwrap()
+                            );
                             ExitCode::FAILURE
                         }
                     }

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -525,19 +525,37 @@ fn main() -> ExitCode {
                 VaultAction::Sync => {
                     omawarden::daemon::ensure_daemon_running();
                     let resp = send_daemon_request(&json!({ "action": "sync" }));
-                    let ok = resp
-                        .as_ref()
-                        .and_then(|v| v.get("ok"))
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or_else(|| vault_mgr.sync().is_ok());
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({ "ok": ok })).unwrap()
-                    );
-                    if ok {
-                        ExitCode::SUCCESS
+                    if let Some(resp_val) = resp {
+                        let ok = resp_val
+                            .get("ok")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        println!("{}", serde_json::to_string_pretty(&resp_val).unwrap());
+                        if ok {
+                            ExitCode::SUCCESS
+                        } else {
+                            ExitCode::FAILURE
+                        }
                     } else {
-                        ExitCode::FAILURE
+                        match vault_mgr.sync() {
+                            Ok(_) => {
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(&json!({ "ok": true })).unwrap()
+                                );
+                                ExitCode::SUCCESS
+                            }
+                            Err(e) => {
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(
+                                        &json!({ "ok": false, "error": e })
+                                    )
+                                    .unwrap()
+                                );
+                                ExitCode::FAILURE
+                            }
+                        }
                     }
                 }
                 VaultAction::List { category } => {

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -361,6 +361,14 @@ impl VaultManager {
     }
 
     pub fn sync(&self) -> Result<usize, String> {
+        if !self.is_unlocked() {
+            crate::log_warn!(
+                "omawarden:vault",
+                "Cannot sync vault: vault is locked. Please unlock first."
+            );
+            return Err("Vault is locked. Please unlock first.".to_string());
+        }
+
         crate::log_info!(
             "omawarden:vault",
             "Starting vault synchronization with server..."
@@ -1295,6 +1303,12 @@ mod tests {
 
         vault_mgr.lock();
         assert!(!vault_mgr.is_unlocked());
+        let sync_err = vault_mgr.sync();
+        assert!(sync_err.is_err());
+        assert_eq!(
+            sync_err.unwrap_err(),
+            "Vault is locked. Please unlock first."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary of Changes
- Enforced strict `is_unlocked()` check before allowing `vault sync` in omawarden engine, returning an error response when the vault is locked.
- Eliminated the UI race condition in `OmarchyBitwarden.qml` by removing synchronous authState checks during `open()`, delegating sync decisions exclusively to authoritative `auth status` probe responses.
- Guaranteed thorough memory cleanup by purging in-memory vault items and search cache whenever a non-unlocked status is reported.
- Standardized multi-line pretty-printed JSON output for all CLI error responses.