### PR TITLE
fix(vault): allow syncing encrypted vault when logged in but locked

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -283,8 +283,9 @@ Item {
   }
 
   function syncVault(isBackground, force) {
-    if (root.authState.status !== "unlocked") {
-      root.logWarn("omarchy:vault", "Cannot sync vault: vault is not unlocked.")
+    var hasSession = root.authState && (root.authState.has_session || root.authState.status === "unlocked" || root.authState.status === "locked")
+    if (!hasSession) {
+      root.logWarn("omarchy:vault", "Cannot sync vault: not logged in.")
       return
     }
     if (vaultSyncProc.running) return
@@ -1537,7 +1538,7 @@ Item {
 
       Shortcut {
         sequence: "Ctrl+R"
-        enabled: root.opened && root.authState.status === "unlocked" && !root.isBusy && !root.showSshKeyModal
+        enabled: root.opened && (root.authState.status === "unlocked" || (root.authState.status === "locked" && root.authState.has_session)) && !root.isBusy && !root.showSshKeyModal
         onActivated: root.syncVault(false, true)
       }
 
@@ -1713,7 +1714,7 @@ Item {
           } else if (event.key === Qt.Key_L && root.authState.status === "unlocked" && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.doLock()
             event.accepted = true
-          } else if (event.key === Qt.Key_R && root.authState.status === "unlocked" && !root.isBusy && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
+          } else if (event.key === Qt.Key_R && (root.authState.status === "unlocked" || (root.authState.status === "locked" && root.authState.has_session)) && !root.isBusy && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
             root.syncVault(false, true)
             event.accepted = true
           } else if (event.key === Qt.Key_Comma && !root.showSshKeyModal && !root.showPasswordHistoryModal) {
@@ -2517,9 +2518,21 @@ Item {
       waitForEnd: true
       onStreamFinished: {
         root.isBusy = false
+        try {
+          var res = JSON.parse(text)
+          if (res && res.ok === false) {
+            root.errorMessage = res.error || "Vault sync failed."
+            root.logError("omarchy:vault", "Vault sync failed: " + root.errorMessage)
+            return
+          }
+        } catch (e) {
+          // Non-JSON output
+        }
         root.lastSyncTime = Date.now()
         root.statusMessage = "Vault synchronized."
-        root.loadVaultItems()
+        if (root.authState && root.authState.status === "unlocked") {
+          root.loadVaultItems()
+        }
         Qt.callLater(function() {
           if (root.opened && root.effectiveView === "search" && searchHeader && searchHeader.searchField && !root.showActionPalette) {
             searchHeader.searchField.forceActiveFocus()
@@ -2533,7 +2546,7 @@ Item {
     }
     onExited: function(code) {
       root.isBusy = false
-      if (code !== 0) {
+      if (code !== 0 && !root.errorMessage) {
         root.errorMessage = "Vault sync failed."
         root.logError("omarchy:vault", "Vault sync process exited with code " + code)
       }

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -362,14 +362,6 @@ impl VaultManager {
     }
 
     pub fn sync(&self) -> Result<usize, String> {
-        if !self.is_unlocked() {
-            crate::log_warn!(
-                "omawarden:vault",
-                "Cannot sync vault: vault is locked. Please unlock first."
-            );
-            return Err("Vault is locked. Please unlock first.".to_string());
-        }
-
         crate::log_info!(
             "omawarden:vault",
             "Starting vault synchronization with server..."
@@ -1329,8 +1321,28 @@ mod tests {
         assert!(sync_err.is_err());
         assert_eq!(
             sync_err.unwrap_err(),
-            "Vault is locked. Please unlock first."
+            "Session token missing. Please log in."
         );
+    }
+
+    #[test]
+    fn test_sync_allowed_when_locked_with_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vault_sync_locked.json");
+        let storage_mgr = StorageManager::new(path);
+        let mut storage = storage_mgr.load();
+        storage.access_token = Some("fake_test_token".to_string());
+        storage_mgr.save(&storage).unwrap();
+
+        let vault_mgr = VaultManager::new("http://127.0.0.1:9", Some(storage_mgr), None);
+        assert!(!vault_mgr.is_unlocked());
+
+        let sync_res = vault_mgr.sync();
+        assert!(sync_res.is_err());
+        let err_msg = sync_res.unwrap_err();
+        assert!(!err_msg.contains("Vault is locked"));
+        assert!(!err_msg.contains("Session token missing"));
+        assert!(err_msg.contains("Sync failed"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #104

## Summary of Changes
- **omawarden ()**:
  - Removed artificial `is_unlocked` check in `VaultManager::sync()`. Syncing downloads encrypted ciphers from the server and only requires an active session token.
  - Retained conditional in-memory decryption: if the vault is unlocked, items are decrypted into memory; if locked, ciphertext is safely updated in local storage and decrypted later upon unlock.
  - Added unit test `test_sync_allowed_when_locked_with_session` and updated lifecycle test assertions.
- **QML UI ()**:
  - Updated `syncVault()` precondition to allow syncing whenever an active session exists (`has_session` or `locked`/`unlocked`), rather than strictly requiring an unlocked state.
  - Enabled `Ctrl+R` shortcut and key handling when locked with an active session.
  - Updated `vaultSyncProc` to parse JSON responses and properly report errors instead of unconditionally displaying 'Vault synchronized.'.
  - Guarded `loadVaultItems()` on sync completion to only execute when the vault is unlocked.