### PR TITLE
fix(ui): rename note category label from Notes to Secure Note

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Powered by a dedicated pure Rust engine (`omawarden`), `omarchy-bitwarden` deliv
 | <kbd>Ctrl</kbd> + <kbd>L</kbd>         | Manually lock the vault immediately                                       |
 | <kbd>Ctrl</kbd> + <kbd>R</kbd>         | Trigger manual vault sync with Bitwarden server                           |
 | <kbd>↓</kbd> / <kbd>↑</kbd>            | Navigate item list or action options (stops at boundaries)                |
-| <kbd>Tab</kbd>                         | Switch category filters (All, Logins, Cards, Identities, Notes, SSH Keys) |
+| <kbd>Tab</kbd>                         | Switch category filters (All, Logins, Cards, Identities, Secure Note, SSH Keys) |
 | <kbd>Esc</kbd>                         | Dismiss Action Palette, History modal, Settings, or hide overlay          |
 
 ---

--- a/components/CategoryTabBar.qml
+++ b/components/CategoryTabBar.qml
@@ -25,7 +25,7 @@ RowLayout {
       case "login": return "Logins"
       case "card": return "Cards"
       case "identity": return "Identities"
-      case "note": return "Notes"
+      case "note": return "Secure Note"
       case "ssh_key": return "SSH Keys"
       default: return cat
     }

--- a/components/EmptyInspector.qml
+++ b/components/EmptyInspector.qml
@@ -106,7 +106,7 @@ ScrollView {
         }
       }
       Text {
-        text: "Switch category filter (Logins, Cards, Notes, SSH)"
+        text: "Switch category filter (Logins, Cards, Secure Note, SSH)"
         color: Qt.darker(emptyInspectorRoot.foreground, 1.3)
         font.pixelSize: 10
         Layout.fillWidth: true


### PR DESCRIPTION
## Summary of Changes
- Rename category tab label in `CategoryTabBar.qml` from `Notes` to `Secure Note` to match official Bitwarden domain item type (Cipher Type 2) and avoid confusion with generic item notes fields.
- Update category filter prompt in `EmptyInspector.qml` and shortcut documentation in `README.md`.