### PR TITLE
refactor(ui): streamline engine status badges and add in-app release notes modal

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -63,6 +63,9 @@ Item {
   property string latestVersion: ""
   property bool isCheckingUpdate: false
   property string updateCheckStatus: ""
+  property string latestReleaseNotes: ""
+  property string latestReleaseUrl: ""
+  property string latestReleaseTitle: ""
   readonly property bool updateAvailable: {
     if (!latestVersion) return false
     var currentVer = (cliHealth && cliHealth.version) ? cliHealth.version : ""
@@ -1183,6 +1186,9 @@ Item {
         sequence: "Ctrl+,"
         enabled: root.opened && !root.showSshKeyModal
         onActivated: {
+          if (settingsView.showReleaseNotes) {
+            settingsView.showReleaseNotes = false
+          }
           root.currentView = (root.effectiveView === "settings") ? "auto" : "settings"
         }
       }
@@ -1197,6 +1203,8 @@ Item {
             root.showActionPalette = false
           } else if (root.activeAttachmentPreview !== null) {
             root.activeAttachmentPreview = null
+          } else if (settingsView.visible && settingsView.showReleaseNotes) {
+            settingsView.showReleaseNotes = false
           } else if (root.effectiveView === "settings") {
             root.currentView = "auto"
           } else {
@@ -1226,6 +1234,8 @@ Item {
         if (event.key === Qt.Key_Escape) {
           if (root.activeAttachmentPreview !== null) {
             root.activeAttachmentPreview = null
+          } else if (settingsView.visible && settingsView.showReleaseNotes) {
+            settingsView.showReleaseNotes = false
           } else if (root.effectiveView === "settings") {
             root.currentView = "auto"
           } else {
@@ -1446,6 +1456,7 @@ Item {
 
           // Mode C: Settings View
           SettingsModal {
+            id: settingsView
             anchors.fill: parent
             visible: root.effectiveView === "settings"
             config: root.config
@@ -1455,6 +1466,9 @@ Item {
             isBusy: root.isBusy
             updateAvailable: root.updateAvailable
             latestVersion: root.latestVersion
+            latestReleaseNotes: root.latestReleaseNotes
+            latestReleaseUrl: root.latestReleaseUrl
+            latestReleaseTitle: root.latestReleaseTitle
             isCheckingUpdate: root.isCheckingUpdate
             updateCheckStatus: root.updateCheckStatus
             fontFamily: root.fontFamily
@@ -1496,6 +1510,9 @@ Item {
           onSyncTriggered: { root.syncVault(false, true) }
           onLockTriggered: { root.doLock() }
           onSettingsTriggered: {
+            if (settingsView.showReleaseNotes) {
+              settingsView.showReleaseNotes = false
+            }
             root.currentView = (root.effectiveView === "settings") ? "auto" : "settings"
           }
           onDownloadCliTriggered: { root.downloadCli() }
@@ -1773,6 +1790,9 @@ Item {
             var rawTag = data.tag
             var cleanTag = String(rawTag).replace(/^omawarden-|^v/i, "").trim()
             root.latestVersion = cleanTag
+            root.latestReleaseNotes = data.body || ""
+            root.latestReleaseUrl = data.url || (rawTag ? ("https://github.com/icyleaf/omarchy-bitwarden/releases/tag/" + rawTag) : "")
+            root.latestReleaseTitle = data.name || (cleanTag ? ("omawarden v" + cleanTag) : "")
             var currentVer = (root.cliHealth && root.cliHealth.version) ? root.cliHealth.version : ""
             if (currentVer && root.compareSemVer(cleanTag, currentVer) > 0) {
               root.updateCheckStatus = "Update available: v" + cleanTag

--- a/components/ReleaseNotesModal.qml
+++ b/components/ReleaseNotesModal.qml
@@ -1,0 +1,328 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Rectangle {
+  id: releaseModalRoot
+
+  property bool active: false
+  property string version: ""
+  property string releaseTitle: ""
+  property string releaseNotes: ""
+  property string releaseUrl: ""
+  property bool isDownloadingCli: false
+  property color foreground: "#ffffff"
+  property color accent: "#3b82f6"
+  property color borderColor: Qt.rgba(1, 1, 1, 0.1)
+  property string fontFamily: ""
+
+  signal closeRequested()
+  signal updateRequested()
+
+  anchors.fill: parent
+  color: Qt.rgba(0, 0, 0, 0.6)
+  visible: active
+  z: 100
+
+  Keys.onEscapePressed: releaseModalRoot.closeRequested()
+
+  function escapeHtml(text) {
+    if (!text) return ""
+    return String(text)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+  }
+
+  function formatInlineMarkdown(text) {
+    if (!text) return ""
+    var escaped = escapeHtml(text)
+
+    // Markdown link: [Title](url)
+    escaped = escaped.replace(/\[([^\]]+)\]\((https?:\/\/[^\s\)]+)\)/g, function(match, title, url) {
+      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + title + "</a>"
+    })
+
+    // GitHub PR link: https://github.com/.../pull/123 -> #123
+    escaped = escaped.replace(/(https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/pull\/(\d+))/g, function(match, url, prNum) {
+      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>#" + prNum + "</a>"
+    })
+
+    // GitHub Commit link: https://github.com/.../commit/abcdef123 -> abcdef1
+    escaped = escaped.replace(/(https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/commit\/([a-f0-9]{7,40}))/g, function(match, url, sha) {
+      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline; font-family: monospace;'>" + sha.substring(0, 7) + "</a>"
+    })
+
+    // GitHub Compare link: https://github.com/.../compare/v1...v2 -> v1...v2
+    escaped = escaped.replace(/(https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/compare\/([^\s\<\>\)]+))/g, function(match, url, range) {
+      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + range + "</a>"
+    })
+
+    // Other plain URLs
+    escaped = escaped.replace(/(^|[\s\(])(https?:\/\/[^\s<\)]+)/g, function(match, prefix, url) {
+      return prefix + "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + url + "</a>"
+    })
+
+    // Bold: **text**
+    escaped = escaped.replace(/\*\*([^*]+)\*\*/g, "<b style='color: #ffffff;'>$1</b>")
+
+    // Inline code: `code`
+    escaped = escaped.replace(/`([^`]+)`/g, "<span style='background-color: rgba(255,255,255,0.12); color: #f1f5f9; font-family: monospace; font-size: 10px; padding: 1px 3px;'>$1</span>")
+
+    // GitHub user/bot mentions: @user
+    escaped = escaped.replace(/@([a-zA-Z0-9_-]+(?:\[bot\])?)/g, "<span style='color: #93c5fd; font-weight: 500;'>@$1</span>")
+
+    return escaped
+  }
+
+  function renderMarkdown(raw) {
+    if (!raw || !raw.trim()) {
+      return "<div style='color: #94a3b8; font-size: 11px;'>No release notes found for this version.</div>"
+    }
+
+    var lines = raw.split("\n")
+    var html = ""
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i].trim()
+      if (!line) continue
+
+      // Headers: #, ##, ###, ####
+      if (line.match(/^#{1,4}\s+/)) {
+        var hText = line.replace(/^#{1,4}\s+/, "")
+        html += "<div style='font-size: 13px; font-weight: bold; color: #ffffff; margin-top: 8px; margin-bottom: 12px;'>" + escapeHtml(hText) + "</div>"
+        continue
+      }
+
+      // Unordered list items: * or -
+      if (line.match(/^[\*\-]\s+/)) {
+        var itemText = line.replace(/^[\*\-]\s+/, "")
+        html += "<div style='margin-top: 3px; margin-bottom: 4px; color: #cbd5e1; font-size: 11px; line-height: 1.4;'><span style='color: #60a5fa;'>• </span>" + formatInlineMarkdown(itemText) + "</div>"
+        continue
+      }
+
+      // Ordered list items: 1. or 1)
+      var numMatch = line.match(/^(\d+[\.\)])\s+/)
+      if (numMatch) {
+        var numPrefix = numMatch[1]
+        var numItemText = line.substring(numPrefix.length).trim()
+        html += "<div style='margin-top: 3px; margin-bottom: 4px; color: #cbd5e1; font-size: 11px; line-height: 1.4;'><span style='color: #60a5fa; font-weight: 600;'>" + numPrefix + " </span>" + formatInlineMarkdown(numItemText) + "</div>"
+        continue
+      }
+
+      // Normal paragraph
+      html += "<div style='margin-top: 12px; margin-bottom: 4px; color: #cbd5e1; font-size: 11px; line-height: 1.4;'>" + formatInlineMarkdown(line) + "</div>"
+    }
+
+    return html
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: releaseModalRoot.closeRequested()
+  }
+
+  Rectangle {
+    id: modalCard
+    anchors.centerIn: parent
+    width: Math.min(parent.width - 48, 560)
+    height: Math.min(parent.height - 48, 460)
+    radius: 8
+    color: Qt.rgba(0.12, 0.14, 0.18, 0.98)
+    border.color: releaseModalRoot.borderColor
+    border.width: 1
+
+    MouseArea {
+      anchors.fill: parent
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 16
+      spacing: 12
+
+      // Modal Header
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Text {
+          text: "\uf15c"
+          font.family: releaseModalRoot.fontFamily
+          font.pixelSize: 14
+          color: releaseModalRoot.accent
+        }
+
+        Text {
+          text: releaseModalRoot.releaseTitle ? ("Release: " + releaseModalRoot.releaseTitle) : ("Release Notes (v" + releaseModalRoot.version + ")")
+          color: releaseModalRoot.foreground
+          font.pixelSize: 13
+          font.weight: Font.DemiBold
+          elide: Text.ElideRight
+          Layout.fillWidth: true
+        }
+
+        Rectangle {
+          implicitWidth: 22
+          implicitHeight: 22
+          radius: 4
+          color: closeMouse.containsMouse ? Qt.rgba(1, 1, 1, 0.1) : "transparent"
+
+          Text {
+            anchors.centerIn: parent
+            text: "\uf00d"
+            font.family: releaseModalRoot.fontFamily
+            font.pixelSize: 12
+            color: releaseModalRoot.foreground
+          }
+
+          MouseArea {
+            id: closeMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: releaseModalRoot.closeRequested()
+          }
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: releaseModalRoot.borderColor
+      }
+
+      // Scrollable Release Notes Content
+      ScrollView {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        clip: true
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
+        TextEdit {
+          id: notesTextEdit
+          width: modalCard.width - 32
+          text: releaseModalRoot.renderMarkdown(releaseModalRoot.releaseNotes)
+          textFormat: Text.RichText
+          color: releaseModalRoot.foreground
+          font.pixelSize: 11
+          font.family: "sans-serif"
+          wrapMode: Text.Wrap
+          readOnly: true
+          selectByMouse: true
+          cursorVisible: false
+          selectionColor: releaseModalRoot.accent
+          onLinkActivated: function(link) {
+            Qt.openUrlExternally(link)
+          }
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: releaseModalRoot.borderColor
+      }
+
+      // Footer Actions
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        // Open in Browser Button
+        Rectangle {
+          visible: Boolean(releaseModalRoot.releaseUrl)
+          implicitHeight: 26
+          implicitWidth: extBtnRow.implicitWidth + 14
+          radius: 4
+          color: extMouse.containsMouse ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.2)
+          border.color: releaseModalRoot.borderColor
+          border.width: 1
+
+          RowLayout {
+            id: extBtnRow
+            anchors.centerIn: parent
+            spacing: 5
+
+            Text {
+              text: "\uf08e"
+              font.family: releaseModalRoot.fontFamily
+              color: Qt.darker(releaseModalRoot.foreground, 1.4)
+              font.pixelSize: 10
+            }
+
+            Text {
+              text: "Open on GitHub"
+              color: releaseModalRoot.foreground
+              font.pixelSize: 10
+              font.weight: Font.Medium
+            }
+          }
+
+          MouseArea {
+            id: extMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+              if (releaseModalRoot.releaseUrl) {
+                Qt.openUrlExternally(releaseModalRoot.releaseUrl)
+              }
+            }
+          }
+        }
+
+        Item { Layout.fillWidth: true }
+
+        // Close Button
+        Rectangle {
+          implicitHeight: 26
+          implicitWidth: closeBtnText.implicitWidth + 16
+          radius: 4
+          color: Qt.rgba(1, 1, 1, 0.08)
+          border.color: releaseModalRoot.borderColor
+          border.width: 1
+
+          Text {
+            id: closeBtnText
+            anchors.centerIn: parent
+            text: "Close"
+            color: releaseModalRoot.foreground
+            font.pixelSize: 10
+            font.weight: Font.Medium
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: releaseModalRoot.closeRequested()
+          }
+        }
+
+        // Update Engine Button
+        Rectangle {
+          implicitHeight: 26
+          implicitWidth: upBtnText.implicitWidth + 16
+          radius: 4
+          color: "#22c55e"
+
+          Text {
+            id: upBtnText
+            anchors.centerIn: parent
+            text: releaseModalRoot.isDownloadingCli ? "Updating..." : ("Update to v" + releaseModalRoot.version)
+            color: "#ffffff"
+            font.pixelSize: 10
+            font.weight: Font.Medium
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            enabled: !releaseModalRoot.isDownloadingCli
+            onClicked: releaseModalRoot.updateRequested()
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -12,6 +12,10 @@ Item {
   property bool isBusy: false
   property bool updateAvailable: false
   property string latestVersion: ""
+  property string latestReleaseNotes: ""
+  property string latestReleaseUrl: ""
+  property string latestReleaseTitle: ""
+  property bool showReleaseNotes: false
   property bool isCheckingUpdate: false
   property string updateCheckStatus: ""
   property bool justCheckedLatest: false
@@ -30,6 +34,12 @@ Item {
     if (!isCheckingUpdate && !updateAvailable) {
       justCheckedLatest = true
       latestTimer.restart()
+    }
+  }
+
+  onVisibleChanged: {
+    if (!visible) {
+      showReleaseNotes = false
     }
   }
 
@@ -269,14 +279,18 @@ Item {
             Layout.fillWidth: true
             spacing: 6
 
-            // CLI Engine Badge
+            // Unified Engine Badge & Update Action
             Rectangle {
+              id: engineBadgeBox
               implicitHeight: 24
               implicitWidth: cliBadgeRow.implicitWidth + 14
               radius: 4
-              color: Qt.rgba(0, 0, 0, 0.2)
+              color: engineMouse.containsMouse ? Qt.rgba(0, 0, 0, 0.4) : Qt.rgba(0, 0, 0, 0.2)
               border.color: settingsRoot.borderColor
               border.width: 1
+
+              readonly property bool isInstalled: Boolean(settingsRoot.cliHealth.installed)
+              readonly property bool hasUpdate: isInstalled && settingsRoot.updateAvailable && Boolean(settingsRoot.latestVersion)
 
               RowLayout {
                 id: cliBadgeRow
@@ -287,68 +301,74 @@ Item {
                   implicitWidth: 6
                   implicitHeight: 6
                   radius: 3
-                  color: settingsRoot.cliHealth.installed ? "#4ade80" : "#f87171"
+                  color: engineBadgeBox.isInstalled ? "#4ade80" : "#f87171"
                 }
 
                 Text {
-                  text: "Engine: " + (settingsRoot.cliHealth.version || (settingsRoot.cliHealth.installed ? "Ready" : "Missing"))
+                  text: "Engine: " + (settingsRoot.cliHealth.version || (engineBadgeBox.isInstalled ? "Ready" : "Missing"))
                   color: settingsRoot.foreground
                   font.pixelSize: 10
                 }
-              }
-            }
 
-            // Update Engine Button (visible when installed and update is available)
-            Rectangle {
-              visible: settingsRoot.cliHealth.installed && settingsRoot.updateAvailable && Boolean(settingsRoot.latestVersion)
-              implicitHeight: 24
-              implicitWidth: upBtnRow.implicitWidth + 14
-              radius: 4
-              color: "#22c55e"
+                // Inline update tag when update is available
+                Rectangle {
+                  visible: engineBadgeBox.hasUpdate
+                  implicitHeight: 16
+                  implicitWidth: updateTagRow.implicitWidth + 8
+                  radius: 3
+                  color: Qt.rgba(0.2, 0.8, 0.4, 0.15)
 
-              RowLayout {
-                id: upBtnRow
-                anchors.centerIn: parent
-                spacing: 4
+                  RowLayout {
+                    id: updateTagRow
+                    anchors.centerIn: parent
+                    spacing: 3
+                    Text {
+                      text: "\uf062"
+                      font.family: settingsRoot.fontFamily
+                      color: "#ffffff"
+                      font.pixelSize: 8
+                    }
+                    Text {
+                      text: "Update to v" + settingsRoot.latestVersion
+                      color: "#ffffff"
+                      font.pixelSize: 9
+                      font.weight: Font.DemiBold
+                    }
+                  }
+                }
 
-                Text {
-                  id: upBtnText
-                  text: settingsRoot.isDownloadingCli ? "Updating..." : ("Update to v" + settingsRoot.latestVersion)
-                  color: "#ffffff"
-                  font.pixelSize: 10
-                  font.weight: Font.Medium
+                // Download pill when missing
+                Rectangle {
+                  visible: !engineBadgeBox.isInstalled
+                  implicitHeight: 16
+                  implicitWidth: dlTagText.implicitWidth + 8
+                  radius: 3
+                  color: settingsRoot.accent
+
+                  Text {
+                    id: dlTagText
+                    anchors.centerIn: parent
+                    text: settingsRoot.isDownloadingCli ? "Downloading..." : "Download"
+                    color: "#ffffff"
+                    font.pixelSize: 9
+                    font.weight: Font.Medium
+                  }
                 }
               }
 
               MouseArea {
+                id: engineMouse
                 anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
+                hoverEnabled: engineBadgeBox.hasUpdate || !engineBadgeBox.isInstalled
+                cursorShape: (engineBadgeBox.hasUpdate || !engineBadgeBox.isInstalled) ? Qt.PointingHandCursor : Qt.ArrowCursor
                 enabled: !settingsRoot.isDownloadingCli
-                onClicked: settingsRoot.downloadCliRequested()
-              }
-            }
-
-            // Download Engine Button (visible when not installed)
-            Rectangle {
-              visible: !settingsRoot.cliHealth.installed
-              implicitHeight: 24
-              implicitWidth: dlBtnText.implicitWidth + 12
-              radius: 4
-              color: settingsRoot.accent
-
-              Text {
-                id: dlBtnText
-                anchors.centerIn: parent
-                text: settingsRoot.isDownloadingCli ? "Downloading..." : "Download Engine"
-                color: "#ffffff"
-                font.pixelSize: 10
-                font.weight: Font.Medium
-              }
-              MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                enabled: !settingsRoot.isDownloadingCli
-                onClicked: settingsRoot.downloadCliRequested()
+                onClicked: {
+                  if (engineBadgeBox.hasUpdate) {
+                    settingsRoot.showReleaseNotes = true
+                  } else if (!engineBadgeBox.isInstalled) {
+                    settingsRoot.downloadCliRequested()
+                  }
+                }
               }
             }
 
@@ -935,6 +955,25 @@ Item {
           }
         }
       }
+    }
+  }
+
+  // Release Notes Modal
+  ReleaseNotesModal {
+    active: settingsRoot.showReleaseNotes
+    version: settingsRoot.latestVersion
+    releaseTitle: settingsRoot.latestReleaseTitle
+    releaseNotes: settingsRoot.latestReleaseNotes
+    releaseUrl: settingsRoot.latestReleaseUrl
+    isDownloadingCli: settingsRoot.isDownloadingCli
+    foreground: settingsRoot.foreground
+    accent: settingsRoot.accent
+    borderColor: settingsRoot.borderColor
+    fontFamily: settingsRoot.fontFamily
+    onCloseRequested: settingsRoot.showReleaseNotes = false
+    onUpdateRequested: {
+      settingsRoot.showReleaseNotes = false
+      settingsRoot.downloadCliRequested()
     }
   }
 }

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -14,10 +14,24 @@ Item {
   property string latestVersion: ""
   property bool isCheckingUpdate: false
   property string updateCheckStatus: ""
+  property bool justCheckedLatest: false
   property color foreground: "#ffffff"
   property color accent: "#3b82f6"
   property color borderColor: Qt.rgba(1, 1, 1, 0.1)
   property string fontFamily: ""
+
+  Timer {
+    id: latestTimer
+    interval: 2500
+    onTriggered: settingsRoot.justCheckedLatest = false
+  }
+
+  onIsCheckingUpdateChanged: {
+    if (!isCheckingUpdate && !updateAvailable) {
+      justCheckedLatest = true
+      latestTimer.restart()
+    }
+  }
 
   property string activeTab: "general" // "general" | "logs"
   property string logFilter: "all" // "all" | "error" | "warn"
@@ -206,7 +220,7 @@ Item {
         // 1. Engine Diagnostic Health Badges
         ColumnLayout {
           Layout.fillWidth: true
-          spacing: 6
+          spacing: 8
 
           RowLayout {
             Layout.fillWidth: true
@@ -225,8 +239,8 @@ Item {
               Text {
                 id: chkUpText
                 anchors.centerIn: parent
-                text: settingsRoot.isCheckingUpdate ? "Checking..." : "Check Update"
-                color: settingsRoot.accent
+                text: settingsRoot.isCheckingUpdate ? "Checking..." : (settingsRoot.justCheckedLatest ? "Latest" : "Check Update")
+                color: settingsRoot.justCheckedLatest ? "#4ade80" : settingsRoot.accent
                 font.pixelSize: 10
               }
               MouseArea {
@@ -251,79 +265,6 @@ Item {
             }
           }
 
-          // Update Available Banner & Action
-          Rectangle {
-            visible: settingsRoot.updateAvailable && Boolean(settingsRoot.latestVersion)
-            Layout.fillWidth: true
-            implicitHeight: updateRow.implicitHeight + 16
-            radius: 5
-            color: Qt.rgba(0.2, 0.8, 0.4, 0.12)
-            border.color: "#4ade80"
-            border.width: 1
-
-            RowLayout {
-              id: updateRow
-              anchors.fill: parent
-              anchors.margins: 8
-              spacing: 8
-
-              Text {
-                text: "\uf005"
-                font.family: settingsRoot.fontFamily
-                color: "#4ade80"
-                font.pixelSize: 14
-              }
-
-              ColumnLayout {
-                Layout.fillWidth: true
-                spacing: 2
-                Text {
-                  text: "New omawarden engine available: v" + settingsRoot.latestVersion
-                  color: "#4ade80"
-                  font.pixelSize: 11
-                  font.weight: Font.DemiBold
-                }
-                Text {
-                  text: "Current installed version: " + (settingsRoot.cliHealth.version || "unknown")
-                  color: Qt.darker(settingsRoot.foreground, 1.6)
-                  font.pixelSize: 10
-                }
-              }
-
-              Rectangle {
-                implicitHeight: 26
-                implicitWidth: upBtnText.implicitWidth + 14
-                radius: 4
-                color: "#22c55e"
-
-                Text {
-                  id: upBtnText
-                  anchors.centerIn: parent
-                  text: settingsRoot.isDownloadingCli ? "Updating..." : ("Update to v" + settingsRoot.latestVersion)
-                  color: "#ffffff"
-                  font.pixelSize: 10
-                  font.weight: Font.Medium
-                }
-
-                MouseArea {
-                  anchors.fill: parent
-                  cursorShape: Qt.PointingHandCursor
-                  enabled: !settingsRoot.isDownloadingCli
-                  onClicked: settingsRoot.downloadCliRequested()
-                }
-              }
-            }
-          }
-
-          // Update Check Status Feedback
-          Text {
-            visible: !settingsRoot.updateAvailable && Boolean(settingsRoot.updateCheckStatus)
-            text: settingsRoot.updateCheckStatus
-            color: Qt.darker(settingsRoot.foreground, 1.6)
-            font.pixelSize: 10
-            font.weight: Font.Medium
-          }
-
           RowLayout {
             Layout.fillWidth: true
             spacing: 6
@@ -331,27 +272,63 @@ Item {
             // CLI Engine Badge
             Rectangle {
               implicitHeight: 24
-              implicitWidth: cliBadgeRow.implicitWidth + 10
+              implicitWidth: cliBadgeRow.implicitWidth + 14
               radius: 4
-              color: settingsRoot.cliHealth.installed ? Qt.rgba(0.2, 0.8, 0.4, 0.15) : Qt.rgba(0.9, 0.2, 0.2, 0.15)
-              border.color: settingsRoot.cliHealth.installed ? "#4ade80" : "#f87171"
+              color: Qt.rgba(0, 0, 0, 0.2)
+              border.color: settingsRoot.borderColor
               border.width: 1
 
               RowLayout {
                 id: cliBadgeRow
                 anchors.centerIn: parent
-                spacing: 4
-                Text {
-                  text: settingsRoot.cliHealth.installed ? "\uf00c" : "\uf00d"
-                  font.family: settingsRoot.fontFamily
+                spacing: 6
+
+                Rectangle {
+                  implicitWidth: 6
+                  implicitHeight: 6
+                  radius: 3
                   color: settingsRoot.cliHealth.installed ? "#4ade80" : "#f87171"
+                }
+
+                Text {
+                  text: "Engine: " + (settingsRoot.cliHealth.version || (settingsRoot.cliHealth.installed ? "Ready" : "Missing"))
+                  color: settingsRoot.foreground
                   font.pixelSize: 10
                 }
-                Text { text: "Engine: " + (settingsRoot.cliHealth.version || (settingsRoot.cliHealth.installed ? "Ready" : "Missing")); color: settingsRoot.foreground; font.pixelSize: 10 }
               }
             }
 
-            // Download Engine Button
+            // Update Engine Button (visible when installed and update is available)
+            Rectangle {
+              visible: settingsRoot.cliHealth.installed && settingsRoot.updateAvailable && Boolean(settingsRoot.latestVersion)
+              implicitHeight: 24
+              implicitWidth: upBtnRow.implicitWidth + 14
+              radius: 4
+              color: "#22c55e"
+
+              RowLayout {
+                id: upBtnRow
+                anchors.centerIn: parent
+                spacing: 4
+
+                Text {
+                  id: upBtnText
+                  text: settingsRoot.isDownloadingCli ? "Updating..." : ("Update to v" + settingsRoot.latestVersion)
+                  color: "#ffffff"
+                  font.pixelSize: 10
+                  font.weight: Font.Medium
+                }
+              }
+
+              MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                enabled: !settingsRoot.isDownloadingCli
+                onClicked: settingsRoot.downloadCliRequested()
+              }
+            }
+
+            // Download Engine Button (visible when not installed)
             Rectangle {
               visible: !settingsRoot.cliHealth.installed
               implicitHeight: 24
@@ -378,46 +355,58 @@ Item {
             // Keyring Badge
             Rectangle {
               implicitHeight: 24
-              implicitWidth: krBadgeRow.implicitWidth + 10
+              implicitWidth: krBadgeRow.implicitWidth + 14
               radius: 4
-              color: settingsRoot.cliHealth.keyring_available ? Qt.rgba(0.2, 0.8, 0.4, 0.15) : Qt.rgba(0.9, 0.2, 0.2, 0.15)
-              border.color: settingsRoot.cliHealth.keyring_available ? "#4ade80" : "#f87171"
+              color: Qt.rgba(0, 0, 0, 0.2)
+              border.color: settingsRoot.borderColor
               border.width: 1
 
               RowLayout {
                 id: krBadgeRow
                 anchors.centerIn: parent
-                spacing: 4
-                Text {
-                  text: settingsRoot.cliHealth.keyring_available ? "\uf00c" : "\uf00d"
-                  font.family: settingsRoot.fontFamily
+                spacing: 6
+
+                Rectangle {
+                  implicitWidth: 6
+                  implicitHeight: 6
+                  radius: 3
                   color: settingsRoot.cliHealth.keyring_available ? "#4ade80" : "#f87171"
+                }
+
+                Text {
+                  text: "Keyring: " + (settingsRoot.cliHealth.keyring_available ? "Ready" : "Unavailable")
+                  color: settingsRoot.foreground
                   font.pixelSize: 10
                 }
-                Text { text: "Keyring: " + (settingsRoot.cliHealth.keyring_available ? "Ready" : "Unavailable"); color: settingsRoot.foreground; font.pixelSize: 10 }
               }
             }
 
             // Clipboard Badge
             Rectangle {
               implicitHeight: 24
-              implicitWidth: clipBadgeRow.implicitWidth + 10
+              implicitWidth: clipBadgeRow.implicitWidth + 14
               radius: 4
-              color: settingsRoot.cliHealth.clipboard_available ? Qt.rgba(0.2, 0.8, 0.4, 0.15) : Qt.rgba(0.9, 0.2, 0.2, 0.15)
-              border.color: settingsRoot.cliHealth.clipboard_available ? "#4ade80" : "#f87171"
+              color: Qt.rgba(0, 0, 0, 0.2)
+              border.color: settingsRoot.borderColor
               border.width: 1
 
               RowLayout {
                 id: clipBadgeRow
                 anchors.centerIn: parent
-                spacing: 4
-                Text {
-                  text: settingsRoot.cliHealth.clipboard_available ? "\uf00c" : "\uf00d"
-                  font.family: settingsRoot.fontFamily
+                spacing: 6
+
+                Rectangle {
+                  implicitWidth: 6
+                  implicitHeight: 6
+                  radius: 3
                   color: settingsRoot.cliHealth.clipboard_available ? "#4ade80" : "#f87171"
+                }
+
+                Text {
+                  text: "Clipboard: " + (settingsRoot.cliHealth.clipboard_available ? "Ready" : "Missing")
+                  color: settingsRoot.foreground
                   font.pixelSize: 10
                 }
-                Text { text: "Clipboard: " + (settingsRoot.cliHealth.clipboard_available ? "Ready" : "Missing"); color: settingsRoot.foreground; font.pixelSize: 10 }
               }
             }
           }

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -3,7 +3,42 @@ set -e
 
 REPO="${1:-icyleaf/omarchy-bitwarden}"
 
-# 1. Try web redirect first (not subject to GitHub REST API rate limits)
+# 1. Try using python3 for full JSON fetching and safe parsing (releases API)
+if command -v python3 >/dev/null 2>&1; then
+  python3 - <<EOF
+import json, sys, urllib.request
+
+repo = "${REPO}"
+headers = {"User-Agent": "OmarchyBitwarden"}
+req = urllib.request.Request(f"https://api.github.com/repos/{repo}/releases/latest", headers=headers)
+try:
+    with urllib.request.urlopen(req, timeout=6) as response:
+        data = json.loads(response.read().decode())
+        tag = data.get("tag_name", "")
+        name = data.get("name", "")
+        body = data.get("body", "")
+        url = data.get("html_url", "")
+        pub = data.get("published_at", "")
+        if tag:
+            print(json.dumps({
+                "ok": True,
+                "tag": tag,
+                "name": name,
+                "body": body,
+                "url": url,
+                "published_at": pub
+            }))
+            sys.exit(0)
+except Exception:
+    pass
+sys.exit(1)
+EOF
+  if [ $? -eq 0 ]; then
+    exit 0
+  fi
+fi
+
+# 2. Fallback: Try web redirect (not subject to GitHub REST API rate limits)
 if command -v curl >/dev/null 2>&1; then
   TAG=$(curl -sIL --max-time 6 "https://github.com/${REPO}/releases/latest" 2>/dev/null | grep -i "^location:" | awk -F'/tag/' '{print $2}' | tr -d ' \r\n' || true)
 elif command -v wget >/dev/null 2>&1; then
@@ -12,7 +47,7 @@ else
   TAG=""
 fi
 
-# 2. Fallback to GitHub REST API if redirect was empty
+# 3. Fallback: GitHub REST API via curl/wget
 if [ -z "$TAG" ]; then
   if command -v curl >/dev/null 2>&1; then
     TAG=$(curl -sSL -H "User-Agent: OmarchyBitwarden" --max-time 6 "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep -o '"tag_name": *"[^"]*"' | head -n 1 | cut -d'"' -f4 || true)
@@ -22,7 +57,7 @@ if [ -z "$TAG" ]; then
 fi
 
 if [ -n "$TAG" ]; then
-  echo "{\"ok\":true,\"tag\":\"$TAG\"}"
+  echo "{\"ok\":true,\"tag\":\"$TAG\",\"url\":\"https://github.com/${REPO}/releases/tag/${TAG}\"}"
 else
   echo "{\"ok\":false,\"error\":\"Failed to fetch latest release metadata\"}"
 fi


### PR DESCRIPTION
## Summary of Changes

- **Streamline Engine Health Badges & Update Button**:
  - Replaced heavy green borders/backgrounds with subtle neutral surfaces and small 6px status indicators (🟢 ready / 🔴 missing).
  - Merged the Engine badge and Update button into a unified interactive badge when a new version is available.
  - Removed redundant "Up to date" static text; added temporary "Latest" feedback on the Check Update button.
- **In-App Release Notes Viewer**:
  - Clicking the update badge triggers an in-app Release Notes modal with clean, left-aligned Markdown rendering.
  - Formatted lists and block elements to eliminate Qt rich text forced 40px left indentation.
  - Compacted PR/commit/compare URLs into clean clickable link badges and highlighted user mentions.
  - Safe overlay dismissal on <kbd>Esc</kbd>, <kbd>Ctrl+,</kbd>, or leaving the Settings page.