### PR TITLE
feat(clipboard): add deep copy command and dependency guards

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -561,15 +561,24 @@ Item {
 
   function copyToClipboard(text, isSensitive, label) {
     if (!text) return
+    if (root.cliHealth && root.cliHealth.clipboard_available === false) {
+      root.errorMessage = "Wayland clipboard utility 'wl-copy' not found. Please install 'wl-clipboard'."
+      root.logWarn("omarchy:clipboard", root.errorMessage)
+      return
+    }
     root.logInfo("omarchy:clipboard", "Copying " + (label || "item") + " to clipboard (sensitive: " + isSensitive + ")")
     var cmd = [root.helperPath, "clipboard", "copy"]
     if (isSensitive) {
       cmd.push("--sensitive")
     }
+    var ttl = (root.config && root.config.clipboard_clear_seconds) || 30
+    if (ttl) {
+      cmd.push("--timeout", String(ttl))
+    }
     clipCopyProc.secret = JSON.stringify({ text: String(text) })
     clipCopyProc.command = cmd
     clipCopyProc.running = true
-    root.statusMessage = "Copied " + (label || "value") + " to clipboard" + (isSensitive ? " (clears in 30s)" : "") + "."
+    root.statusMessage = "Copied " + (label || "value") + " to clipboard" + (isSensitive ? (" (clears in " + ttl + "s)") : "") + "."
   }
 
   function executePrimaryAction(item) {

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -567,7 +567,7 @@ Item {
       return
     }
     root.logInfo("omarchy:clipboard", "Copying " + (label || "item") + " to clipboard (sensitive: " + isSensitive + ")")
-    var cmd = [root.helperPath, "clipboard", "copy"]
+    var cmd = [root.helperPath, "copy", "--stdin"]
     if (isSensitive) {
       cmd.push("--sensitive")
     }

--- a/docs/adr/0003-omawarden-rust-native-helper-and-daemon-architecture.md
+++ b/docs/adr/0003-omawarden-rust-native-helper-and-daemon-architecture.md
@@ -15,7 +15,7 @@ To achieve sub-millisecond query responses (<1ms), deterministic memory zeroizat
    - Embed compile-time Git Commit SHA (`GIT_HASH`) and Build Date (`BUILD_DATE`) into the binary.
 
 2. **Dual-Mode Execution Architecture & Seamless Daemon Auto-Upgrade**:
-   - **CLI Mode**: Standalone subcommands for `config`, `health`, `auth`, `hook`, `vault`, `clipboard`, `totp`, `attachment`.
+   - **CLI Mode**: Standalone subcommands for `config`, `health`, `auth`, `hook`, `vault`, `copy`, `totp`, `attachment`, `ssh-key`.
    - **Resident Daemon Mode**: Stateful background daemon listening on `/run/user/<UID>/omawarden.sock` with `0600` permissions. Holds decrypted vault items in RAM while unlocked, enabling instantaneous sub-millisecond fuzzy search.
    - **Version Handshake & Auto-Upgrade**: The CLI queries the daemon version on every command; if the daemon's commit SHA does not match the active binary, the CLI gracefully requests the outdated daemon to exit via `{"action": "stop"}` and spawns the new version automatically.
 

--- a/omawarden/src/clipboard.rs
+++ b/omawarden/src/clipboard.rs
@@ -21,7 +21,20 @@ impl ClipboardManager {
         Self { wl_copy_path: path }
     }
 
+    pub fn is_available(&self) -> bool {
+        which::which(&self.wl_copy_path).is_ok()
+    }
+
     pub fn copy(&self, text: &str, sensitive: bool, timeout_seconds: i64) -> bool {
+        if !self.is_available() {
+            crate::log_warn!(
+                "omawarden:clipboard",
+                "Wayland clipboard utility '{}' not found in PATH. Please install 'wl-clipboard'.",
+                self.wl_copy_path
+            );
+            return false;
+        }
+
         let mut child = match Command::new(&self.wl_copy_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/omawarden/src/daemon.rs
+++ b/omawarden/src/daemon.rs
@@ -246,6 +246,15 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
                 json!({ "ok": false, "error": "Vault is locked. Please unlock the vault first." })
             }
         }
+        "get_item" => {
+            let query = req.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            let category = req.get("category").and_then(|v| v.as_str());
+            if let Some(item) = state.vault_mgr.find_item(query, category) {
+                json!({ "ok": true, "item": item })
+            } else {
+                json!({ "ok": false, "error": format!("Item '{}' not found in vault", query) })
+            }
+        }
         "get_ssh_key" => {
             let query = req.get("query").and_then(|v| v.as_str()).unwrap_or("");
             if let Some(item) = state.vault_mgr.find_ssh_key(query) {

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -60,7 +60,9 @@ enum Commands {
         #[command(subcommand)]
         action: VaultAction,
     },
-    #[command(about = "Wayland clipboard integration")]
+    #[command(
+        about = "[Deprecated] Low-level Wayland clipboard integration (use 'omawarden copy' instead)"
+    )]
     Clipboard {
         #[command(subcommand)]
         action: ClipboardAction,
@@ -183,7 +185,9 @@ enum VaultAction {
 
 #[derive(Subcommand)]
 enum ClipboardAction {
-    #[command(about = "Copy text to clipboard (text read securely from stdin)")]
+    #[command(
+        about = "[Deprecated] Copy raw text to clipboard from stdin (use 'omawarden copy' instead)"
+    )]
     Copy {
         #[arg(long)]
         sensitive: bool,

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -61,18 +61,17 @@ enum Commands {
         action: VaultAction,
     },
     #[command(
-        about = "[Deprecated] Low-level Wayland clipboard integration (use 'omawarden copy' instead)"
-    )]
-    Clipboard {
-        #[command(subcommand)]
-        action: ClipboardAction,
-    },
-    #[command(
-        about = "Copy a vault item field directly to Wayland clipboard without revealing secrets"
+        about = "Wayland clipboard operations (copy vault item field, pipe stdin, or clear)"
     )]
     Copy {
-        #[arg(index = 1, required = true, help = "Vault item ID or name query")]
-        query: String,
+        #[arg(index = 1, help = "Vault item ID or name query")]
+        query: Option<String>,
+        #[arg(long, help = "Clear Wayland clipboard immediately")]
+        clear: bool,
+        #[arg(long, help = "Read text to copy from standard input")]
+        stdin: bool,
+        #[arg(long, help = "Mark STDIN text as sensitive with auto-clear")]
+        sensitive: bool,
         #[arg(long, help = "Copy password (default for login items)")]
         password: bool,
         #[arg(long, help = "Copy username")]
@@ -181,21 +180,6 @@ enum VaultAction {
         #[arg(long = "filter")]
         category: Option<String>,
     },
-}
-
-#[derive(Subcommand)]
-enum ClipboardAction {
-    #[command(
-        about = "[Deprecated] Copy raw text to clipboard from stdin (use 'omawarden copy' instead)"
-    )]
-    Copy {
-        #[arg(long)]
-        sensitive: bool,
-        #[arg(long)]
-        timeout: Option<i64>,
-    },
-    #[command(about = "Clear clipboard immediately")]
-    Clear,
 }
 
 #[derive(Subcommand)]
