### PR TITLE
fix(ci): pass --latest flag to git-cliff action for incremental release notes

### DIFF
--- a/.github/workflows/release-omawarden.yml
+++ b/.github/workflows/release-omawarden.yml
@@ -108,7 +108,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --tag ${{ github.ref_name }} --include-path "omawarden/**" --strip header
+          args: --tag ${{ github.ref_name }} --include-path "omawarden/**" --strip header --latest
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -43,7 +43,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --tag ${{ github.ref_name }} --exclude-path "omawarden/**" --strip header
+          args: --tag ${{ github.ref_name }} --exclude-path "omawarden/**" --strip header --latest
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary of Changes
- Added `--latest` argument to `git-cliff-action` in `release-omawarden.yml` and `release-plugin.yml`.
- Prevents `git-cliff` from outputting the entire historical changelog and duplicate groups for a single release tag.