### PR TITLE
fix(ui): prevent link double-wrapping and attribute leakage in release notes

### DIFF
--- a/components/ReleaseNotesModal.qml
+++ b/components/ReleaseNotesModal.qml
@@ -38,30 +38,42 @@ Rectangle {
     if (!text) return ""
     var escaped = escapeHtml(text)
 
-    // Markdown link: [Title](url)
+    var linkTokens = []
+    function storeLink(html) {
+      var token = "@@OMAWARDEN_LINK_" + linkTokens.length + "@@"
+      linkTokens.push(html)
+      return token
+    }
+
+    // Markdown link: [Title](url) - highest precedence
     escaped = escaped.replace(/\[([^\]]+)\]\((https?:\/\/[^\s\)]+)\)/g, function(match, title, url) {
-      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + title + "</a>"
+      return storeLink("<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + title + "</a>")
     })
 
     // GitHub PR link: https://github.com/.../pull/123 -> #123
     escaped = escaped.replace(/(https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/pull\/(\d+))/g, function(match, url, prNum) {
-      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>#" + prNum + "</a>"
+      return storeLink("<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>#" + prNum + "</a>")
     })
 
     // GitHub Commit link: https://github.com/.../commit/abcdef123 -> abcdef1
     escaped = escaped.replace(/(https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/commit\/([a-f0-9]{7,40}))/g, function(match, url, sha) {
-      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline; font-family: monospace;'>" + sha.substring(0, 7) + "</a>"
+      return storeLink("<a href='" + url + "' style='color: #60a5fa; text-decoration: underline; font-family: monospace;'>" + sha.substring(0, 7) + "</a>")
     })
 
     // GitHub Compare link: https://github.com/.../compare/v1...v2 -> v1...v2
     escaped = escaped.replace(/(https?:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/compare\/([^\s\<\>\)]+))/g, function(match, url, range) {
-      return "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + range + "</a>"
+      return storeLink("<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + range + "</a>")
     })
 
     // Other plain URLs
     escaped = escaped.replace(/(^|[\s\(])(https?:\/\/[^\s<\)]+)/g, function(match, prefix, url) {
-      return prefix + "<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + url + "</a>"
+      return prefix + storeLink("<a href='" + url + "' style='color: #60a5fa; text-decoration: underline;'>" + url + "</a>")
     })
+
+    // Restore all link tokens
+    for (var i = 0; i < linkTokens.length; i++) {
+      escaped = escaped.replace("@@OMAWARDEN_LINK_" + i + "@@", linkTokens[i])
+    }
 
     // Bold: **text**
     escaped = escaped.replace(/\*\*([^*]+)\*\*/g, "<b style='color: #ffffff;'>$1</b>")

--- a/tests/tst_release_notes_markdown.qml
+++ b/tests/tst_release_notes_markdown.qml
@@ -1,0 +1,62 @@
+import QtQuick
+import QtQuick.Controls
+import "../components"
+
+ApplicationWindow {
+  id: testRunner
+  visible: true
+  width: 400
+  height: 300
+
+  ReleaseNotesModal {
+    id: modal
+  }
+
+  function assert(condition, message) {
+    if (!condition) {
+      console.error("ASSERTION FAILED: " + message)
+      Qt.quit()
+      throw new Error("Assertion failed: " + message)
+    } else {
+      console.log("PASS: " + message)
+    }
+  }
+
+  Timer {
+    id: testTimer
+    interval: 50
+    running: true
+    repeat: false
+    onTriggered: {
+      console.log("Running Release Notes Markdown Rendering Tests...")
+
+      var rawInput = "- **(auth)**: Fix sync failure and unlock flow when logging in via api key (#99) ([7384f3f](https://github.com/icyleaf/omarchy-bitwarden/commit/7384f3f8754))"
+      var rendered = modal.renderMarkdown(rawInput)
+
+      console.log("Rendered output:\n" + rendered)
+
+      // Test 1: Should NOT contain broken attribute leakage in commit link text:
+      // e.g. 7384f3f' style='color: #60a5fa; text-decoration: underline;'>7384f3f
+      assert(rendered.indexOf("7384f3f' style=") === -1, "No broken attribute leakage in commit link text")
+      assert(rendered.indexOf("<a href='<a") === -1, "No nested <a href='<a tag corruption")
+
+      // Test 2: Commit link should be cleanly rendered
+      assert(rendered.indexOf("<a href='https://github.com/icyleaf/omarchy-bitwarden/commit/7384f3f8754'") !== -1, "Commit link has correct href")
+      assert(rendered.indexOf(">7384f3f</a>") !== -1, "Commit link has correct label")
+
+      // Test 3: PR link should be cleanly rendered
+      var prInput = "- Fix some issue ([#99](https://github.com/icyleaf/omarchy-bitwarden/pull/99))"
+      var prRendered = modal.renderMarkdown(prInput)
+      assert(prRendered.indexOf("<a href='<a") === -1, "No nested tags for markdown PR links")
+      assert(prRendered.indexOf("style='color: #60a5fa; text-decoration: underline;'>#99</a>") !== -1, "PR link rendered cleanly")
+
+      // Test 4: Standalone URLs should still work
+      var urlInput = "- See https://github.com/icyleaf/omarchy-bitwarden/commit/1234567890abcdef"
+      var urlRendered = modal.renderMarkdown(urlInput)
+      assert(urlRendered.indexOf("<a href='<a") === -1, "Standalone commit URL rendered cleanly without double wrapping")
+
+      console.log("ALL RELEASE NOTES MARKDOWN TESTS PASSED!")
+      Qt.quit()
+    }
+  }
+}


### PR DESCRIPTION
Closes #102

## Root Cause Analysis
In [components/ReleaseNotesModal.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/components/ReleaseNotesModal.qml), `formatInlineMarkdown` sequentially executes regular expressions to format Markdown links and auto-detect bare URLs:
1. Markdown links: `[Title](url)` -> `<a href='url' style='...'>Title</a>`
2. Bare PR links: `https://github.com/.../pull/123` -> `<a href='...'>#123</a>`
3. Bare Commit links: `https://github.com/.../commit/abcdef1` -> `<a href='...'>abcdef1</a>`
4. Plain URLs: `https://...` -> `<a href='...'>...</a>`

Because generated `<a href='https://...'>` HTML tags contain raw URLs in their `href` attributes, subsequent passes (such as the commit link or generic URL replacers) matched the URL inside `href='...'`. This injected a nested tag:
`<a href='<a href='https...' style='...'>sha</a>' style='...'>sha</a>`
When rendered by Qt Quick's rich text renderer, the broken inner tag closed prematurely, leaking the unclosed raw style attributes into the visible text:
`(auth): Fix sync failure and unlock flow when logging in via api key (#99) (7384f3f' style='color: #60a5fa; text-decoration: underline;'>7384f3f)`

## Solution
- Introduced a token pool (`storeLink`) in `formatInlineMarkdown`: every generated link is stored in an array and replaced with an opaque placeholder token (`@@OMAWARDEN_LINK_N@@`).
- URL replacers now never encounter HTML tags or attributes during formatting.
- All tokens are restored in a single final pass.
- Added comprehensive automated regression tests in `tests/tst_release_notes_markdown.qml`.

## Verification
- `qml6 tests/tst_release_notes_markdown.qml`: Passed (verified original symptom no longer reproduces)
- All 4 QML test suites passed
- `qmllint components/ReleaseNotesModal.qml tests/tst_release_notes_markdown.qml`: 0 errors/warnings
- `cargo fmt --check` & `cargo clippy`: 0 errors