@@ -633,40 +617,11 @@ fn main() -> ExitCode {
             }
         }
 
-        Commands::Clipboard { action } => {
-            let clip_mgr = ClipboardManager::default();
-            match action {
-                ClipboardAction::Copy { sensitive, timeout } => {
-                    let text_val = read_clipboard_stdin();
-                    let timeout_val = timeout.unwrap_or(cfg.clipboard_clear_seconds);
-                    let ok = clip_mgr.copy(&text_val, sensitive, timeout_val);
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({ "ok": ok })).unwrap()
-                    );
-                    if ok {
-                        ExitCode::SUCCESS
-                    } else {
-                        ExitCode::FAILURE
-                    }
-                }
-                ClipboardAction::Clear => {
-                    let ok = clip_mgr.clear();
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({ "ok": ok })).unwrap()
-                    );
-                    if ok {
-                        ExitCode::SUCCESS
-                    } else {
-                        ExitCode::FAILURE
-                    }
-                }
-            }
-        }
-
         Commands::Copy {
             query,
+            clear,
+            stdin,
+            sensitive,
             password,
             username,
             totp,
@@ -687,6 +642,54 @@ fn main() -> ExitCode {
                 );
                 return ExitCode::FAILURE;
             }
+
+            if clear {
+                let ok = clip_mgr.clear();
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({ "ok": ok })).unwrap()
+                );
+                return if ok {
+                    ExitCode::SUCCESS
+                } else {
+                    ExitCode::FAILURE
+                };
+            }
+
+            if stdin {
+                let text_val = read_clipboard_stdin();
+                let timeout_val = timeout.unwrap_or(cfg.clipboard_clear_seconds);
+                let ok = clip_mgr.copy(&text_val, sensitive, timeout_val);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "ok": ok,
+                        "copied": "stdin",
+                        "timeout": if sensitive { timeout_val } else { 0 }
+                    }))
+                    .unwrap()
+                );
+                return if ok {
+                    ExitCode::SUCCESS
+                } else {
+                    ExitCode::FAILURE
+                };
+            }
+
+            let query = match query {
+                Some(q) if !q.trim().is_empty() => q,
+                _ => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "ok": false,
+                            "error": "Missing item query or action flag (--clear / --stdin). See 'omawarden copy --help'."
+                        }))
+                        .unwrap()
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
 
             omawarden::daemon::ensure_daemon_running();
             let st = send_daemon_request(&json!({ "action": "status" }));

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -65,6 +65,27 @@ enum Commands {
         #[command(subcommand)]
         action: ClipboardAction,
     },
