### PR TITLE
feat(ui)!: add password history modal and change TOTP shortcut to Ctrl+Enter

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,7 +38,7 @@
 
 ### Vault Item Domain & Type Isolation
 - **Vault Item**: A single entity stored in the vault, categorized by type with strict type-specific JSON serialization (omitting empty structures for unrelated types):
-  - **Login**: Website/app credentials (Username, Password, URIs, live TOTP countdown, Custom Fields).
+  - **Login**: Website/app credentials (Username, Password, URIs, live TOTP countdown, Custom Fields, Password History with `Ctrl+H` modal).
   - **Card**: Payment card details (Brand, Cardholder, Number with reveal toggle, Expiration, CVV/Security Code).
   - **Identity**: Personal identification records (Title, Full Name, Username, Email, Phone, Company, Address, SSN, Passport, License).
   - **Secure Note**: Encrypted text notes or documentation with dedicated category classification.
@@ -49,8 +49,8 @@
 ### Interaction & UI Paradigms
 - **Overlay Window**: Main search launcher modal summoned by global shortcut (`Super+/` or user-defined).
 - **Category Tabs**: Filter bar allowing quick switching across item kinds (All, Login, Card, Identity, Note, SSH).
-- **Inspector Pane**: Side panel rendering details, masked secrets, live TOTP countdown, custom fields, organization/folder tags, and attachments.
-- **Action Palette (`Ctrl+K`)**: Modal listing all contextual operations (Copy Password `↵`, Copy Username `Ctrl+U`, Copy TOTP `Ctrl+T`, Open Website `Ctrl+O`, Copy Organization Name, Copy Folder Name, Copy Card/Identity attributes, Copy Public/Private Key, View/Download Attachments, Lock Vault `Ctrl+L`, Sync `Ctrl+R`).
+- **Inspector Pane**: Side panel rendering details, masked secrets, live TOTP countdown, custom fields, organization/folder tags, attachments, and password history entry.
+- **Action Palette (`Ctrl+K`)**: Modal listing all contextual operations (Copy Password `↵`, Copy TOTP `Ctrl+↵`, Copy Username `Ctrl+U`, Toggle Field Visibility `Ctrl+T`, View Password History `Ctrl+H`, Open Website `Ctrl+O`, Copy Organization Name, Copy Folder Name, Copy Card/Identity attributes, Copy Public/Private Key, View/Download Attachments, Lock Vault `Ctrl+L`, Sync `Ctrl+R`).
 - **Config & Settings View**: Allows user configuration of `server_url`, `download_dir`, `auto_lock_minutes`, `clipboard_clear_seconds`, `max_output_mb`, and `log_level`, with real-time CLI readiness indicators and an embedded Logs Viewer.
 - **Observability & Diagnostics**: Dual-channel structured logging across `omawarden` (`stderr`) and Quickshell (`console.error`), featuring module prefixes (`[omawarden:cli]`, `[omarchy:ui]`), configurable log levels (`error` by default), zero-knowledge credential and custom server URL redaction, and one-click "Copy Diagnostics" for privacy-safe GitHub issue reporting (see `docs/adr/0004-structured-logging-and-diagnostics.md`).
 

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -91,6 +91,9 @@ Item {
   // Details Inspector State
   property bool showPasswordRevealed: false
   property bool showPrivateKeyRevealed: false
+  property bool showCardNumberRevealed: false
+  property bool showCardCodeRevealed: false
+  property bool showCustomHiddenRevealed: false
   property var currentTotp: ({ code: "", ttl: 30, period: 30 })
   property bool showActionPalette: false
   property int actionPaletteIndex: 0
@@ -98,6 +101,8 @@ Item {
   property bool showSshKeyModal: false
   property string sshKeyModalMode: "create"
   property var sshKeyModalItem: null
+  property bool showPasswordHistoryModal: false
+  property var activePasswordHistoryItem: null
   property var activeAttachmentPreview: null
   property string loadingAttachmentId: ""
 
@@ -180,6 +185,7 @@ Item {
     root.opened = false
     root.showActionPalette = false
     root.showSshKeyModal = false
+    root.showPasswordHistoryModal = false
   }
 
   function dismiss() {
@@ -513,10 +519,32 @@ Item {
   function handleSelectedItemChanged() {
     root.showPasswordRevealed = false
     root.showPrivateKeyRevealed = false
+    root.showCardNumberRevealed = false
+    root.showCardCodeRevealed = false
+    root.showCustomHiddenRevealed = false
     root.activeAttachmentPreview = null
     root.loadingAttachmentId = ""
     root.updateTotpForSelected()
     root.updateAvailableActions()
+  }
+
+  function toggleItemRevealed() {
+    if (root.showPasswordHistoryModal) {
+      if (passwordHistoryModalComponent) {
+        passwordHistoryModalComponent.toggleAllRevealed()
+      }
+      return
+    }
+
+    if (root.effectiveView === "search" && root.selectedItem) {
+      var anyRevealed = root.showPasswordRevealed || root.showPrivateKeyRevealed || root.showCardNumberRevealed || root.showCardCodeRevealed || root.showCustomHiddenRevealed
+      var targetState = !anyRevealed
+      root.showPasswordRevealed = targetState
+      root.showPrivateKeyRevealed = targetState
+      root.showCardNumberRevealed = targetState
+      root.showCardCodeRevealed = targetState
+      root.showCustomHiddenRevealed = targetState
+    }
   }
 
   function updateAvailableActions() {
@@ -533,6 +561,12 @@ Item {
 
   onShowSshKeyModalChanged: {
     if (!root.showSshKeyModal) {
+      root.restoreSearchFocus()
+    }
+  }
+
+  onShowPasswordHistoryModalChanged: {
+    if (!root.showPasswordHistoryModal) {
       root.restoreSearchFocus()
     }
   }
@@ -696,7 +730,7 @@ Item {
         actions.push({
           label: totpLabel,
           icon: "\uf017",
-          shortcut: "Ctrl+T",
+          shortcut: "Ctrl+↵",
           action: function() {
             if (root.currentTotp && root.currentTotp.code) {
               root.copyToClipboard(root.currentTotp.code, true, "TOTP code")
@@ -725,6 +759,17 @@ Item {
             hasAssignedUrlShortcut = true
           }
         }
+      }
+      if (item.login.password_history && item.login.password_history.length > 0) {
+        actions.push({
+          label: "Password History (" + item.login.password_history.length + ")",
+          icon: "\uf1da",
+          shortcut: "Ctrl+H",
+          action: function() {
+            root.activePasswordHistoryItem = item
+            root.showPasswordHistoryModal = true
+          }
+        })
       }
     } else if (item.type_name === "card" && item.card) {
       if (item.card.number) actions.push({ label: "Copy Card Number", icon: "\uf09d", shortcut: "↵", action: function() { root.copyToClipboard(item.card.number, true, "card number") } })
@@ -835,6 +880,7 @@ Item {
       })
     }
 
+    actions.push({ label: "Toggle Field Visibility", icon: "\uf06e", shortcut: "Ctrl+T", action: function() { root.toggleItemRevealed() } })
     actions.push({ label: "Copy Item Name (" + item.name + ")", icon: "\uf0c5", shortcut: "", action: function() { root.copyToClipboard(item.name, false, "item name") } })
     actions.push({ label: "Generate SSH Key", icon: "\uf067", shortcut: "", action: function() { root.openSshKeyModal("create", null) } })
     actions.push({ label: "Import SSH Key", icon: "\uf093", shortcut: "", action: function() { root.openSshKeyModal("import", null) } })
@@ -1145,6 +1191,12 @@ Item {
       }
 
       Shortcut {
+        sequences: ["Ctrl+Return", "Ctrl+Enter"]
+        enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal
+        onActivated: root.copyItemTotp(root.selectedItem)
+      }
+
+      Shortcut {
         sequence: "Ctrl+U"
         enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal
         onActivated: root.copyItemUsername(root.selectedItem)
@@ -1152,8 +1204,8 @@ Item {
 
       Shortcut {
         sequence: "Ctrl+T"
-        enabled: root.opened && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal
-        onActivated: root.copyItemTotp(root.selectedItem)
+        enabled: root.opened && (root.showPasswordHistoryModal || (root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal))
+        onActivated: root.toggleItemRevealed()
       }
 
       Shortcut {
@@ -1197,7 +1249,9 @@ Item {
         sequence: "Escape"
         enabled: root.opened
         onActivated: {
-          if (root.showSshKeyModal) {
+          if (root.showPasswordHistoryModal) {
+            root.showPasswordHistoryModal = false
+          } else if (root.showSshKeyModal) {
             root.showSshKeyModal = false
           } else if (root.showActionPalette) {
             root.showActionPalette = false
@@ -1215,6 +1269,12 @@ Item {
 
       Keys.priority: Keys.BeforeItem
       Keys.onPressed: function(event) {
+        if (event.modifiers & Qt.ControlModifier && (event.key === Qt.Key_T || (event.text && event.text.toLowerCase() === "t"))) {
+          root.toggleItemRevealed()
+          event.accepted = true
+          return
+        }
+
         if (root.showSshKeyModal) {
           if (event.key === Qt.Key_Escape) {
             root.showSshKeyModal = false
@@ -1226,6 +1286,14 @@ Item {
         if (root.showActionPalette) {
           if (event.key === Qt.Key_Escape) {
             root.showActionPalette = false
+            event.accepted = true
+          }
+          return
+        }
+
+        if (root.showPasswordHistoryModal) {
+          if (event.key === Qt.Key_Escape) {
+            root.showPasswordHistoryModal = false
             event.accepted = true
           }
           return
@@ -1264,29 +1332,40 @@ Item {
           }
           event.accepted = true
         } else if (event.modifiers & Qt.ControlModifier) {
-          if (event.key === Qt.Key_U && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal) {
+          if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter) && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
+            root.copyItemTotp(root.selectedItem)
+            event.accepted = true
+          } else if (event.key === Qt.Key_U && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.copyItemUsername(root.selectedItem)
             event.accepted = true
-          } else if (event.key === Qt.Key_K && root.effectiveView === "search" && !root.showActionPalette && !root.showSshKeyModal) {
+          } else if (event.key === Qt.Key_K && root.effectiveView === "search" && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.actionPaletteIndex = 0
             root.showActionPalette = true
             event.accepted = true
-          } else if (event.key === Qt.Key_T && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal) {
-            root.copyItemTotp(root.selectedItem)
+          } else if (event.key === Qt.Key_T && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
+            root.toggleItemRevealed()
             event.accepted = true
-          } else if (event.key === Qt.Key_O && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal) {
+          } else if (event.key === Qt.Key_O && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.openFirstWebsite(root.selectedItem)
             event.accepted = true
-          } else if (event.key === Qt.Key_E && root.effectiveView === "search" && root.selectedItem !== null && root.selectedItem.type_name === "ssh_key" && !root.showActionPalette && !root.showSshKeyModal) {
+          } else if (event.key === Qt.Key_E && root.effectiveView === "search" && root.selectedItem !== null && root.selectedItem.type_name === "ssh_key" && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.openSshKeyModal("export", root.selectedItem)
             event.accepted = true
-          } else if (event.key === Qt.Key_L && root.authState.status === "unlocked" && !root.showSshKeyModal) {
+          } else if (event.key === Qt.Key_H && root.effectiveView === "search" && root.selectedItem !== null && !root.showActionPalette && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
+            if (root.selectedItem.login && root.selectedItem.login.password_history && root.selectedItem.login.password_history.length > 0) {
+              root.activePasswordHistoryItem = root.selectedItem
+              root.showPasswordHistoryModal = true
+            } else {
+              root.statusMessage = "No password history recorded for this item."
+            }
+            event.accepted = true
+          } else if (event.key === Qt.Key_L && root.authState.status === "unlocked" && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.doLock()
             event.accepted = true
-          } else if (event.key === Qt.Key_R && root.authState.status === "unlocked" && !root.isBusy && !root.showSshKeyModal) {
+          } else if (event.key === Qt.Key_R && root.authState.status === "unlocked" && !root.isBusy && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.syncVault(false, true)
             event.accepted = true
-          } else if (event.key === Qt.Key_Comma && !root.showSshKeyModal) {
+          } else if (event.key === Qt.Key_Comma && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.currentView = (root.effectiveView === "settings") ? "auto" : "settings"
             event.accepted = true
           }
@@ -1305,6 +1384,7 @@ Item {
         SearchHeader {
           id: searchHeader
           visible: root.effectiveView === "search"
+          modalsActive: root.showActionPalette || root.showSshKeyModal || root.showPasswordHistoryModal
           Layout.preferredHeight: visible ? implicitHeight : 0
           searchQuery: root.searchQuery
           categoryList: root.categoryList
@@ -1401,6 +1481,9 @@ Item {
                 currentTotp: root.currentTotp
                 showPasswordRevealed: root.showPasswordRevealed
                 showPrivateKeyRevealed: root.showPrivateKeyRevealed
+                showCardNumberRevealed: root.showCardNumberRevealed
+                showCardCodeRevealed: root.showCardCodeRevealed
+                showCustomHiddenRevealed: root.showCustomHiddenRevealed
                 activeAttachmentPreview: root.activeAttachmentPreview
                 loadingAttachmentId: root.loadingAttachmentId
                 fontFamily: root.fontFamily
@@ -1414,6 +1497,13 @@ Item {
                 onClosePreviewRequested: { root.activeAttachmentPreview = null }
                 onTogglePasswordRevealed: { root.showPasswordRevealed = !root.showPasswordRevealed }
                 onTogglePrivateKeyRevealed: { root.showPrivateKeyRevealed = !root.showPrivateKeyRevealed }
+                onToggleCardNumberRevealed: { root.showCardNumberRevealed = !root.showCardNumberRevealed }
+                onToggleCardCodeRevealed: { root.showCardCodeRevealed = !root.showCardCodeRevealed }
+                onToggleCustomHiddenRevealed: { root.showCustomHiddenRevealed = !root.showCustomHiddenRevealed }
+                onPasswordHistoryRequested: function(item) {
+                  root.activePasswordHistoryItem = item
+                  root.showPasswordHistoryModal = true
+                }
               }
 
               // Empty Selection State View
@@ -1569,6 +1659,19 @@ Item {
         onImportRequested: function(payload) { root.handleSshKeyImport(payload) }
         onExportRequested: function(payload) { root.handleSshKeyExport(payload) }
         onCloseRequested: { root.showSshKeyModal = false }
+      }
+
+      // 7. Password History Modal Overlay
+      PasswordHistoryModal {
+        id: passwordHistoryModalComponent
+        active: root.showPasswordHistoryModal
+        item: root.activePasswordHistoryItem
+        fontFamily: root.fontFamily
+        foreground: root.foreground
+        accent: root.accent
+        borderColor: root.borderColor
+        onCopyRequested: function(text, isSensitive, label) { root.copyToClipboard(text, isSensitive, label) }
+        onCloseRequested: { root.showPasswordHistoryModal = false }
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -26,19 +26,21 @@ Powered by a dedicated pure Rust engine (`omawarden`), `omarchy-bitwarden` deliv
 
 ## Keyboard Shortcuts
 
-| Shortcut                       | Description                                                               |
-| :----------------------------- | :------------------------------------------------------------------------ |
-| <kbd>Enter</kbd>               | Copy primary credential (Password / Card Number / Public Key)             |
-| <kbd>Ctrl</kbd> + <kbd>U</kbd> | Copy username                                                             |
-| <kbd>Ctrl</kbd> + <kbd>T</kbd> | Copy live TOTP code                                                       |
-| <kbd>Ctrl</kbd> + <kbd>O</kbd> | Open primary website URL in default browser                               |
-| <kbd>Ctrl</kbd> + <kbd>K</kbd> | Open Action Palette (Copy username, TOTP, PIN, Org Name, etc.)            |
-| <kbd>Ctrl</kbd> + <kbd>,</kbd> | Open / Toggle Settings configuration view                                 |
-| <kbd>Ctrl</kbd> + <kbd>L</kbd> | Manually lock the vault immediately                                       |
-| <kbd>Ctrl</kbd> + <kbd>R</kbd> | Trigger manual vault sync with Bitwarden server                           |
-| <kbd>↓</kbd> / <kbd>↑</kbd>    | Navigate item list or action options (stops at boundaries)                |
-| <kbd>Tab</kbd>                 | Switch category filters (All, Logins, Cards, Identities, Notes, SSH Keys) |
-| <kbd>Esc</kbd>                 | Dismiss Action Palette, Settings, or hide the overlay                     |
+| Shortcut                               | Description                                                               |
+| :------------------------------------- | :------------------------------------------------------------------------ |
+| <kbd>Enter</kbd>                       | Copy primary credential (Password / Card Number / Public Key)             |
+| <kbd>Ctrl</kbd> + <kbd>Enter</kbd>     | Copy live TOTP code                                                       |
+| <kbd>Ctrl</kbd> + <kbd>U</kbd>         | Copy username                                                             |
+| <kbd>Ctrl</kbd> + <kbd>T</kbd>         | Toggle field / secret visibility (passwords, keys, card codes, etc.)      |
+| <kbd>Ctrl</kbd> + <kbd>H</kbd>         | Open password history modal for the selected login item                   |
+| <kbd>Ctrl</kbd> + <kbd>O</kbd>         | Open primary website URL in default browser                               |
+| <kbd>Ctrl</kbd> + <kbd>K</kbd>         | Open Action Palette (Copy username, TOTP, PIN, Org Name, History, etc.)    |
+| <kbd>Ctrl</kbd> + <kbd>,</kbd>         | Open / Toggle Settings configuration view                                 |
+| <kbd>Ctrl</kbd> + <kbd>L</kbd>         | Manually lock the vault immediately                                       |
+| <kbd>Ctrl</kbd> + <kbd>R</kbd>         | Trigger manual vault sync with Bitwarden server                           |
+| <kbd>↓</kbd> / <kbd>↑</kbd>            | Navigate item list or action options (stops at boundaries)                |
+| <kbd>Tab</kbd>                         | Switch category filters (All, Logins, Cards, Identities, Notes, SSH Keys) |
+| <kbd>Esc</kbd>                         | Dismiss Action Palette, History modal, Settings, or hide overlay          |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,19 +26,21 @@
 
 ## 常用快捷键
 
-| 快捷键                         | 功能说明                                                   |
-| :----------------------------- | :--------------------------------------------------------- |
-| <kbd>Enter</kbd>               | 复制主要凭据（密码 / 卡号 / SSH 公钥）                     |
-| <kbd>Ctrl</kbd> + <kbd>U</kbd> | 复制用户名                                                 |
-| <kbd>Ctrl</kbd> + <kbd>T</kbd> | 复制实时 TOTP 动态验证码                                   |
-| <kbd>Ctrl</kbd> + <kbd>O</kbd> | 在系统默认浏览器中打开登录网址                             |
-| <kbd>Ctrl</kbd> + <kbd>K</kbd> | 打开动作面板（复制用户名、TOTP、PIN 码、组织名称等）       |
-| <kbd>Ctrl</kbd> + <kbd>,</kbd> | 打开 / 切换设置面板                                        |
-| <kbd>Ctrl</kbd> + <kbd>L</kbd> | 立即手动锁定密码库                                         |
-| <kbd>Ctrl</kbd> + <kbd>R</kbd> | 触发与 Bitwarden 服务器的手动同步                          |
-| <kbd>↓</kbd> / <kbd>↑</kbd>    | 列表或动作菜单导航（到达边界自动停止）                     |
-| <kbd>Tab</kbd>                 | 切换分类标签（全部、登录、卡片、身份、安全备注、SSH 密钥） |
-| <kbd>Esc</kbd>                 | 关闭动作面板、设置面板或隐藏覆盖层                         |
+| 快捷键                                 | 功能说明                                                   |
+| :------------------------------------- | :--------------------------------------------------------- |
+| <kbd>Enter</kbd>                       | 复制主要凭据（密码 / 卡号 / SSH 公钥）                     |
+| <kbd>Ctrl</kbd> + <kbd>Enter</kbd>     | 复制实时 TOTP 动态验证码                                   |
+| <kbd>Ctrl</kbd> + <kbd>U</kbd>         | 复制用户名                                                 |
+| <kbd>Ctrl</kbd> + <kbd>T</kbd>         | 切换字段/秘密明文与掩码展示（密码、密钥、卡号等）          |
+| <kbd>Ctrl</kbd> + <kbd>H</kbd>         | 查看当前登录项的历史密码记录                               |
+| <kbd>Ctrl</kbd> + <kbd>O</kbd>         | 在系统默认浏览器中打开登录网址                             |
+| <kbd>Ctrl</kbd> + <kbd>K</kbd>         | 打开动作面板（复制用户名、TOTP、PIN 码、密码历史等）       |
+| <kbd>Ctrl</kbd> + <kbd>,</kbd>         | 打开 / 切换设置面板                                        |
+| <kbd>Ctrl</kbd> + <kbd>L</kbd>         | 立即手动锁定密码库                                         |
+| <kbd>Ctrl</kbd> + <kbd>R</kbd>         | 触发与 Bitwarden 服务器的手动同步                          |
+| <kbd>↓</kbd> / <kbd>↑</kbd>            | 列表或动作菜单导航（到达边界自动停止）                     |
+| <kbd>Tab</kbd>                         | 切换分类标签（全部、登录、卡片、身份、安全备注、SSH 密钥） |
+| <kbd>Esc</kbd>                         | 关闭动作面板、历史记录、设置面板或隐藏覆盖层               |
 
 ---
 

--- a/components/ActionPaletteModal.qml
+++ b/components/ActionPaletteModal.qml
@@ -102,6 +102,15 @@ Rectangle {
                 }
                 event.accepted = true
               } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                if (event.modifiers & Qt.ControlModifier) {
+                  for (var r = 0; r < filtered.length; r++) {
+                    if (filtered[r].shortcut && (filtered[r].shortcut === "Ctrl+↵" || filtered[r].shortcut.toLowerCase() === "ctrl+enter" || filtered[r].shortcut.toLowerCase() === "ctrl+return")) {
+                      paletteRoot.actionSelected(filtered[r])
+                      event.accepted = true
+                      return
+                    }
+                  }
+                }
                 if (filtered.length > 0 && paletteRoot.selectedIndex >= 0 && paletteRoot.selectedIndex < filtered.length) {
                   paletteRoot.actionSelected(filtered[paletteRoot.selectedIndex])
                 }
@@ -115,6 +124,7 @@ Rectangle {
                 else if (event.key === Qt.Key_E) pressedKey = "Ctrl+E"
                 else if (event.key === Qt.Key_T) pressedKey = "Ctrl+T"
                 else if (event.key === Qt.Key_O) pressedKey = "Ctrl+O"
+                else if (event.key === Qt.Key_H) pressedKey = "Ctrl+H"
 
                 if (pressedKey) {
                   for (var i = 0; i < filtered.length; i++) {

--- a/components/EmptyInspector.qml
+++ b/components/EmptyInspector.qml
@@ -138,6 +138,31 @@ ScrollView {
         wrapMode: Text.WordWrap
       }
 
+      // Ctrl+↵
+      Rectangle {
+        implicitHeight: 20
+        implicitWidth: kEnterTotp.implicitWidth + 10
+        radius: 3
+        color: Qt.rgba(0, 0, 0, 0.25)
+        border.color: emptyInspectorRoot.borderColor
+        border.width: 1
+        Text {
+          id: kEnterTotp
+          anchors.centerIn: parent
+          text: "Ctrl + ↵"
+          color: emptyInspectorRoot.foreground
+          font.pixelSize: 10
+          font.weight: Font.Medium
+        }
+      }
+      Text {
+        text: "Copy live TOTP code"
+        color: Qt.darker(emptyInspectorRoot.foreground, 1.3)
+        font.pixelSize: 10
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+      }
+
       // Ctrl+U
       Rectangle {
         implicitHeight: 20
@@ -181,7 +206,32 @@ ScrollView {
         }
       }
       Text {
-        text: "Copy live TOTP code"
+        text: "Toggle field / secret visibility"
+        color: Qt.darker(emptyInspectorRoot.foreground, 1.3)
+        font.pixelSize: 10
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+      }
+
+      // Ctrl+H
+      Rectangle {
+        implicitHeight: 20
+        implicitWidth: kH.implicitWidth + 10
+        radius: 3
+        color: Qt.rgba(0, 0, 0, 0.25)
+        border.color: emptyInspectorRoot.borderColor
+        border.width: 1
+        Text {
+          id: kH
+          anchors.centerIn: parent
+          text: "Ctrl + H"
+          color: emptyInspectorRoot.foreground
+          font.pixelSize: 10
+          font.weight: Font.Medium
+        }
+      }
+      Text {
+        text: "Open password history modal"
         color: Qt.darker(emptyInspectorRoot.foreground, 1.3)
         font.pixelSize: 10
         Layout.fillWidth: true

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -11,6 +11,7 @@ ScrollView {
   property bool showPrivateKeyRevealed: false
   property bool showCardNumberRevealed: false
   property bool showCardCodeRevealed: false
+  property bool showCustomHiddenRevealed: false
   property var activeAttachmentPreview: null
   property string loadingAttachmentId: ""
   property color foreground: "#ffffff"
@@ -23,6 +24,7 @@ ScrollView {
   onItemChanged: {
     showCardNumberRevealed = false
     showCardCodeRevealed = false
+    showCustomHiddenRevealed = false
   }
 
   signal copyRequested(string text, bool isSensitive, string label)
@@ -32,6 +34,10 @@ ScrollView {
   signal closePreviewRequested()
   signal togglePasswordRevealed()
   signal togglePrivateKeyRevealed()
+  signal toggleCardNumberRevealed()
+  signal toggleCardCodeRevealed()
+  signal toggleCustomHiddenRevealed()
+  signal passwordHistoryRequested(var item)
 
   clip: true
   ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
@@ -1300,7 +1306,8 @@ ScrollView {
               spacing: 8
 
               property bool isHiddenField: Boolean(modelData && modelData.type === 1)
-              property bool isRevealed: false
+              property bool itemRevealed: false
+              property bool isRevealed: itemRevealed || inspectorRoot.showCustomHiddenRevealed
 
               Rectangle {
                 Layout.fillWidth: true
@@ -1340,7 +1347,13 @@ ScrollView {
                   visible: modelData.type === 1
                   iconText: customFieldRow.isRevealed ? "\uf070" : "\uf06e"
                   tooltip: customFieldRow.isRevealed ? "Hide field" : "Show field"
-                  onClicked: customFieldRow.isRevealed = !customFieldRow.isRevealed
+                  onClicked: {
+                    if (inspectorRoot.showCustomHiddenRevealed) {
+                      customFieldRow.itemRevealed = false
+                    } else {
+                      customFieldRow.itemRevealed = !customFieldRow.itemRevealed
+                    }
+                  }
                 }
 
                 // Ghost Copy Button
@@ -1527,6 +1540,45 @@ ScrollView {
                   elide: Text.ElideRight
                   Layout.fillWidth: true
                 }
+              }
+            }
+          }
+
+          // Password History Entry Button (Only for Login items with history)
+          ColumnLayout {
+            visible: Boolean(inspectorRoot.item && inspectorRoot.item.login && inspectorRoot.item.login.password_history && inspectorRoot.item.login.password_history.length > 0)
+            Layout.fillWidth: true
+            spacing: 8
+
+            Rectangle {
+              Layout.fillWidth: true
+              height: 1
+              color: Qt.rgba(255, 255, 255, 0.05)
+            }
+
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: 8
+
+              ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 2
+                Text { text: "Password History"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
+                Text {
+                  text: (inspectorRoot.item && inspectorRoot.item.login && inspectorRoot.item.login.password_history) ? (inspectorRoot.item.login.password_history.length + " previous password(s)") : ""
+                  color: inspectorRoot.foreground
+                  font.pixelSize: inspectorRoot.valuePixelSize
+                  font.weight: Font.Medium
+                  elide: Text.ElideRight
+                  Layout.fillWidth: true
+                }
+              }
+
+              // View Password History Ghost Button
+              GhostIconButton {
+                iconText: "\uf1da"
+                tooltip: "View password history (Ctrl+H)"
+                onClicked: inspectorRoot.passwordHistoryRequested(inspectorRoot.item)
               }
             }
           }

--- a/components/PasswordHistoryModal.qml
+++ b/components/PasswordHistoryModal.qml
@@ -1,0 +1,305 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Rectangle {
+  id: historyModalRoot
+
+  property bool active: false
+  property var item: null
+  property color foreground: "#ffffff"
+  property color accent: "#3b82f6"
+  property color borderColor: Qt.rgba(1, 1, 1, 0.1)
+  property string fontFamily: ""
+
+  property bool allRevealed: false
+  property var revealedIndexes: ({})
+
+  signal copyRequested(string text, bool isSensitive, string label)
+  signal closeRequested()
+
+  anchors.fill: parent
+  color: Qt.rgba(0, 0, 0, 0.65)
+  visible: active
+  z: 110
+
+  Keys.onEscapePressed: historyModalRoot.closeRequested()
+
+  Keys.onPressed: function(event) {
+    if (event.key === Qt.Key_Escape) {
+      historyModalRoot.closeRequested()
+      event.accepted = true
+    } else if (event.modifiers & Qt.ControlModifier) {
+      if (event.key === Qt.Key_T) {
+        historyModalRoot.toggleAllRevealed()
+        event.accepted = true
+      }
+    }
+  }
+
+  onActiveChanged: {
+    if (active) {
+      allRevealed = false
+      revealedIndexes = {}
+      historyModalRoot.forceActiveFocus()
+    }
+  }
+
+  function toggleAllRevealed() {
+    allRevealed = !allRevealed
+    var copy = {}
+    var list = getHistoryList()
+    for (var i = 0; i < list.length; i++) {
+      copy[i] = allRevealed
+    }
+    revealedIndexes = copy
+  }
+
+  function formatDateTime(dateStr) {
+    if (!dateStr) return ""
+    try {
+      var d = new Date(dateStr)
+      if (!isNaN(d.getTime())) {
+        var year = d.getFullYear()
+        var month = String(d.getMonth() + 1).padStart(2, '0')
+        var day = String(d.getDate()).padStart(2, '0')
+        var hours = String(d.getHours()).padStart(2, '0')
+        var minutes = String(d.getMinutes()).padStart(2, '0')
+        return year + "-" + month + "-" + day + " " + hours + ":" + minutes
+      }
+    } catch (e) {}
+    return String(dateStr).substring(0, 16).replace("T", " ")
+  }
+
+  function getHistoryList() {
+    if (!item || !item.login || !item.login.password_history) return []
+    var list = item.login.password_history
+    if (!Array.isArray(list)) return []
+    // Show newest first
+    return list.slice().reverse()
+  }
+
+  function isIndexRevealed(idx) {
+    if (allRevealed) return true
+    return Boolean(revealedIndexes && revealedIndexes[idx])
+  }
+
+  function toggleReveal(idx) {
+    var list = getHistoryList()
+    var copy = {}
+    if (allRevealed) {
+      for (var i = 0; i < list.length; i++) {
+        copy[i] = (i !== idx)
+      }
+      allRevealed = false
+    } else {
+      copy = Object.assign({}, revealedIndexes || {})
+      copy[idx] = !Boolean(copy[idx])
+    }
+    revealedIndexes = copy
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: historyModalRoot.closeRequested()
+  }
+
+  Rectangle {
+    id: modalCard
+    anchors.centerIn: parent
+    width: Math.min(parent.width - 48, 520)
+    height: Math.min(parent.height - 48, 440)
+    radius: 8
+    color: Qt.rgba(0.12, 0.14, 0.18, 0.98)
+    border.color: historyModalRoot.borderColor
+    border.width: 1
+
+    MouseArea {
+      anchors.fill: parent
+    }
+
+    ColumnLayout {
+      anchors.fill: parent
+      anchors.margins: 16
+      spacing: 12
+
+      // Modal Header
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Text {
+          text: "\uf1da"
+          font.family: historyModalRoot.fontFamily
+          font.pixelSize: 14
+          color: historyModalRoot.accent
+        }
+
+        Text {
+          text: "Password History: " + (historyModalRoot.item ? (historyModalRoot.item.name || "Item") : "")
+          color: historyModalRoot.foreground
+          font.pixelSize: 13
+          font.weight: Font.DemiBold
+          elide: Text.ElideRight
+          Layout.fillWidth: true
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: historyModalRoot.borderColor
+      }
+
+      // Scrollable History Content
+      ScrollView {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        clip: true
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
+        ColumnLayout {
+          width: modalCard.width - 32
+          spacing: 8
+
+          Repeater {
+            model: historyModalRoot.getHistoryList()
+
+            Rectangle {
+              id: entryCard
+              property bool isEntryRevealed: historyModalRoot.allRevealed || Boolean(historyModalRoot.revealedIndexes && historyModalRoot.revealedIndexes[index])
+
+              Layout.fillWidth: true
+              implicitHeight: entryCol.implicitHeight + 16
+              radius: 6
+              color: Qt.rgba(0, 0, 0, 0.25)
+              border.color: historyModalRoot.borderColor
+              border.width: 1
+
+              ColumnLayout {
+                id: entryCol
+                anchors.fill: parent
+                anchors.margins: 8
+                spacing: 6
+
+                // Last Used Date
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: 6
+
+                  Text {
+                    text: (modelData.last_used_date ? historyModalRoot.formatDateTime(modelData.last_used_date) : "Unknown date")
+                    color: Qt.darker(historyModalRoot.foreground, 1.5)
+                    font.pixelSize: 10
+                    font.weight: Font.Medium
+                    Layout.fillWidth: true
+                  }
+
+                  Text {
+                    text: "#" + (historyModalRoot.getHistoryList().length - index)
+                    color: Qt.darker(historyModalRoot.foreground, 2.0)
+                    font.pixelSize: 9
+                  }
+                }
+
+                // Password Row
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: 8
+
+                  Text {
+                    text: entryCard.isEntryRevealed ? ((modelData && modelData.password) ? modelData.password : "") : "••••••••••••••••"
+                    color: historyModalRoot.foreground
+                    font.pixelSize: 12
+                    font.family: entryCard.isEntryRevealed ? "monospace" : "sans-serif"
+                    font.weight: Font.Medium
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                  }
+
+                  // Toggle Mask Ghost Button
+                  GhostIconButton {
+                    iconText: entryCard.isEntryRevealed ? "\uf070" : "\uf06e"
+                    tooltip: entryCard.isEntryRevealed ? "Hide password" : "Show password"
+                    fontFamily: historyModalRoot.fontFamily
+                    onClicked: historyModalRoot.toggleReveal(index)
+                  }
+
+                  // Copy Ghost Button
+                  GhostIconButton {
+                    iconText: "\uf0c5"
+                    tooltip: "Copy history password"
+                    fontFamily: historyModalRoot.fontFamily
+                    onClicked: historyModalRoot.copyRequested((modelData && modelData.password) ? modelData.password : "", true, "history password")
+                  }
+                }
+              }
+            }
+          }
+
+          // Empty state fallback (just in case)
+          Text {
+            visible: historyModalRoot.getHistoryList().length === 0
+            text: "No password history available for this item."
+            color: Qt.darker(historyModalRoot.foreground, 1.8)
+            font.pixelSize: 11
+            Layout.alignment: Qt.AlignCenter
+          }
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: historyModalRoot.borderColor
+      }
+
+      // Footer
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Text {
+          text: historyModalRoot.getHistoryList().length + " past password(s) recorded"
+          color: Qt.darker(historyModalRoot.foreground, 1.8)
+          font.pixelSize: 10
+          Layout.fillWidth: true
+        }
+
+        // Toggle Mask Ghost Button
+        GhostIconButton {
+          visible: historyModalRoot.getHistoryList().length > 0
+          iconText: historyModalRoot.allRevealed ? "\uf070" : "\uf06e"
+          tooltip: historyModalRoot.allRevealed ? "Hide all passwords (Ctrl+T)" : "Show all passwords (Ctrl+T)"
+          fontFamily: historyModalRoot.fontFamily
+          onClicked: historyModalRoot.toggleAllRevealed()
+        }
+
+        // Close Button
+        Rectangle {
+          implicitHeight: 26
+          implicitWidth: closeBtnText.implicitWidth + 16
+          radius: 4
+          color: Qt.rgba(1, 1, 1, 0.08)
+          border.color: historyModalRoot.borderColor
+          border.width: 1
+
+          Text {
+            id: closeBtnText
+            anchors.centerIn: parent
+            text: "Close"
+            color: historyModalRoot.foreground
+            font.pixelSize: 10
+            font.weight: Font.Medium
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: historyModalRoot.closeRequested()
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/SearchHeader.qml
+++ b/components/SearchHeader.qml
@@ -16,6 +16,7 @@ ColumnLayout {
   property color accent: "#3b82f6"
   property color borderColor: Qt.rgba(1, 1, 1, 0.1)
   property string fontFamily: ""
+  property bool modalsActive: false
 
   signal categorySelected(string category)
   signal clearSearchRequested()
@@ -82,12 +83,14 @@ ColumnLayout {
 
           Keys.priority: Keys.BeforeItem
           Keys.onPressed: function(event) {
+            if (searchHeaderRoot.modalsActive) return
+
             if (event.modifiers & Qt.ControlModifier) {
-              if (event.key === Qt.Key_U) {
-                searchHeaderRoot.copyUsernameRequested()
-                event.accepted = true
-              } else if (event.key === Qt.Key_T) {
+              if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                 searchHeaderRoot.copyTotpRequested()
+                event.accepted = true
+              } else if (event.key === Qt.Key_U) {
+                searchHeaderRoot.copyUsernameRequested()
                 event.accepted = true
               } else if (event.key === Qt.Key_O) {
                 searchHeaderRoot.openUrlRequested()


### PR DESCRIPTION
Closes #79

## Summary of Changes
- **Password History Modal (`Ctrl+H`)**: Introduced a dedicated modal overlay to browse historical passwords with timestamps, individual/bulk reveal toggles, and direct copy buttons.
- **Action Palette & Inspector Integration**: Added "Password History" contextual action (`Ctrl+H`) in Action Palette (`Ctrl+K`) and an item history entry in Item Inspector.
- **Global Field Visibility Toggle (`Ctrl+T`)**: Promoted `Ctrl+T` to a global shortcut to toggle masking/revealing of sensitive attributes (passwords, private keys, card details, custom hidden fields) as well as password history items.
- **TOTP Shortcut Migration (`Ctrl+Enter`)**: Migrated live TOTP copying from `Ctrl+T` to `Ctrl+Enter` (`Ctrl+↵`) to eliminate shortcut conflicts.
- **Documentation & Cheat Sheet Updates**: Updated `README.md`, `README.zh-CN.md`, `CONTEXT.md`, and `EmptyInspector.qml` with the updated keybindings.

## Breaking Changes
- **TOTP Shortcut Changed**: The live TOTP copy shortcut has been changed from `Ctrl+T` to `Ctrl+Enter` (`Ctrl+↵`).
- **Field Visibility Shortcut**: `Ctrl+T` is now assigned to toggle masked field/secret visibility across the inspector and modal overlays.