### PR TITLE
fix(ui): prevent horizontal layout overflow on long text fields

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -814,7 +814,7 @@ Item {
     var actions = []
     if (!item) {
       actions.push({ label: "Generate SSH Key", icon: "\uf067", shortcut: "", action: function() { root.openSshKeyModal("create", null) } })
-      actions.push({ label: "Import SSH Key", icon: "\uf093", shortcut: "", action: function() { root.openSshKeyModal("import", null) } })
+      actions.push({ label: "Import SSH Key", icon: "\uf019", shortcut: "", action: function() { root.openSshKeyModal("import", null) } })
       actions.push({ label: "Sync Vault Now", icon: "\uf021", shortcut: "Ctrl+R", action: function() { root.syncVault(false, true) } })
       actions.push({ label: "Lock Vault", icon: "\uf023", shortcut: "Ctrl+L", action: function() { root.doLock() } })
       return actions
@@ -889,7 +889,7 @@ Item {
       if (item.ssh_key.passphrase) actions.push({ label: "Copy Passphrase", icon: "\uf023", shortcut: "", action: function() { root.copyToClipboard(item.ssh_key.passphrase, true, "passphrase") } })
       actions.push({
         label: "Export to ~/.ssh",
-        icon: "\uf019",
+        icon: "\uf093",
         shortcut: "Ctrl+E",
         action: function() {
           root.openSshKeyModal("export", item)
@@ -986,7 +986,7 @@ Item {
     actions.push({ label: "Toggle Field Visibility", icon: "\uf06e", shortcut: "Ctrl+T", action: function() { root.toggleItemRevealed() } })
     actions.push({ label: "Copy Item Name (" + item.name + ")", icon: "\uf0c5", shortcut: "", action: function() { root.copyToClipboard(item.name, false, "item name") } })
     actions.push({ label: "Generate SSH Key", icon: "\uf067", shortcut: "", action: function() { root.openSshKeyModal("create", null) } })
-    actions.push({ label: "Import SSH Key", icon: "\uf093", shortcut: "", action: function() { root.openSshKeyModal("import", null) } })
+    actions.push({ label: "Import SSH Key", icon: "\uf019", shortcut: "", action: function() { root.openSshKeyModal("import", null) } })
     actions.push({ label: "Sync Vault Now", icon: "\uf021", shortcut: "Ctrl+R", action: function() { root.syncVault(false, true) } })
     actions.push({ label: "Lock Vault", icon: "\uf023", shortcut: "Ctrl+L", action: function() { root.doLock() } })
 

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -1550,6 +1550,7 @@ Item {
               Layout.fillHeight: true
               Layout.preferredWidth: 320
               Layout.minimumWidth: 260
+              Layout.maximumWidth: 320
               items: root.filteredItems
               selectedIndex: root.selectedIndex
               searchQuery: root.searchQuery

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -1270,7 +1270,7 @@ ScrollView {
               onClicked: { if (inspectorRoot.item && inspectorRoot.item.ssh_key) inspectorRoot.copyRequested(inspectorRoot.item.ssh_key.private_key, true, "SSH private key") }
             }
             GhostIconButton {
-              iconText: "\uf019"
+              iconText: "\uf093"
               tooltip: "Export SSH key to ~/.ssh"
               onClicked: { if (inspectorRoot.item) inspectorRoot.exportSshKeyRequested(inspectorRoot.item) }
             }

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -242,7 +242,7 @@ ScrollView {
   }
 
   ColumnLayout {
-    width: inspectorRoot.width - 16
+    width: Math.max(0, inspectorRoot.availableWidth - 12)
     spacing: 12
 
     // ----------------------------------------------------
@@ -301,6 +301,7 @@ ScrollView {
           font.weight: Font.Medium
           elide: Text.ElideRight
           Layout.fillWidth: true
+          Layout.preferredWidth: 0
         }
 
         // Open Externally
@@ -493,10 +494,12 @@ ScrollView {
 
         ColumnLayout {
           Layout.fillWidth: true
+          Layout.preferredWidth: 0
           spacing: 3
 
           RowLayout {
             Layout.fillWidth: true
+            Layout.preferredWidth: 0
             spacing: 6
 
             Text {
@@ -506,6 +509,7 @@ ScrollView {
               font.weight: Font.DemiBold
               elide: Text.ElideRight
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
             }
 
             // Monochrome Favorite Badge
@@ -584,6 +588,9 @@ ScrollView {
             text: inspectorRoot.item ? (inspectorRoot.item.sub_title || inspectorRoot.item.type_name || "Item") : ""
             color: Qt.darker(inspectorRoot.foreground, 1.6)
             font.pixelSize: 11
+            elide: Text.ElideRight
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
           }
         }
       }
@@ -614,6 +621,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Username"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -623,6 +631,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -649,6 +658,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Password"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -659,6 +669,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -711,6 +722,7 @@ ScrollView {
 
                 ColumnLayout {
                   Layout.fillWidth: true
+                  Layout.preferredWidth: 0
                   spacing: 2
                   Text { text: uriWrapper.labelText; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
                   Text {
@@ -720,6 +732,7 @@ ScrollView {
                     font.weight: Font.Medium
                     elide: Text.ElideRight
                     Layout.fillWidth: true
+                    Layout.preferredWidth: 0
                   }
                 }
 
@@ -762,6 +775,7 @@ ScrollView {
 
               ColumnLayout {
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
                 spacing: 2
 
                 RowLayout {
@@ -780,7 +794,9 @@ ScrollView {
                   font.pixelSize: 14
                   font.family: "monospace"
                   font.weight: Font.Bold
+                  elide: Text.ElideRight
                   Layout.fillWidth: true
+                  Layout.preferredWidth: 0
                 }
               }
 
@@ -823,6 +839,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
 
               Text { text: "Passkey"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
@@ -832,6 +849,7 @@ ScrollView {
                 font.pixelSize: inspectorRoot.valuePixelSize
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
           }
@@ -864,6 +882,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Cardholder"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -873,6 +892,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -899,6 +919,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Brand"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -908,6 +929,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
           }
@@ -928,6 +950,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Card Number"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -938,6 +961,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -969,6 +993,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Expires"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -979,6 +1004,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1005,6 +1031,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Security Code"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1015,6 +1042,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1057,6 +1085,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Full Name"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1066,6 +1095,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1093,6 +1123,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Email"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1102,6 +1133,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1126,6 +1158,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Phone"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1135,6 +1168,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1159,6 +1193,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Address"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1168,6 +1203,7 @@ ScrollView {
                 font.weight: Font.Medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1208,6 +1244,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Private Key"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1218,6 +1255,7 @@ ScrollView {
                 font.weight: Font.Medium
                 wrapMode: Text.WrapAnywhere
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1252,6 +1290,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Public Key"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1262,6 +1301,7 @@ ScrollView {
                 font.weight: Font.Medium
                 wrapMode: Text.WrapAnywhere
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1286,6 +1326,7 @@ ScrollView {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
               spacing: 2
               Text { text: "Fingerprint"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
               Text {
@@ -1296,6 +1337,7 @@ ScrollView {
                 font.weight: Font.Medium
                 wrapMode: Text.WrapAnywhere
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
               }
             }
 
@@ -1341,11 +1383,12 @@ ScrollView {
 
           Text {
             Layout.fillWidth: true
+            Layout.preferredWidth: 0
             text: inspectorRoot.item ? (inspectorRoot.item.notes || "") : ""
             color: inspectorRoot.foreground
             font.pixelSize: inspectorRoot.valuePixelSize
             lineHeight: 1.35
-            wrapMode: Text.Wrap
+            wrapMode: Text.WrapAnywhere
             textFormat: Text.PlainText
           }
         }
@@ -1426,6 +1469,7 @@ ScrollView {
 
                 ColumnLayout {
                   Layout.fillWidth: true
+                  Layout.preferredWidth: 0
                   spacing: 2
 
                   Text {
@@ -1434,6 +1478,7 @@ ScrollView {
                     font.pixelSize: inspectorRoot.keyPixelSize
                     elide: Text.ElideRight
                     Layout.fillWidth: true
+                    Layout.preferredWidth: 0
                   }
 
                   Text {
@@ -1444,6 +1489,7 @@ ScrollView {
                     font.weight: Font.Medium
                     elide: Text.ElideRight
                     Layout.fillWidth: true
+                    Layout.preferredWidth: 0
                   }
                 }
 
@@ -1523,6 +1569,7 @@ ScrollView {
 
                 ColumnLayout {
                   Layout.fillWidth: true
+                  Layout.preferredWidth: 0
                   spacing: 1
 
                   Text {
@@ -1532,6 +1579,7 @@ ScrollView {
                     font.weight: Font.Medium
                     elide: Text.ElideRight
                     Layout.fillWidth: true
+                    Layout.preferredWidth: 0
                   }
                   Text {
                     text: modelData.sizeName || inspectorRoot.formatFileSize(modelData.size)
@@ -1602,6 +1650,7 @@ ScrollView {
 
               ColumnLayout {
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
                 spacing: 2
                 Text { text: "Created"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
                 Text {
@@ -1611,6 +1660,7 @@ ScrollView {
                   font.weight: Font.Medium
                   elide: Text.ElideRight
                   Layout.fillWidth: true
+                  Layout.preferredWidth: 0
                 }
               }
             }
@@ -1635,6 +1685,7 @@ ScrollView {
 
               ColumnLayout {
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
                 spacing: 2
                 Text { text: "Updated"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
                 Text {
@@ -1644,6 +1695,7 @@ ScrollView {
                   font.weight: Font.Medium
                   elide: Text.ElideRight
                   Layout.fillWidth: true
+                  Layout.preferredWidth: 0
                 }
               }
             }
@@ -1667,6 +1719,7 @@ ScrollView {
 
               ColumnLayout {
                 Layout.fillWidth: true
+                Layout.preferredWidth: 0
                 spacing: 2
                 Text { text: "Password History"; color: Qt.darker(inspectorRoot.foreground, 1.6); font.pixelSize: inspectorRoot.keyPixelSize }
                 Text {
@@ -1676,6 +1729,7 @@ ScrollView {
                   font.weight: Font.Medium
                   elide: Text.ElideRight
                   Layout.fillWidth: true
+                  Layout.preferredWidth: 0
                 }
               }
 

--- a/components/PasswordHistoryModal.qml
+++ b/components/PasswordHistoryModal.qml
@@ -142,6 +142,7 @@ Rectangle {
           font.weight: Font.DemiBold
           elide: Text.ElideRight
           Layout.fillWidth: true
+          Layout.preferredWidth: 0
         }
       }
 
@@ -215,6 +216,7 @@ Rectangle {
                     font.weight: Font.Medium
                     elide: Text.ElideRight
                     Layout.fillWidth: true
+                    Layout.preferredWidth: 0
                   }
 
                   // Toggle Mask Ghost Button

--- a/components/SearchHeader.qml
+++ b/components/SearchHeader.qml
@@ -202,7 +202,7 @@ ColumnLayout {
 
         Text {
           anchors.centerIn: parent
-          text: "\uf093"
+          text: "\uf019"
           font.family: searchHeaderRoot.fontFamily
           font.pixelSize: 10
           color: importMouse.containsMouse ? searchHeaderRoot.foreground : Qt.darker(searchHeaderRoot.foreground, 1.4)

--- a/components/SshKeyModal.qml
+++ b/components/SshKeyModal.qml
@@ -173,7 +173,7 @@ Rectangle {
         spacing: 8
 
         Text {
-          text: modalRoot.mode === "create" ? "\uf067" : (modalRoot.mode === "import" ? "\uf093" : "\uf019")
+          text: modalRoot.mode === "create" ? "\uf067" : (modalRoot.mode === "import" ? "\uf019" : "\uf093")
           font.family: modalRoot.fontFamily
           font.pixelSize: 14
           color: modalRoot.accent

--- a/components/VaultItemList.qml
+++ b/components/VaultItemList.qml
@@ -189,10 +189,12 @@ Item {
         // Title and Subtitle Column
         ColumnLayout {
           Layout.fillWidth: true
+          Layout.preferredWidth: 0
           spacing: 2
 
           RowLayout {
             Layout.fillWidth: true
+            Layout.preferredWidth: 0
             spacing: 6
 
             Text {
@@ -202,6 +204,7 @@ Item {
               font.weight: Font.Medium
               elide: Text.ElideRight
               Layout.fillWidth: true
+              Layout.preferredWidth: 0
             }
 
             // Organization Badge
@@ -274,6 +277,7 @@ Item {
             font.pixelSize: 11
             elide: Text.ElideRight
             Layout.fillWidth: true
+            Layout.preferredWidth: 0
           }
         }
       }


### PR DESCRIPTION
## Summary of Changes

Fixes horizontal layout overflow when usernames, passwords, or other fields contain extremely long text (such as Argon2 hashes or long tokens), which previously pushed action buttons off-screen and expanded the list/inspector panes.

- **VaultItemList**:
  - Added `Layout.maximumWidth: 320` to keep the item list sidebar bounded.
  - Set `Layout.preferredWidth: 0` on title/subtitle `ColumnLayout`, `RowLayout`, and `Text` to ensure proper right elision (`Text.ElideRight`).
- **ItemInspector**:
  - Bounded content column layout to `inspectorRoot.availableWidth - 12`.
  - Added `Layout.preferredWidth: 0` and right elision to Header subtitle, Username, Password, Website URIs, TOTP, Passkey, Card details, Identity fields, SSH Key fields, Custom Fields, Attachments, and Item History.
  - Updated Notes `wrapMode` from `Text.Wrap` to `Text.WrapAnywhere` to correctly wrap unbroken strings without spaces.
- **PasswordHistoryModal**:
  - Added `Layout.preferredWidth: 0` to modal title and password entries to prevent modal overflow on long text.