### PR TITLE
fix(auth): fix sync failure and unlock flow when logging in via api key

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -2406,20 +2406,27 @@ Item {
         try {
           var data = JSON.parse(text)
           if (data.ok) {
-            root.statusMessage = "Logged in successfully."
+            var statusVal = data.status || "unlocked"
+            if (statusVal === "locked") {
+              root.statusMessage = "API Key authenticated. Please enter Master Password to unlock."
+            } else {
+              root.statusMessage = "Logged in successfully."
+            }
             root.searchQuery = ""
             if (authViewComponent) authViewComponent.clearInputs()
 
             root.show2FAField = false
             root.authState = ({
-              status: "unlocked",
+              status: statusVal,
               server_url: (root.authState && root.authState.server_url) || (root.config && root.config.server_url) || "",
               user_email: (root.authState && root.authState.user_email) || (root.config && root.config.email) || "",
               has_session: true
             })
             root.refreshAuthStatus()
-            root.loadVaultItems()
-            root.syncVault(true, true)
+            if (statusVal === "unlocked") {
+              root.loadVaultItems()
+              root.syncVault(true, true)
+            }
           } else {
             root.errorMessage = data.error || "Login failed."
             root.logWarn("omarchy:auth", root.errorMessage)

--- a/components/AuthView.qml
+++ b/components/AuthView.qml
@@ -44,6 +44,11 @@ Item {
     if (authState && (authState.status === "locked" || authState.status === "unlocked" || authState.status === "unauthenticated")) {
       clearInputs()
     }
+    if (authState && authState.status === "locked") {
+      Qt.callLater(function() {
+        if (unlockPasswordField) unlockPasswordField.forceActiveFocus()
+      })
+    }
   }
 
   Flickable {

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -88,7 +88,9 @@ impl AuthManager {
     pub fn get_status(&self, _verify: bool) -> AuthStatus {
         let storage = self.storage_mgr.load();
 
-        if storage.enc_user_key.is_none() || storage.user_email.is_empty() {
+        if (storage.enc_user_key.is_none() && storage.access_token.is_none())
+            || storage.user_email.is_empty()
+        {
             return AuthStatus {
                 status: "unauthenticated".to_string(),
                 server_url: if storage.server_url.is_empty() {
@@ -132,7 +134,7 @@ impl AuthManager {
                 last_sync: storage.last_sync,
                 user_email: Some(storage.user_email),
                 user_id: storage.user_id,
-                has_session: is_unlocked_same_user,
+                has_session: is_unlocked_same_user || storage.access_token.is_some(),
             };
         }
 
@@ -146,7 +148,7 @@ impl AuthManager {
             last_sync: storage.last_sync,
             user_email: Some(storage.user_email),
             user_id: storage.user_id,
-            has_session: false,
+            has_session: storage.access_token.is_some(),
         }
     }
 
@@ -192,6 +194,19 @@ impl AuthManager {
             storage.folders = sync_data.folders;
             storage.collections = sync_data.collections;
             if let Some(ref prof) = sync_data.profile {
+                if let Some(id) = prof.get("id").and_then(|v| v.as_str()) {
+                    storage.user_id = Some(id.to_string());
+                }
+                if storage.enc_user_key.is_none() {
+                    if let Some(key) = prof.get("key").and_then(|v| v.as_str()) {
+                        storage.enc_user_key = Some(key.to_string());
+                    }
+                }
+                if storage.enc_private_key.is_none() {
+                    if let Some(pk) = prof.get("privateKey").and_then(|v| v.as_str()) {
+                        storage.enc_private_key = Some(pk.to_string());
+                    }
+                }
                 if let Some(orgs) = prof.get("organizations").and_then(|v| v.as_array()) {
                     storage.organizations = orgs.clone();
                 }
@@ -262,11 +277,51 @@ impl AuthManager {
             storage.folders = sync_data.folders;
             storage.collections = sync_data.collections;
             if let Some(ref prof) = sync_data.profile {
+                if let Some(email) = prof.get("email").and_then(|v| v.as_str()) {
+                    storage.user_email = email.trim().to_lowercase();
+                }
+                if let Some(id) = prof.get("id").and_then(|v| v.as_str()) {
+                    storage.user_id = Some(id.to_string());
+                }
+                if storage.enc_user_key.is_none() {
+                    if let Some(key) = prof.get("key").and_then(|v| v.as_str()) {
+                        storage.enc_user_key = Some(key.to_string());
+                    }
+                }
+                if storage.enc_private_key.is_none() {
+                    if let Some(pk) = prof.get("privateKey").and_then(|v| v.as_str()) {
+                        storage.enc_private_key = Some(pk.to_string());
+                    }
+                }
+                if storage.kdf.is_none() {
+                    if let Some(kdf) = prof.get("kdf").and_then(|v| v.as_u64()) {
+                        storage.kdf = Some(kdf as u32);
+                    }
+                }
+                if storage.kdf_iterations.is_none() {
+                    if let Some(iter) = prof.get("kdfIterations").and_then(|v| v.as_u64()) {
+                        storage.kdf_iterations = Some(iter as u32);
+                    }
+                }
+                if storage.kdf_memory.is_none() {
+                    if let Some(mem) = prof.get("kdfMemory").and_then(|v| v.as_u64()) {
+                        storage.kdf_memory = Some(mem as u32);
+                    }
+                }
+                if storage.kdf_parallelism.is_none() {
+                    if let Some(par) = prof.get("kdfParallelism").and_then(|v| v.as_u64()) {
+                        storage.kdf_parallelism = Some(par as u32);
+                    }
+                }
                 if let Some(orgs) = prof.get("organizations").and_then(|v| v.as_array()) {
                     storage.organizations = orgs.clone();
                 }
             }
             storage.last_sync = Some(chrono::Utc::now().to_rfc3339());
+        }
+
+        if storage.user_email.is_empty() {
+            storage.user_email = client_id.trim().to_string();
         }
 
         let _ = self.storage_mgr.save(&storage);
@@ -464,5 +519,35 @@ mod tests {
         assert!(!res.ok);
         assert_eq!(res.status.as_deref(), Some("unauthenticated"));
         assert!(res.error.is_some());
+    }
+
+    #[test]
+    fn test_auth_status_with_apikey_session() {
+        let dir = tempdir().unwrap();
+        let storage_path = dir.path().join("test_apikey_status.json");
+        let storage_mgr = StorageManager::new(storage_path);
+
+        let mock_keyring = KeyringManager::new("non_existent_secret_tool_for_test");
+        let auth_mgr = AuthManager::new(
+            "https://vault.example.com",
+            Some(storage_mgr.clone()),
+            Some(mock_keyring),
+        );
+
+        // Simulate storage after API key authentication
+        let storage = VaultStorage {
+            user_email: "apikey-user@example.com".to_string(),
+            user_id: Some("user-uuid-123".to_string()),
+            access_token: Some("fake_access_token_abc".to_string()),
+            enc_user_key: Some("2.dummy_iv|dummy_ct|dummy_mac".to_string()),
+            ..Default::default()
+        };
+        storage_mgr.save(&storage).unwrap();
+
+        let st = auth_mgr.get_status(false);
+        assert_eq!(st.status, "locked");
+        assert_eq!(st.user_email.as_deref(), Some("apikey-user@example.com"));
+        assert_eq!(st.user_id.as_deref(), Some("user-uuid-123"));
+        assert!(st.has_session);
     }
 }


### PR DESCRIPTION
Closes #98

## Root Cause Analysis
1. **Frontend Hardcoded Unlocked Status**: In [OmarchyBitwarden.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/OmarchyBitwarden.qml), `authLoginProc` unconditionally assigned `root.authState.status = "unlocked"` upon successful login, regardless of whether password or API key was used. It then immediately fired `root.loadVaultItems()` and `root.syncVault(true, true)`.
2. **Bitwarden Zero-Knowledge API Key Constraint**: API key authentication authenticates the OAuth session and downloads encrypted ciphers, but leaves the vault locked (`status: "locked"`) until the user inputs their Master Password to decrypt the user symmetric key.
3. **Premature Sync Failure**: Because `omawarden vault sync` checks whether the vault is unlocked, invoking sync on a locked vault exited with code 1 (`Cannot sync vault: vault is locked. Please unlock first.`), triggering the "Vault sync failed" error banner in the UI.
4. **Missing Profile Data in omawarden**: `login_apikey` did not extract `email`, `id`, `key`, or KDF settings from the initial sync profile, leading `omawarden auth status` to incorrectly treat the session as unauthenticated.

## Summary of Changes
- **`OmarchyBitwarden.qml`**:
  - Respects `data.status` returned from the login process instead of assuming `"unlocked"`.
  - When `status === "locked"` (such as API key login), updates the status message to prompt for master password, transitions to the unlock view, and does not trigger `syncVault` or `loadVaultItems` until unlocked.
- **`components/AuthView.qml`**:
  - Automatically requests focus on `unlockPasswordField` when transitioning to `locked` status.
- **`omawarden/src/auth.rs`**:
  - Extracted `user_email`, `user_id`, `enc_user_key`, `enc_private_key`, and KDF parameters from the initial sync profile during `login_apikey` (with client ID fallback for email).
  - Also extracted `user_id` and fallback keys during `login_password`.
  - Enhanced `get_status` to recognize active API key sessions when evaluating `has_session` and authentication state.
  - Added unit test `test_auth_status_with_apikey_session`.

## Verification
- `cargo fmt --check`: Passed
- `cargo clippy --all-targets --all-features -- -D warnings`: Passed
- `XDG_RUNTIME_DIR=/tmp cargo test`: All 57 tests passed
- `qmllint OmarchyBitwarden.qml components/AuthView.qml`: Passed with 0 errors/warnings