+    #[command(
+        about = "Copy a vault item field directly to Wayland clipboard without revealing secrets"
+    )]
+    Copy {
+        #[arg(index = 1, required = true, help = "Vault item ID or name query")]
+        query: String,
+        #[arg(long, help = "Copy password (default for login items)")]
+        password: bool,
+        #[arg(long, help = "Copy username")]
+        username: bool,
+        #[arg(long, help = "Copy TOTP code")]
+        totp: bool,
+        #[arg(long, help = "Copy notes")]
+        notes: bool,
+        #[arg(long, help = "Copy SSH private key or card security code")]
+        private_key: bool,
+        #[arg(long, help = "Copy SSH public key or card number")]
+        public_key: bool,
+        #[arg(long, help = "Auto-clear timeout in seconds (default: config value)")]
+        timeout: Option<i64>,
+    },
     #[command(about = "Generate TOTP verification code")]
     Totp {
         #[command(subcommand)]
@@ -637,6 +658,257 @@ fn main() -> ExitCode {
                         ExitCode::FAILURE
                     }
                 }
+            }
+        }
+
+        Commands::Copy {
+            query,
+            password,
+            username,
+            totp,
+            notes,
+            private_key,
+            public_key,
+            timeout,
+        } => {
+            let clip_mgr = ClipboardManager::default();
+            if !clip_mgr.is_available() {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "ok": false,
+                        "error": "Wayland clipboard utility 'wl-copy' not found. Please install 'wl-clipboard'."
+                    }))
+                    .unwrap()
+                );
+                return ExitCode::FAILURE;
+            }
+
+            omawarden::daemon::ensure_daemon_running();
+            let st = send_daemon_request(&json!({ "action": "status" }));
+            let is_unlocked = st
+                .as_ref()
+                .and_then(|v| v.get("is_unlocked"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let vault_mgr = VaultManager::new(&cfg.server_url, None, None);
+            let item: Option<omawarden::vault::VaultItem> = if is_unlocked {
+                let daemon_res = send_daemon_request(&json!({
+                    "action": "get_item",
+                    "query": query
+                }));
+                daemon_res
+                    .filter(|r| r.get("ok").and_then(|v| v.as_bool()) == Some(true))
+                    .and_then(|res| {
+                        res.get("item")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    })
+            } else {
+                match ensure_unlocked_user_key(&vault_mgr, &cfg.server_url) {
+                    Ok(user_key) => {
+                        let storage = vault_mgr.storage_mgr.load();
+                        let items = omawarden::api::decrypt_sync_ciphers_with_context(
+                            &storage.ciphers,
+                            &storage.folders,
+                            &storage.organizations,
+                            &user_key,
+                            storage.enc_private_key.as_deref(),
+                        );
+                        let lower = query.to_lowercase();
+                        items.into_iter().find(|i| {
+                            i.id == query
+                                || i.name.eq_ignore_ascii_case(&query)
+                                || i.name.to_lowercase().contains(&lower)
+                        })
+                    }
+                    Err(e) => {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&json!({ "ok": false, "error": e }))
+                                .unwrap()
+                        );
+                        return ExitCode::FAILURE;
+                    }
+                }
+            };
+
+            let item = match item {
+                Some(i) => i,
+                None => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "ok": false,
+                            "error": format!("Item '{}' not found in vault", query)
+                        }))
+                        .unwrap()
+                    );
+                    return ExitCode::FAILURE;
+                }
+            };
+
+            let (field_name, text_to_copy, is_sensitive) = if username {
+                let u = item
+                    .login
+                    .as_ref()
+                    .and_then(|l| l.get("username"))
+                    .and_then(|v| v.as_str())
+                    .or_else(|| {
+                        item.identity
+                            .as_ref()
+                            .and_then(|id| id.get("username"))
+                            .and_then(|v| v.as_str())
+                    })
+                    .or_else(|| {
+                        item.identity
+                            .as_ref()
+                            .and_then(|id| id.get("email"))
+                            .and_then(|v| v.as_str())
+                    })
+                    .unwrap_or_default()
+                    .to_string();
+                ("username", u, false)
+            } else if totp {
+                let seed = item
+                    .login
+                    .as_ref()
+                    .and_then(|l| l.get("totp"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                if let Some(t_res) = omawarden::totp::generate_totp(seed, None, 6, 30) {
+                    ("totp", t_res.code, true)
+                } else {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&json!({
+                            "ok": false,
+                            "error": "Item has no valid TOTP configuration"
+                        }))
+                        .unwrap()
+                    );
+                    return ExitCode::FAILURE;
+                }
+            } else if notes {
+                ("notes", item.notes.clone().unwrap_or_default(), false)
+            } else if public_key {
+                let pk = item
+                    .ssh_key
+                    .as_ref()
+                    .and_then(|s| s.public_key.as_deref())
+                    .or_else(|| {
+                        item.card
+                            .as_ref()
+                            .and_then(|c| c.get("number"))
+                            .and_then(|v| v.as_str())
+                    })
+                    .unwrap_or_default()
+                    .to_string();
+                ("public_key", pk, false)
+            } else if private_key {
+                let privk = item
+                    .ssh_key
+                    .as_ref()
+                    .and_then(|s| s.private_key.as_deref())
+                    .or_else(|| {
+                        item.card
+                            .as_ref()
+                            .and_then(|c| c.get("code"))
+                            .and_then(|v| v.as_str())
+                    })
+                    .unwrap_or_default()
+                    .to_string();
+                ("private_key", privk, true)
+            } else if password {
+                let pwd = item
+                    .login
+                    .as_ref()
+                    .and_then(|l| l.get("password"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                ("password", pwd, true)
+            } else {
+                match item.type_name.as_str() {
+                    "login" => {
+                        let pwd = item
+                            .login
+                            .as_ref()
+                            .and_then(|l| l.get("password"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        ("password", pwd, true)
+                    }
+                    "ssh_key" => {
+                        let privk = item
+                            .ssh_key
+                            .as_ref()
+                            .and_then(|s| s.private_key.as_deref())
+                            .unwrap_or_default()
+                            .to_string();
+                        ("private_key", privk, true)
+                    }
+                    "card" => {
+                        let num = item
+                            .card
+                            .as_ref()
+                            .and_then(|c| c.get("number"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        ("card_number", num, true)
+                    }
+                    "note" => ("notes", item.notes.clone().unwrap_or_default(), false),
+                    _ => {
+                        let val = item
+                            .login
+                            .as_ref()
+                            .and_then(|l| l.get("password"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        ("password", val, true)
+                    }
+                }
+            };
+
+            if text_to_copy.is_empty() {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "ok": false,
+                        "error": format!("Field '{}' is empty for item '{}'", field_name, item.name)
+                    }))
+                    .unwrap()
+                );
+                return ExitCode::FAILURE;
+            }
+
+            let timeout_val = timeout.unwrap_or(cfg.clipboard_clear_seconds);
+            let ok = clip_mgr.copy(&text_to_copy, is_sensitive, timeout_val);
+            if ok {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "ok": true,
+                        "name": item.name,
+                        "copied": field_name,
+                        "timeout": if is_sensitive { timeout_val } else { 0 }
+                    }))
+                    .unwrap()
+                );
+                ExitCode::SUCCESS
+            } else {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "ok": false,
+                        "error": "Failed to copy content to clipboard"
+                    }))
+                    .unwrap()
+                );
+                ExitCode::FAILURE
             }
         }
 

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -717,36 +717,57 @@ impl VaultManager {
         Ok(decrypted_item)
     }
 
