### PR TITLE
feat(clipboard): propagate --sensitive hint to wl-copy for sensitive credentials

### DIFF
--- a/omawarden/src/clipboard.rs
+++ b/omawarden/src/clipboard.rs
@@ -35,7 +35,12 @@ impl ClipboardManager {
             return false;
         }
 
-        let mut child = match Command::new(&self.wl_copy_path)
+        let mut cmd = Command::new(&self.wl_copy_path);
+        if sensitive {
+            cmd.arg("--sensitive");
+        }
+
+        let mut child = match cmd
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -127,11 +132,14 @@ mod tests {
     fn test_mock_clipboard_copy_and_clear() {
         let dir = tempdir().unwrap();
         let clip_file = dir.path().join("clipboard.txt");
+        let args_file = dir.path().join("args.txt");
         let mock_wl = dir.path().join("mock-wl-copy");
 
         let script = format!(
             r#"#!/bin/sh
 CF="{}"
+AF="{}"
+echo "$*" > "$AF"
 if [ "$1" = "--clear" ]; then
     rm -f "$CF"
     exit 0
@@ -140,7 +148,8 @@ else
     exit 0
 fi
 "#,
-            clip_file.display()
+            clip_file.display(),
+            args_file.display()
         );
 
         fs::write(&mock_wl, script).unwrap();
@@ -150,12 +159,20 @@ fi
 
         let mgr = ClipboardManager::new(mock_wl.to_str().unwrap());
 
-        // Copy text
-        assert!(mgr.copy("super_secret_password", false, 0));
+        // Copy sensitive text -> should pass --sensitive
+        assert!(mgr.copy("super_secret_password", true, 0));
         assert_eq!(
             fs::read_to_string(&clip_file).unwrap(),
             "super_secret_password"
         );
+        let args = fs::read_to_string(&args_file).unwrap();
+        assert!(args.contains("--sensitive"));
+
+        // Copy non-sensitive text -> should NOT pass --sensitive
+        assert!(mgr.copy("public_username", false, 0));
+        assert_eq!(fs::read_to_string(&clip_file).unwrap(), "public_username");
+        let args_non_sensitive = fs::read_to_string(&args_file).unwrap();
+        assert!(!args_non_sensitive.contains("--sensitive"));
 
         // Copy multi-line report
         let multiline_report = "### Title\n\n- item 1\n- item 2\n```\nlog 1\n```\n";
@@ -165,6 +182,8 @@ fi
         // Clear clipboard
         assert!(mgr.clear());
         assert!(!clip_file.exists());
+        let clear_args = fs::read_to_string(&args_file).unwrap();
+        assert!(clear_args.contains("--clear"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #68

## Summary of Changes

- **Propagated `--sensitive` argument in `ClipboardManager::copy`**:
  - When copying sensitive content (`sensitive == true`), `--sensitive` is passed as a CLI flag to `wl-copy`.
  - Sets the Wayland data offer hint `x-kde-passwordManagerHint`, allowing Omarchy's built-in clipboard manager (`omarchy.clipboard` / `capture.sh`) and compatible Wayland history daemons (like `cliphist`) to automatically discard sensitive credentials without writing them to disk.
  - Non-sensitive fields (username, website URL, SSH public key, notes) are copied without `--sensitive` so they remain accessible in clipboard history.
- **Unit Testing**:
  - Updated mock `wl-copy` tests in `omawarden/src/clipboard.rs` to verify argument capture, asserting `--sensitive` is present for sensitive payloads and absent for non-sensitive text.

## Verification
- `cargo test` (51/51 tests passing).
- `cargo fmt --check` & `cargo clippy --all-targets --all-features -- -D warnings` clean.
