### PR TITLE
chore(ci): configure develop branch workflow and update git guidelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - develop
       - feat/*
       - fix/*
   pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   test:

--- a/docs/agents/git.md
+++ b/docs/agents/git.md
@@ -4,10 +4,12 @@ All implementation and bugfix tasks must follow a strict branch-and-PR workflow 
 
 ## Rules
 
-1. **Never commit directly to `main`**:
-   - Always branch off `main` before starting any implementation, bugfix, or chore:
+1. **Branch Strategy (`main` vs `develop`)**:
+   - `main`: **Production / Stable Release Branch** and the default GitHub branch. End-users install plugins and download releases from `main`. Direct commits are strictly forbidden. Only Release PRs (from `develop`) or emergency hotfixes merge into `main`.
+   - `develop`: **Active Integration Branch**. All feature branches, bugfixes, refactors, and chores must branch off `develop` and target `develop` for PRs.
+   - Always branch off `develop` before starting any work:
      ```bash
-     git checkout main && git pull
+     git checkout develop && git pull
      git checkout -b <type>/<short-description-or-issue>
      ```
    - Standard branch naming conventions:
@@ -47,21 +49,34 @@ All implementation and bugfix tasks must follow a strict branch-and-PR workflow 
      ```bash
      git push -u origin HEAD
      ```
-   - Create PR linking the issue:
+   - Create PR targeting `develop` (linking the issue if applicable):
      ```bash
-     gh pr create --title "<type>(<scope>): <summary>" --body "Closes #<issue_number>
+     gh pr create --base develop --title "<type>(<scope>): <summary>" --body "Closes #<issue_number>
 
      ## Summary of Changes
      - ..."
      ```
 
 5. **Merge PR & Clean Up**:
-   - Merge the pull request (squash or merge):
+   - Merge the pull request into `develop` (squash or rebase):
      ```bash
      gh pr merge --squash --delete-branch
      ```
-   - Sync local `main`:
+   - Sync local `develop`:
+     ```bash
+     git checkout develop && git pull
+     ```
+
+6. **Release Lifecycle (Promoting `develop` to `main`)**:
+   - When preparing a new release, open a Release PR from `develop` into `main`:
+     ```bash
+     gh pr create --base main --head develop --title "chore(release): release <version>" --body "Promote develop to main for release."
+     ```
+   - After merging into `main`, tag the release on `main` to trigger automated GitHub Actions workflows:
      ```bash
      git checkout main && git pull
+     git tag -a omawarden-v<version> -m "Release omawarden v<version>"
+     git push origin omawarden-v<version>
      ```
+
 


### PR DESCRIPTION
## Summary of Changes
- Add `develop` branch to CI push and pull_request event triggers in `.github/workflows/ci.yml`
- Update `docs/agents/git.md` to formalize the dual-branch strategy:
  - `main` remains GitHub default branch & stable production release branch
  - `develop` becomes active integration branch for feature/fix/chore PRs
  - Added release promotion lifecycle instructions (`develop` -> `main` -> tag)
