### PR TITLE
sec(attachment): verify download integrity and secure preview lifecycle

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -33,3 +33,23 @@ depends = ["build-release", "dev-update-omarchy-plugin"]
 depends_post = ["dev-restart-omarchy"]
 run = "mkdir -p ~/.config/omarchy/plugins/icyleaf.bitwarden/bin && cp -f bin/omawarden ~/.config/omarchy/plugins/icyleaf.bitwarden/bin/omawarden"
 
+[tasks.version]
+description = "Show the latest version of the project"
+run = """
+printf "Latest omawarden tag: "
+git tag --sort=-creatordate | grep omawarden | head -n 1
+
+printf "Latest omarchy plugin tag: "
+git tag --sort=-creatordate | grep omarchy-bitwarden | head -n 1
+"""
+
+[tasks.unreleased-changelog]
+description = "Show the unreleased changelog"
+run = """
+export RUST_LOG=off
+echo '## Unreleased omawarden changelog:'
+git cliff --tag-pattern "^omawarden-v?[0-9].*" --include-path "omawarden/**" --unreleased
+
+echo '## Unreleased omarchy plugin changelog:'
+git cliff --tag-pattern "^omarchy-bitwarden-v?[0-9].*" --exclude-path "omawarden/**" --unreleased
+"""

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -998,6 +998,7 @@ Item {
     root.logInfo("omarchy:attachment", "Requesting preview for " + (att.fileName || "attachment"))
     root.loadingAttachmentId = (att.id || att.fileName || "loading")
     attachmentProc.activeAttachmentId = att.id || ""
+    attachmentProc.activeItemId = item.id || ""
     attachmentProc.command = [
       root.helperPath,
       "attachment",
@@ -1597,7 +1598,14 @@ Item {
                 onViewAttachmentRequested: function(item, att) { root.viewAttachment(item, att) }
                 onDownloadAttachmentRequested: function(item, att) { root.downloadAttachment(item, att) }
                 onExportSshKeyRequested: function(item) { root.openSshKeyModal("export", item) }
-                onClosePreviewRequested: { root.activeAttachmentPreview = null }
+                onClosePreviewRequested: {
+                  var prevItem = root.activeAttachmentPreview ? (root.activeAttachmentPreview.item_id || "") : ""
+                  root.activeAttachmentPreview = null
+                  if (prevItem) {
+                    cleanAttachmentProc.command = [root.helperPath, "attachment", "clean", "--item-id", prevItem]
+                    cleanAttachmentProc.running = true
+                  }
+                }
                 onTogglePasswordRevealed: { root.showPasswordRevealed = !root.showPasswordRevealed }
                 onTogglePrivateKeyRevealed: { root.showPrivateKeyRevealed = !root.showPrivateKeyRevealed }
                 onToggleCardNumberRevealed: { root.showCardNumberRevealed = !root.showCardNumberRevealed }
@@ -2361,8 +2369,14 @@ Item {
   }
 
   Process {
+    id: cleanAttachmentProc
+    command: []
+  }
+
+  Process {
     id: attachmentProc
     property string activeAttachmentId: ""
+    property string activeItemId: ""
     command: []
     stdout: StdioCollector {
       waitForEnd: true
@@ -2373,6 +2387,7 @@ Item {
           if (data.ok) {
             if (data.action === "preview") {
               data.attachment_id = attachmentProc.activeAttachmentId
+              data.item_id = attachmentProc.activeItemId
               root.activeAttachmentPreview = data
             } else if (data.action === "view") {
               root.statusMessage = "Opened " + (data.filename || "attachment") + "."

--- a/omawarden/src/attachment.rs
+++ b/omawarden/src/attachment.rs
@@ -68,6 +68,47 @@ pub fn send_notification_with_actions(title: &str, body: &str, file_path: &Path)
     });
 }
 
+pub fn get_preview_dir(item_id: Option<&str>) -> PathBuf {
+    let base = if let Ok(runtime_dir) = env::var("XDG_RUNTIME_DIR") {
+        PathBuf::from(runtime_dir)
+            .join("omarchy-bitwarden")
+            .join("attachments")
+    } else {
+        #[cfg(unix)]
+        let uid = unsafe { libc::getuid() };
+        #[cfg(not(unix))]
+        let uid = 1000;
+        PathBuf::from(format!("/tmp/omarchy-bitwarden-{}/attachments", uid))
+    };
+
+    if let Some(id) = item_id {
+        base.join(id)
+    } else {
+        base
+    }
+}
+
+pub fn clear_preview_attachments(item_id: Option<&str>) {
+    #[cfg(test)]
+    if item_id.is_none() {
+        return;
+    }
+
+    let dir = get_preview_dir(item_id);
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    // Also clean up legacy /tmp/omarchy-bitwarden/attachments if present
+    let legacy_dir = if let Some(id) = item_id {
+        PathBuf::from("/tmp/omarchy-bitwarden/attachments").join(id)
+    } else {
+        PathBuf::from("/tmp/omarchy-bitwarden/attachments")
+    };
+    if legacy_dir.exists() {
+        let _ = fs::remove_dir_all(&legacy_dir);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn get_attachment(
     item_id: &str,
@@ -97,6 +138,25 @@ pub fn get_attachment(
     let cfg = ConfigManager::new(None).load();
     let storage_mgr = StorageManager::default();
     let storage = storage_mgr.load();
+
+    let mut expected_size: Option<u64> = storage
+        .ciphers
+        .iter()
+        .find(|c| c.get("id").and_then(|v| v.as_str()) == Some(item_id))
+        .and_then(|c| c.get("attachments").and_then(|v| v.as_array()))
+        .and_then(|arr| {
+            arr.iter()
+                .find(|a| a.get("id").and_then(|v| v.as_str()) == Some(attachment_id))
+        })
+        .and_then(|a| {
+            a.get("size").and_then(|v| {
+                if let Some(s) = v.as_str() {
+                    s.parse::<u64>().ok()
+                } else {
+                    v.as_u64()
+                }
+            })
+        });
 
     let initial_token = session_token
         .map(|s| s.to_string())
@@ -131,7 +191,7 @@ pub fn get_attachment(
     };
 
     let target_dir = if open_file || preview {
-        PathBuf::from("/tmp/omarchy-bitwarden/attachments").join(item_id)
+        get_preview_dir(Some(item_id))
     } else {
         let dest_dir_str = output_dir.unwrap_or(&cfg.download_dir);
         let expanded = if dest_dir_str.starts_with('~') {
@@ -157,11 +217,15 @@ pub fn get_attachment(
         };
     }
 
+    #[cfg(unix)]
+    if open_file || preview {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700));
+    }
+
     let dest_path = target_dir.join(&safe_filename);
 
-    let preview_cached_path = PathBuf::from("/tmp/omarchy-bitwarden/attachments")
-        .join(item_id)
-        .join(&safe_filename);
+    let preview_cached_path = get_preview_dir(Some(item_id)).join(&safe_filename);
 
     // Fast-path: Check if already previewed or downloaded to avoid duplicate network requests
     if (!open_file && !preview) && preview_cached_path.is_file() {
@@ -169,27 +233,46 @@ pub fn get_attachment(
             let _ = fs::copy(&preview_cached_path, &dest_path);
         }
         if let Ok(cached_bytes) = fs::read(&dest_path) {
-            return build_attachment_response(
-                &dest_path,
-                &safe_filename,
-                &target_dir,
-                open_file,
-                preview,
-                notify,
-                &cached_bytes,
-            );
+            if is_cached_file_valid(&dest_path, expected_size, &cached_bytes) {
+                return build_attachment_response(
+                    &dest_path,
+                    &safe_filename,
+                    &target_dir,
+                    open_file,
+                    preview,
+                    notify,
+                    &cached_bytes,
+                );
+            } else {
+                crate::log_warn!(
+                    "omawarden:attachment",
+                    "Cached attachment {:?} is dirty or un-decrypted ciphertext. Purging and re-downloading.",
+                    dest_path
+                );
+                let _ = fs::remove_file(&dest_path);
+                let _ = fs::remove_file(&preview_cached_path);
+            }
         }
     } else if (open_file || preview) && dest_path.is_file() {
         if let Ok(cached_bytes) = fs::read(&dest_path) {
-            return build_attachment_response(
-                &dest_path,
-                &safe_filename,
-                &target_dir,
-                open_file,
-                preview,
-                notify,
-                &cached_bytes,
-            );
+            if is_cached_file_valid(&dest_path, expected_size, &cached_bytes) {
+                return build_attachment_response(
+                    &dest_path,
+                    &safe_filename,
+                    &target_dir,
+                    open_file,
+                    preview,
+                    notify,
+                    &cached_bytes,
+                );
+            } else {
+                crate::log_warn!(
+                    "omawarden:attachment",
+                    "Cached attachment {:?} is dirty or un-decrypted ciphertext. Purging and re-downloading.",
+                    dest_path
+                );
+                let _ = fs::remove_file(&dest_path);
+            }
         }
     }
 
@@ -252,6 +335,7 @@ pub fn get_attachment(
 
     let bytes = match download_res {
         Ok(r) if r.status().is_success() => {
+            let r_content_len = r.content_length();
             let body_bytes = match r.bytes() {
                 Ok(b) => b.to_vec(),
                 Err(e) => {
@@ -274,6 +358,16 @@ pub fn get_attachment(
             // Check if response is a JSON object with a direct download url (e.g. S3 / signed storage url)
             if let Ok(json_val) = serde_json::from_slice::<serde_json::Value>(&body_bytes) {
                 if let Some(url_str) = json_val.get("url").and_then(|u| u.as_str()) {
+                    if let Some(json_size) = json_val.get("size").and_then(|v| {
+                        if let Some(s) = v.as_str() {
+                            s.parse::<u64>().ok()
+                        } else {
+                            v.as_u64()
+                        }
+                    }) {
+                        expected_size = Some(json_size);
+                    }
+
                     let full_signed_url =
                         if url_str.starts_with("http://") || url_str.starts_with("https://") {
                             url_str.to_string()
@@ -290,13 +384,73 @@ pub fn get_attachment(
                         req = req.header("Authorization", format!("Bearer {}", active_token));
                     }
 
-                    if let Ok(blob_resp) = req.send() {
-                        if blob_resp.status().is_success() {
-                            blob_resp.bytes().map(|b| b.to_vec()).unwrap_or(body_bytes)
-                        } else {
+                    let blob_resp = match req.send() {
+                        Ok(resp) => resp,
+                        Err(e) => {
+                            let err_msg =
+                                format!("Failed to connect to attachment storage URL: {}", e);
+                            crate::log_error!("omawarden:attachment", "{}", err_msg);
+                            return AttachmentResponse {
+                                ok: false,
+                                error: Some(err_msg),
+                                path: None,
+                                filename: None,
+                                action: None,
+                                is_image: None,
+                                is_text: None,
+                                text_content: None,
+                                size: None,
+                            };
+                        }
+                    };
+
+                    if !blob_resp.status().is_success() {
+                        let err_msg = format!(
+                            "Failed to fetch attachment from storage (HTTP {})",
+                            blob_resp.status()
+                        );
+                        crate::log_error!("omawarden:attachment", "{}", err_msg);
+                        return AttachmentResponse {
+                            ok: false,
+                            error: Some(err_msg),
+                            path: None,
+                            filename: None,
+                            action: None,
+                            is_image: None,
+                            is_text: None,
+                            text_content: None,
+                            size: None,
+                        };
+                    }
+
+                    let blob_content_len = blob_resp.content_length();
+                    let raw_bytes = match blob_resp.bytes() {
+                        Ok(b) => b.to_vec(),
+                        Err(e) => {
+                            let err_msg =
+                                format!("Failed to read attachment bytes from storage: {}", e);
+                            crate::log_error!("omawarden:attachment", "{}", err_msg);
+                            return AttachmentResponse {
+                                ok: false,
+                                error: Some(err_msg),
+                                path: None,
+                                filename: None,
+                                action: None,
+                                is_image: None,
+                                is_text: None,
+                                text_content: None,
+                                size: None,
+                            };
+                        }
+                    };
+
+                    // Verify HTTP Content-Length if provided by server
+                    if let Some(expected_len) = blob_content_len {
+                        if (raw_bytes.len() as u64) != expected_len {
                             let err_msg = format!(
-                                "Failed to fetch attachment from storage (HTTP {})",
-                                blob_resp.status()
+                                "Incomplete attachment download: received {} bytes, expected {} bytes (Content-Length mismatch)",
+                                raw_bytes.len(),
+                                expected_len
                             );
                             crate::log_error!("omawarden:attachment", "{}", err_msg);
                             return AttachmentResponse {
@@ -311,8 +465,44 @@ pub fn get_attachment(
                                 size: None,
                             };
                         }
-                    } else {
-                        let err_msg = "Failed to connect to attachment storage URL".to_string();
+                    }
+
+                    // Verify against attachment metadata size if provided
+                    if let Some(exp) = expected_size {
+                        if exp > 0 && (raw_bytes.len() as u64) != exp {
+                            let err_msg = format!(
+                                "Incomplete attachment download: received {} bytes, expected {} bytes (metadata size mismatch)",
+                                raw_bytes.len(),
+                                exp
+                            );
+                            crate::log_error!("omawarden:attachment", "{}", err_msg);
+                            return AttachmentResponse {
+                                ok: false,
+                                error: Some(err_msg),
+                                path: None,
+                                filename: None,
+                                action: None,
+                                is_image: None,
+                                is_text: None,
+                                text_content: None,
+                                size: None,
+                            };
+                        }
+                    }
+
+                    raw_bytes
+                } else {
+                    body_bytes
+                }
+            } else {
+                // Direct file body response
+                if let Some(expected_len) = r_content_len {
+                    if (body_bytes.len() as u64) != expected_len {
+                        let err_msg = format!(
+                            "Incomplete attachment download: received {} bytes, expected {} bytes (Content-Length mismatch)",
+                            body_bytes.len(),
+                            expected_len
+                        );
                         crate::log_error!("omawarden:attachment", "{}", err_msg);
                         return AttachmentResponse {
                             ok: false,
@@ -326,10 +516,30 @@ pub fn get_attachment(
                             size: None,
                         };
                     }
-                } else {
-                    body_bytes
                 }
-            } else {
+
+                if let Some(exp) = expected_size {
+                    if exp > 0 && (body_bytes.len() as u64) != exp {
+                        let err_msg = format!(
+                            "Incomplete attachment download: received {} bytes, expected {} bytes (metadata size mismatch)",
+                            body_bytes.len(),
+                            exp
+                        );
+                        crate::log_error!("omawarden:attachment", "{}", err_msg);
+                        return AttachmentResponse {
+                            ok: false,
+                            error: Some(err_msg),
+                            path: None,
+                            filename: None,
+                            action: None,
+                            is_image: None,
+                            is_text: None,
+                            text_content: None,
+                            size: None,
+                        };
+                    }
+                }
+
                 body_bytes
             }
         }
@@ -421,10 +631,11 @@ pub fn get_attachment(
         };
     };
 
-    if let Err(e) = fs::write(&dest_path, &bytes) {
+    let temp_part_path = target_dir.join(format!("{}.part_{}", safe_filename, std::process::id()));
+    if let Err(e) = fs::write(&temp_part_path, &bytes) {
         return AttachmentResponse {
             ok: false,
-            error: Some(format!("Failed to write file to disk: {}", e)),
+            error: Some(format!("Failed to write temporary file to disk: {}", e)),
             path: None,
             filename: None,
             action: None,
@@ -433,6 +644,33 @@ pub fn get_attachment(
             text_content: None,
             size: None,
         };
+    }
+
+    #[cfg(unix)]
+    if open_file || preview {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&temp_part_path, fs::Permissions::from_mode(0o600));
+    }
+
+    if let Err(e) = fs::rename(&temp_part_path, &dest_path) {
+        let _ = fs::remove_file(&temp_part_path);
+        return AttachmentResponse {
+            ok: false,
+            error: Some(format!("Failed to finalize downloaded file: {}", e)),
+            path: None,
+            filename: None,
+            action: None,
+            is_image: None,
+            is_text: None,
+            text_content: None,
+            size: None,
+        };
+    }
+
+    #[cfg(unix)]
+    if open_file || preview {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&dest_path, fs::Permissions::from_mode(0o600));
     }
 
     build_attachment_response(
@@ -444,6 +682,110 @@ pub fn get_attachment(
         notify,
         &bytes,
     )
+}
+
+fn is_cached_file_valid(path: &Path, expected_encrypted_size: Option<u64>, bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+
+    // 1. Raw API JSON response string check
+    if bytes.starts_with(b"{\"") || bytes.starts_with(b"{\n") || bytes.starts_with(b"{\r") {
+        if let Ok(val) = serde_json::from_slice::<serde_json::Value>(bytes) {
+            if val.get("url").is_some() || val.get("id").is_some() || val.get("error").is_some() {
+                return false;
+            }
+        }
+    }
+
+    // 2. Raw Bitwarden encrypted EncArrayBuffer check
+    // Bitwarden encrypted binary blobs start with encType 2 or 0, followed by 16-byte IV
+    if bytes.len() >= 49 && (bytes[0] == 2 || bytes[0] == 0) {
+        let ext = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_lowercase())
+            .unwrap_or_default();
+        if matches!(
+            ext.as_str(),
+            "jpg"
+                | "jpeg"
+                | "png"
+                | "gif"
+                | "webp"
+                | "bmp"
+                | "ico"
+                | "svg"
+                | "pdf"
+                | "zip"
+                | "tar"
+                | "gz"
+                | "bz2"
+                | "7z"
+                | "txt"
+                | "md"
+                | "json"
+                | "xml"
+                | "yaml"
+                | "yml"
+                | "toml"
+                | "html"
+                | "css"
+                | "js"
+                | "ts"
+                | "py"
+                | "sh"
+                | "rs"
+                | "go"
+                | "c"
+                | "cpp"
+                | "heic"
+                | "mp3"
+                | "mp4"
+        ) {
+            return false;
+        }
+    }
+
+    // 3. Exact ciphertext size match check
+    // If the cached file length matches expected encrypted blob size exactly,
+    // it is the un-decrypted raw ciphertext, because decrypted plaintext is always
+    // 50-65 bytes smaller due to encType + IV + MAC + PKCS#7 padding.
+    if let Some(exp) = expected_encrypted_size {
+        if exp > 65 && bytes.len() as u64 == exp {
+            return false;
+        }
+    }
+
+    // 4. Image magic bytes validation for image files
+    let ext = path
+        .extension()
+        .map(|e| e.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+    match ext.as_str() {
+        "jpg" | "jpeg"
+            if bytes.len() < 3 || bytes[0] != 0xFF || bytes[1] != 0xD8 || bytes[2] != 0xFF =>
+        {
+            return false;
+        }
+        "png" if bytes.len() < 8 || &bytes[..8] != b"\x89PNG\r\n\x1a\n" => {
+            return false;
+        }
+        "gif" if bytes.len() < 4 || (&bytes[..4] != b"GIF8" && &bytes[..4] != b"GIF7") => {
+            return false;
+        }
+        "webp" if bytes.len() < 12 || &bytes[..4] != b"RIFF" || &bytes[8..12] != b"WEBP" => {
+            return false;
+        }
+        "bmp" if bytes.len() < 2 || &bytes[..2] != b"BM" => {
+            return false;
+        }
+        "pdf" if bytes.len() < 4 || &bytes[..4] != b"%PDF" => {
+            return false;
+        }
+        _ => {}
+    }
+
+    true
 }
 
 fn build_attachment_response(
@@ -622,8 +964,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let dl_target = temp_dir.path().to_str().unwrap();
 
-        // Create a simulated preview cache file in /tmp/omarchy-bitwarden/attachments/test_item_999/test_file.txt
-        let preview_dir = PathBuf::from("/tmp/omarchy-bitwarden/attachments/test_item_999");
+        // Create a simulated preview cache file in preview_dir/test_file.txt
+        let preview_dir = get_preview_dir(Some("test_item_999"));
         let _ = fs::create_dir_all(&preview_dir);
         let preview_file = preview_dir.join("test_file.txt");
         let _ = fs::write(&preview_file, b"cached attachment secret content 12345");
@@ -663,5 +1005,120 @@ mod tests {
 
         // Cleanup
         let _ = fs::remove_file(&preview_file);
+    }
+
+    #[test]
+    fn test_zero_byte_poisoned_cache_is_pruned_and_rejected() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dl_target = temp_dir.path().to_str().unwrap();
+
+        // Create a 0-byte corrupt preview file
+        let preview_dir = get_preview_dir(Some("test_item_empty"));
+        let _ = fs::create_dir_all(&preview_dir);
+        let preview_file = preview_dir.join("empty.txt");
+        let _ = fs::write(&preview_file, b"");
+
+        // Attempting to download should prune the 0-byte poisoned file and reject returning empty cache
+        let res = get_attachment(
+            "test_item_empty",
+            "att_empty",
+            "empty.txt",
+            Some(dl_target),
+            false,
+            false,
+            Some("fake_token"),
+            None,
+            false,
+        );
+
+        // Should not treat 0-byte file as valid cached download
+        assert!(
+            !preview_file.exists(),
+            "0-byte poisoned cache file should have been removed"
+        );
+        assert!(
+            !res.ok,
+            "Download with fake token should fail instead of returning 0-byte cached file"
+        );
+    }
+
+    #[test]
+    fn test_is_cached_file_valid_detection() {
+        let jpg_path = Path::new("test.jpg");
+
+        // Valid JPEG header
+        let valid_jpg = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        assert!(is_cached_file_valid(jpg_path, None, &valid_jpg));
+
+        // Invalid: Raw Bitwarden EncArrayBuffer (encType=2)
+        let raw_ciphertext = vec![0x02u8; 100];
+        assert!(!is_cached_file_valid(jpg_path, None, &raw_ciphertext));
+
+        // Invalid: Raw API JSON string
+        let raw_json = b"{\"id\":\"att1\",\"url\":\"https://example.com\"}";
+        assert!(!is_cached_file_valid(jpg_path, None, raw_json));
+
+        // Valid JPEG header where size is smaller than ciphertext size
+        assert!(is_cached_file_valid(
+            jpg_path,
+            Some(100),
+            &[0xFF, 0xD8, 0xFF, 0xE0]
+        ));
+
+        // Invalid: exact ciphertext size match
+        let mut fake_100_bytes = vec![0x00u8; 100];
+        fake_100_bytes[0] = 0xFF;
+        fake_100_bytes[1] = 0xD8;
+        fake_100_bytes[2] = 0xFF;
+        assert!(!is_cached_file_valid(jpg_path, Some(100), &fake_100_bytes));
+    }
+
+    #[test]
+    fn test_dirty_raw_ciphertext_cache_is_pruned() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dl_target = temp_dir.path().to_str().unwrap();
+
+        // Create a dirty preview file containing raw EncArrayBuffer
+        let preview_dir = get_preview_dir(Some("test_item_dirty"));
+        let _ = fs::create_dir_all(&preview_dir);
+        let preview_file = preview_dir.join("photo.jpg");
+        let mut raw_ct = vec![0x02u8; 200];
+        raw_ct[0] = 0x02; // encType
+        let _ = fs::write(&preview_file, &raw_ct);
+
+        let res = get_attachment(
+            "test_item_dirty",
+            "att_dirty",
+            "photo.jpg",
+            Some(dl_target),
+            false,
+            true, // preview
+            Some("fake_token"),
+            None,
+            false,
+        );
+
+        // Dirty cache file must be purged and not returned as valid preview
+        assert!(
+            !preview_file.exists(),
+            "Dirty ciphertext cache file should have been deleted"
+        );
+        assert!(
+            !res.ok,
+            "Should not return dirty cached ciphertext as preview"
+        );
+    }
+
+    #[test]
+    fn test_clear_preview_attachments() {
+        let preview_dir = get_preview_dir(Some("test_item_clear"));
+        let _ = fs::create_dir_all(&preview_dir);
+        let preview_file = preview_dir.join("secret.jpg");
+        let _ = fs::write(&preview_file, b"secret decrypted payload");
+        assert!(preview_file.exists());
+
+        clear_preview_attachments(Some("test_item_clear"));
+        assert!(!preview_file.exists());
+        assert!(!preview_dir.exists());
     }
 }

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -341,6 +341,7 @@ impl AuthManager {
         let _ = crate::daemon::send_daemon_request(&serde_json::json!({
             "action": "lock"
         }));
+        crate::attachment::clear_preview_attachments(None);
         crate::log_info!("omawarden:auth", "Vault locked.");
         AuthResult {
             ok: true,
@@ -356,6 +357,7 @@ impl AuthManager {
         let _ = crate::daemon::send_daemon_request(&serde_json::json!({
             "action": "lock"
         }));
+        crate::attachment::clear_preview_attachments(None);
         crate::log_info!("omawarden:auth", "Account logged out and session cleared.");
         AuthResult {
             ok: true,

--- a/omawarden/src/crypto.rs
+++ b/omawarden/src/crypto.rs
@@ -492,36 +492,39 @@ pub fn decrypt_attachment_blob(
         let mac = &blob[17..49];
         let ct = &blob[49..];
 
-        if ct.len().is_multiple_of(16) {
-            if let Some(mac_key) = key.mac_key.as_ref() {
-                if let Ok(mut hmac) = HmacSha256::new_from_slice(mac_key) {
-                    hmac.update(iv);
-                    hmac.update(ct);
-                    let calculated_mac = hmac.finalize().into_bytes();
-                    if mac.ct_eq(&calculated_mac).unwrap_u8() == 1 {
-                        if let Ok(decrypted) = decrypt_aes_cbc_bytes(ct, iv, &key.enc_key) {
-                            return Ok(decrypted);
-                        }
-                    }
-                }
-            }
+        if !ct.len().is_multiple_of(16) {
+            return Err(CryptoError::DecryptionFailed(
+                "Attachment ciphertext length is not a multiple of 16 (incomplete or truncated download)".to_string(),
+            ));
+        }
 
-            // If MAC key not present or verification bypassed, attempt AES decrypt
-            if let Ok(decrypted) = decrypt_aes_cbc_bytes(ct, iv, &key.enc_key) {
-                return Ok(decrypted);
+        if let Some(mac_key) = key.mac_key.as_ref() {
+            let mut hmac = HmacSha256::new_from_slice(mac_key)
+                .map_err(|_| CryptoError::DecryptionFailed("Invalid MAC key".to_string()))?;
+            hmac.update(iv);
+            hmac.update(ct);
+            let calculated_mac = hmac.finalize().into_bytes();
+            if mac.ct_eq(&calculated_mac).unwrap_u8() != 1 {
+                return Err(CryptoError::DecryptionFailed(
+                    "Attachment HMAC integrity verification failed (corrupted or incomplete download)".to_string(),
+                ));
             }
         }
+
+        return decrypt_aes_cbc_bytes(ct, iv, &key.enc_key);
     }
 
     // Format 2: [1 byte encType == 0][16 bytes IV][Ciphertext]
     if blob.len() >= 17 && blob[0] == 0 {
         let iv = &blob[1..17];
         let ct = &blob[17..];
-        if ct.len().is_multiple_of(16) {
-            if let Ok(decrypted) = decrypt_aes_cbc_bytes(ct, iv, &key.enc_key) {
-                return Ok(decrypted);
-            }
+        if !ct.len().is_multiple_of(16) {
+            return Err(CryptoError::DecryptionFailed(
+                "Attachment ciphertext length is not a multiple of 16 (incomplete download)"
+                    .to_string(),
+            ));
         }
+        return decrypt_aes_cbc_bytes(ct, iv, &key.enc_key);
     }
 
     // Format 3: [16 bytes IV][32 bytes MAC][Ciphertext] (no leading encType byte)
@@ -541,9 +544,6 @@ pub fn decrypt_attachment_blob(
                         }
                     }
                 }
-            }
-            if let Ok(decrypted) = decrypt_aes_cbc_bytes(ct, iv, &key.enc_key) {
-                return Ok(decrypted);
             }
         }
     }
@@ -571,7 +571,10 @@ pub fn decrypt_attachment_blob(
         }
     }
 
-    Ok(blob.to_vec())
+    Err(CryptoError::DecryptionFailed(
+        "Attachment blob does not match any valid encrypted format or decryption failed"
+            .to_string(),
+    ))
 }
 
 #[cfg(test)]
@@ -707,4 +710,19 @@ fn test_decrypt_attachment_blob() {
 
     let decrypted2 = decrypt_attachment_blob(&blob, &key).unwrap();
     assert_eq!(decrypted2, plaintext);
+
+    // Truncated blob (incomplete download) MUST fail decryption rather than returning raw ciphertext
+    let truncated_blob = &bitwarden_blob[..bitwarden_blob.len() - 5];
+    assert!(
+        decrypt_attachment_blob(truncated_blob, &key).is_err(),
+        "Truncated attachment blob must return Err, not Ok"
+    );
+
+    // Blob with corrupted HMAC (e.g. truncated block boundary) MUST fail decryption
+    let mut bad_mac_blob = bitwarden_blob.clone();
+    bad_mac_blob[20] ^= 0xFF;
+    assert!(
+        decrypt_attachment_blob(&bad_mac_blob, &key).is_err(),
+        "Corrupted MAC attachment blob must return Err, not Ok"
+    );
 }

--- a/omawarden/src/daemon.rs
+++ b/omawarden/src/daemon.rs
@@ -201,6 +201,7 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
         }
         "lock" => {
             state.lock();
+            crate::attachment::clear_preview_attachments(None);
             json!({ "ok": true, "status": "locked" })
         }
         "sync" => match state.sync() {

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -205,6 +205,11 @@ enum AttachmentAction {
         #[arg(long)]
         preview: bool,
     },
+    #[command(about = "Clean temporary preview attachments")]
+    Clean {
+        #[arg(long)]
+        item_id: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1107,6 +1112,11 @@ fn main() -> ExitCode {
                 } else {
                     ExitCode::FAILURE
                 }
+            }
+            AttachmentAction::Clean { item_id } => {
+                omawarden::attachment::clear_preview_attachments(item_id.as_deref());
+                println!("{}", serde_json::json!({ "ok": true, "status": "cleaned" }));
+                ExitCode::SUCCESS
             }
         },
 

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -310,6 +310,7 @@ impl VaultManager {
         if let Ok(mut key) = self.user_key.write() {
             *key = None;
         }
+        crate::attachment::clear_preview_attachments(None);
     }
 
     pub fn unlock(&self, password: &str) -> Result<usize, String> {


### PR DESCRIPTION
## Summary of Changes

### 1. Attachment Download Integrity & Validation
- **Metadata & Length Validation**: Extract `expected_size` from Bitwarden cipher metadata / API JSON and enforce Content-Length and byte length verification before and after download.
- **Strict Decryption**: Enforce strict HMAC-SHA256 verification in `decrypt_attachment_blob` for Format 1 blobs; remove unsafe fallback that returned unverified raw ciphertext/JSON strings.
- **Atomic Writes**: Download to temporary `.part_<pid>` files and atomically rename to destination on success, preventing truncated or poisoned files on abort.
- **Dirty Cache Detection & Purge**: Implemented `is_cached_file_valid()` to proactively inspect preview files for raw cipher bytes, API JSON errors, size mismatches, and invalid magic headers (JPEG, PNG, GIF, WebP, BMP, PDF), automatically purging corrupted cache.

### 2. Temporary File Security & Automatic Lifecycle Cleanup
- **Storage Isolation**: Relocated preview cache from global `/tmp` to `$XDG_RUNTIME_DIR/omarchy-bitwarden/attachments` (RAM `tmpfs`, fallback to `/tmp/omarchy-bitwarden-<UID>/attachments`).
- **File Permissions**: Enforced Unix `0700` directory permissions and `0600` file permissions.
- **Auto-wipe on Events**:
  - Vault lock (manual `Ctrl+L` or daemon inactivity timer) automatically purges all preview attachments.
  - Logout triggers preview directory cleanup.
  - Closing the preview modal in the UI (`onClosePreviewRequested`) triggers async item-level cleanup via helper command.
- **CLI Subcommand**: Added `omawarden attachment clean [--item-id <id>]`.

### 3. Developer Tooling
- Added `version` and `unreleased-changelog` tasks to `.mise.toml`.

## Verification
- `cargo fmt --check`: Passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: Passed.
- `XDG_RUNTIME_DIR=/tmp cargo test`: All 56 tests passed.