### PR TITLE
fix(ui): preserve selected index binding and initialize on overlay open

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -168,6 +168,7 @@ Item {
     root.activeAttachmentPreview = null
     root.loadingAttachmentId = ""
     root.searchQuery = ""
+    root.selectedIndex = 0
     root.refreshHealth()
     root.refreshConfig()
     root.refreshAuthStatus()

--- a/components/VaultItemList.qml
+++ b/components/VaultItemList.qml
@@ -19,9 +19,12 @@ Item {
 
   onSelectedIndexChanged: {
     if (selectedIndex >= 0 && items && selectedIndex < items.length) {
-      if (listView.currentIndex !== selectedIndex) {
-        listView.currentIndex = selectedIndex
-      }
+      listView.positionViewAtIndex(selectedIndex, ListView.Contain)
+    }
+  }
+
+  onItemsChanged: {
+    if (selectedIndex >= 0 && items && selectedIndex < items.length) {
       listView.positionViewAtIndex(selectedIndex, ListView.Contain)
     }
   }
@@ -137,14 +140,10 @@ Item {
       }
     }
 
-    onCurrentIndexChanged: {
-      if (currentIndex !== itemListRoot.selectedIndex) {
-        itemListRoot.itemSelected(currentIndex)
-      }
-    }
-
     delegate: Rectangle {
       id: itemDelegate
+      required property int index
+      required property var modelData
       property bool isSelected: index === itemListRoot.selectedIndex
       width: listView.width
       height: 48
@@ -285,11 +284,9 @@ Item {
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-          itemListRoot.selectedIndex = index
           itemListRoot.itemSelected(index)
         }
         onDoubleClicked: {
-          itemListRoot.selectedIndex = index
           itemListRoot.itemTriggered(index)
         }
       }


### PR DESCRIPTION
## Summary of Changes
- Remove imperative `itemListRoot.selectedIndex = index` assignments from mouse click handlers in `VaultItemList.qml` to prevent breaking declarative QML property binding with `root.selectedIndex`
- Remove `listView.onCurrentIndexChanged` reverse assignment to eliminate desynchronization and feedback loops during model changes
- Reset `root.selectedIndex = 0` on overlay `open()` in `OmarchyBitwarden.qml` to ensure the first item is reliably focused on open
- Declare `required property int index` and `required property var modelData` on list item delegate for standard Qt 6 property tracking
- Add `onItemsChanged` position synchronization in `VaultItemList.qml`