-    pub fn find_ssh_key(&self, id_or_name: &str) -> Option<VaultItem> {
+    pub fn find_item(&self, query: &str, category: Option<&str>) -> Option<VaultItem> {
         let items = self.get_items();
-        let target = id_or_name.trim();
+        let target = query.trim();
+        if target.is_empty() {
+            return None;
+        }
+
+        let cat_filter = category.map(|c| c.to_lowercase());
 
         // 1. Exact ID match
-        if let Some(item) = items
-            .iter()
-            .find(|i| i.type_name == "ssh_key" && i.id == target)
-        {
+        if let Some(item) = items.iter().find(|i| {
+            if let Some(ref c) = cat_filter {
+                if &i.type_name != c {
+                    return false;
+                }
+            }
+            i.id == target
+        }) {
             return Some(item.clone());
         }
 
         // 2. Exact Name match (case-insensitive)
-        if let Some(item) = items
-            .iter()
-            .find(|i| i.type_name == "ssh_key" && i.name.eq_ignore_ascii_case(target))
-        {
+        if let Some(item) = items.iter().find(|i| {
+            if let Some(ref c) = cat_filter {
+                if &i.type_name != c {
+                    return false;
+                }
+            }
+            i.name.eq_ignore_ascii_case(target)
+        }) {
             return Some(item.clone());
         }
 
         // 3. Name contains query (case-insensitive)
         let lower = target.to_lowercase();
-        if let Some(item) = items
-            .iter()
-            .find(|i| i.type_name == "ssh_key" && i.name.to_lowercase().contains(&lower))
-        {
+        if let Some(item) = items.iter().find(|i| {
+            if let Some(ref c) = cat_filter {
+                if &i.type_name != c {
+                    return false;
+                }
+            }
+            i.name.to_lowercase().contains(&lower)
+        }) {
             return Some(item.clone());
         }
 
         None
+    }
+
+    pub fn find_ssh_key(&self, id_or_name: &str) -> Option<VaultItem> {
+        self.find_item(id_or_name, Some("ssh_key"))
     }
 
     pub fn get_status(&self) -> Value {
@@ -1359,5 +1380,16 @@ mod tests {
         // Not found
         let not_found = vault_mgr.find_ssh_key("nonexistent-key");
         assert!(not_found.is_none());
+
+        // Generic find_item test
+        let found_gen = vault_mgr.find_item("Deploy Key", None);
+        assert!(found_gen.is_some());
+        assert_eq!(found_gen.unwrap().id, "item-uuid-1");
+
+        let found_cat = vault_mgr.find_item("Deploy Key", Some("ssh_key"));
+        assert!(found_cat.is_some());
+
+        let not_found_cat = vault_mgr.find_item("Deploy Key", Some("login"));
+        assert!(not_found_cat.is_none());
     }
 }


### PR DESCRIPTION
## Summary of Changes

- **Unified `omawarden copy` Command**:
  - Implemented deep in-memory field copy (`omawarden copy <QUERY> [--password|--totp|--username|...]`) without writing sensitive secrets to stdout.
  - Unified arbitrary text streaming via `--stdin` and immediate clearing via `--clear`.
  - Removed deprecated low-level `omawarden clipboard` subcommand to simplify CLI top-level commands.
- **Daemon & Vault Lookup Support**:
  - Added `get_item` action handler to omawarden daemon for fast in-memory item resolution by ID/name.
- **Wayland Clipboard Guard**:
  - Added pre-flight check in `ClipboardManager::is_available()` and QML to warn gracefully if `wl-clipboard` is missing.
- **Documentation**:
  - Updated ADR 0003 CLI subcommand list.

## Testing & Quality Assurance
- Passed `cargo fmt --check`
- Passed `cargo clippy --all-targets --all-features -- -D warnings`
- Passed all 50 unit tests (`XDG_RUNTIME_DIR=/tmp cargo test`)