### PR TITLE
feat(ci): integrate git-cliff into omawarden and plugin release workflows

### DIFF
--- a/.github/workflows/release-omawarden.yml
+++ b/.github/workflows/release-omawarden.yml
@@ -95,6 +95,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -102,13 +104,24 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Generate Changelog with git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag ${{ github.ref_name }} --include-path "omawarden/**" --strip header
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           name: "${{ github.ref_name }}"
+          body_path: CHANGELOG.md
           files: |
             artifacts/*.tar.gz
             artifacts/*.sha256
           draft: false
           prerelease: false
-          generate_release_notes: true
+

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -3,9 +3,8 @@ name: Release Omarchy Plugin
 on:
   push:
     tags:
-      - 'omarchy-plugin-*'
-      - 'plugin-*'
-      - 'v*'
+      - 'omarchy-bitwarden-*'
+      - 'omarchy-bitwarden-v*'
 
 permissions:
   contents: write
@@ -17,34 +16,48 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Package Plugin Archive
         run: |
           TAG_NAME="${GITHUB_REF_NAME}"
-          ARCHIVE_NAME="omarchy-bitwarden-plugin-${TAG_NAME}"
+          ARCHIVE_NAME="omarchy-bitwarden-${TAG_NAME}"
           mkdir -p dist
 
           tar -czvf "dist/${ARCHIVE_NAME}.tar.gz" \
             OmarchyBitwarden.qml \
             components \
+            scripts \
             manifest.json \
             config.json \
             preview.png \
             LICENSE \
             README.md \
-            docs
-
+            README.zh-CN.md
           cd dist
           sha256sum "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
           cd ..
+
+      - name: Generate Changelog with git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag ${{ github.ref_name }} --exclude-path "omawarden/**" --strip header
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Plugin Release
         uses: softprops/action-gh-release@v2
         with:
           name: "Omarchy Bitwarden Plugin ${{ github.ref_name }}"
+          body_path: CHANGELOG.md
           files: |
             dist/*.tar.gz
             dist/*.sha256
           draft: false
           prerelease: false
-          generate_release_notes: true
+
+


### PR DESCRIPTION
Closes #72

## Summary of Changes
- Integrated `orhun/git-cliff-action@v4` into `.github/workflows/release-omawarden.yml`.
  - Configured `fetch-depth: 0` to ensure full commit history availability.
  - Filtered release changelog to `--include-path omawarden/**`.
  - Passed generated changelog to `softprops/action-gh-release` via `body_path: CHANGELOG.md`.
- Integrated `orhun/git-cliff-action@v4` into `.github/workflows/release-plugin.yml`.
  - Configured `fetch-depth: 0`.
  - Filtered release changelog to `--exclude-path omawarden/**` for plugin-focused notes.
  - Passed generated changelog via `body_path: CHANGELOG.md`.