### PR TITLE
fix(auth): handle expired session and transition UI to login view

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -136,8 +136,8 @@ Item {
 
   readonly property string effectiveView: {
     if (currentView !== "auto") return currentView
-    if (authState.status === "unlocked") return "search"
-    if (authState.status === "locked") return "unlock"
+    if (authState.status === "unlocked" && Boolean(authState.has_session)) return "search"
+    if (authState.status === "locked" && Boolean(authState.has_session)) return "unlock"
     return "login"
   }
 
@@ -283,7 +283,7 @@ Item {
   }
 
   function syncVault(isBackground, force) {
-    var hasSession = root.authState && (root.authState.has_session || root.authState.status === "unlocked" || root.authState.status === "locked")
+    var hasSession = root.authState && Boolean(root.authState.has_session)
     if (!hasSession) {
       root.logWarn("omarchy:vault", "Cannot sync vault: not logged in.")
       return
@@ -2523,6 +2523,18 @@ Item {
           if (res && res.ok === false) {
             root.errorMessage = res.error || "Vault sync failed."
             root.logError("omarchy:vault", "Vault sync failed: " + root.errorMessage)
+            var errStr = String(res.error || "")
+            if (errStr.indexOf("Session expired") !== -1 || errStr.indexOf("Please log in") !== -1 || errStr.indexOf("token missing") !== -1) {
+              root.authState = ({
+                status: "unauthenticated",
+                server_url: (root.authState && root.authState.server_url) || (root.config && root.config.server_url) || "",
+                user_email: (root.authState && root.authState.user_email) || (root.config && root.config.email) || "",
+                has_session: false
+              })
+              root.rawVaultItems = []
+              root.filteredItems = []
+              root.currentView = "auto"
+            }
             return
           }
         } catch (e) {

--- a/components/AuthView.qml
+++ b/components/AuthView.qml
@@ -44,7 +44,7 @@ Item {
     if (authState && (authState.status === "locked" || authState.status === "unlocked" || authState.status === "unauthenticated")) {
       clearInputs()
     }
-    if (authState && authState.status === "locked") {
+    if (authState && authState.status === "locked" && Boolean(authState.has_session)) {
       Qt.callLater(function() {
         if (unlockPasswordField) unlockPasswordField.forceActiveFocus()
       })
@@ -76,7 +76,7 @@ Item {
         // 1. UNLOCK VIEW (When session exists but vault is locked)
         // --------------------------------------------------
         ColumnLayout {
-          visible: authRoot.authState.status === "locked"
+          visible: authRoot.authState.status === "locked" && Boolean(authRoot.authState.has_session)
           Layout.fillWidth: true
           spacing: 14
 
@@ -201,7 +201,7 @@ Item {
         // 2. FULL LOGIN VIEW (When unauthenticated)
         // --------------------------------------------------
         ColumnLayout {
-          visible: authRoot.authState.status !== "locked"
+          visible: authRoot.authState.status !== "locked" || !authRoot.authState.has_session
           Layout.fillWidth: true
           spacing: 12
 

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -48,6 +48,31 @@ pub fn sanitize_auth_error(err_str: Option<&str>) -> String {
     truncated.trim().to_string()
 }
 
+pub fn is_jwt_expired(token: &str) -> bool {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    use base64::engine::general_purpose::{STANDARD, URL_SAFE, URL_SAFE_NO_PAD};
+    use base64::Engine;
+
+    let payload = parts[1];
+    let decoded = URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| URL_SAFE.decode(payload))
+        .or_else(|_| STANDARD.decode(payload));
+
+    if let Ok(bytes) = decoded {
+        if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+            if let Some(exp) = val.get("exp").and_then(|v| v.as_i64()) {
+                let now = chrono::Utc::now().timestamp();
+                return now >= exp;
+            }
+        }
+    }
+    false
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuthStatus {
     pub status: String,
@@ -86,7 +111,7 @@ impl AuthManager {
     }
 
     pub fn get_status(&self, _verify: bool) -> AuthStatus {
-        let storage = self.storage_mgr.load();
+        let mut storage = self.storage_mgr.load();
 
         if (storage.enc_user_key.is_none() && storage.access_token.is_none())
             || storage.user_email.is_empty()
@@ -103,6 +128,33 @@ impl AuthManager {
                 user_id: storage.user_id,
                 has_session: false,
             };
+        }
+
+        // Detect expired session token without refresh capability
+        if let Some(ref tok) = storage.access_token {
+            if is_jwt_expired(tok) && storage.refresh_token.is_none() {
+                crate::log_warn!(
+                    "omawarden:auth",
+                    "Stored session token has expired. Invalidation required."
+                );
+                storage.access_token = None;
+                let _ = self.storage_mgr.save(&storage);
+                let _ =
+                    crate::daemon::send_daemon_request(&serde_json::json!({ "action": "lock" }));
+
+                return AuthStatus {
+                    status: "unauthenticated".to_string(),
+                    server_url: if storage.server_url.is_empty() {
+                        Some(self.server_url.clone())
+                    } else {
+                        Some(storage.server_url)
+                    },
+                    last_sync: storage.last_sync,
+                    user_email: Some(storage.user_email),
+                    user_id: storage.user_id,
+                    has_session: false,
+                };
+            }
         }
 
         if let Some(daemon_resp) =
@@ -549,5 +601,66 @@ mod tests {
         assert_eq!(st.user_email.as_deref(), Some("apikey-user@example.com"));
         assert_eq!(st.user_id.as_deref(), Some("user-uuid-123"));
         assert!(st.has_session);
+    }
+
+    #[test]
+    fn test_jwt_expiration_detection() {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+
+        let now = chrono::Utc::now().timestamp();
+        let past_payload = serde_json::json!({ "exp": now - 3600 });
+        let future_payload = serde_json::json!({ "exp": now + 3600 });
+
+        let past_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&past_payload).unwrap());
+        let future_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&future_payload).unwrap());
+
+        let expired_token = format!("eyJhbGciOiJSUzI1NiJ9.{}.sig", past_b64);
+        let valid_token = format!("eyJhbGciOiJSUzI1NiJ9.{}.sig", future_b64);
+
+        assert!(is_jwt_expired(&expired_token));
+        assert!(!is_jwt_expired(&valid_token));
+        assert!(!is_jwt_expired("invalid_token_not_three_parts"));
+    }
+
+    #[test]
+    fn test_auth_status_with_expired_token() {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+
+        let dir = tempdir().unwrap();
+        let storage_path = dir.path().join("test_expired_status.json");
+        let storage_mgr = StorageManager::new(storage_path);
+
+        let mock_keyring = KeyringManager::new("non_existent_secret_tool_for_test");
+        let auth_mgr = AuthManager::new(
+            "https://vault.example.com",
+            Some(storage_mgr.clone()),
+            Some(mock_keyring),
+        );
+
+        let now = chrono::Utc::now().timestamp();
+        let past_payload = serde_json::json!({ "exp": now - 100 });
+        let past_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&past_payload).unwrap());
+        let expired_token = format!("eyJhbGciOiJSUzI1NiJ9.{}.sig", past_b64);
+
+        let storage = VaultStorage {
+            user_email: "expired-user@example.com".to_string(),
+            user_id: Some("user-uuid-999".to_string()),
+            access_token: Some(expired_token),
+            refresh_token: None,
+            enc_user_key: Some("2.dummy_iv|dummy_ct|dummy_mac".to_string()),
+            ..Default::default()
+        };
+        storage_mgr.save(&storage).unwrap();
+
+        let st = auth_mgr.get_status(false);
+        assert_eq!(st.status, "unauthenticated");
+        assert!(!st.has_session);
+        assert_eq!(st.user_email.as_deref(), Some("expired-user@example.com"));
+
+        // Verify storage had access_token cleared
+        let fresh_storage = storage_mgr.load();
+        assert!(fresh_storage.access_token.is_none());
     }
 }

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -411,6 +411,12 @@ impl VaultManager {
                             "omawarden:vault",
                             "Session expired. Please log in again."
                         );
+                        let mut updated = storage.clone();
+                        updated.access_token = None;
+                        updated.refresh_token = None;
+                        let _ = self.storage_mgr.save(&updated);
+                        self.lock();
+                        crate::attachment::clear_preview_attachments(None);
                         return Err("Session expired. Please log in again.".to_string());
                     }
                 } else {
@@ -418,6 +424,12 @@ impl VaultManager {
                         "omawarden:vault",
                         "Session expired and no refresh token available."
                     );
+                    let mut updated = storage.clone();
+                    updated.access_token = None;
+                    updated.refresh_token = None;
+                    let _ = self.storage_mgr.save(&updated);
+                    self.lock();
+                    crate::attachment::clear_preview_attachments(None);
                     return Err("Session expired. Please log in again.".to_string());
                 }
             }
@@ -766,15 +778,32 @@ impl VaultManager {
     pub fn get_status(&self) -> Value {
         let is_unlocked = self.is_unlocked();
         let fresh_storage = self.storage_mgr.load();
+        let has_valid_token = if let Some(ref tok) = fresh_storage.access_token {
+            !crate::auth::is_jwt_expired(tok) || fresh_storage.refresh_token.is_some()
+        } else {
+            false
+        };
+
+        let status = if !has_valid_token && fresh_storage.access_token.is_some() {
+            "unauthenticated"
+        } else if is_unlocked {
+            "unlocked"
+        } else if fresh_storage.enc_user_key.is_some() {
+            "locked"
+        } else {
+            "unauthenticated"
+        };
+
         json!({
             "ok": true,
-            "status": if is_unlocked { "unlocked" } else if fresh_storage.enc_user_key.is_some() { "locked" } else { "unauthenticated" },
+            "status": status,
             "server_url": fresh_storage.server_url,
             "user_email": fresh_storage.user_email,
             "user_id": fresh_storage.user_id,
             "last_sync": fresh_storage.last_sync,
-            "is_unlocked": is_unlocked,
-            "items_count": self.decrypted_items.read().map(|i| i.len()).unwrap_or(0),
+            "is_unlocked": is_unlocked && has_valid_token,
+            "has_session": has_valid_token,
+            "items_count": if has_valid_token { self.decrypted_items.read().map(|i| i.len()).unwrap_or(0) } else { 0 },
         })
     }
 


### PR DESCRIPTION
Closes #106

## Summary of Changes
- **omawarden (`auth.rs` & `vault.rs`)**:
  - Implemented `is_jwt_expired()` to inspect JWT payload `exp` claims.
  - In `AuthManager::get_status()` and `VaultManager::get_status()`, check if the stored `access_token` is expired and lacks a `refresh_token`. If expired, proactively invalidate stale tokens, lock the daemon, and return `status: unauthenticated` with `has_session: false` (while preserving `user_email` and `server_url` for login prefill).
  - In `VaultManager::sync()`, on 401/403 authorization failure when token refresh is unavailable or fails, clear session tokens, lock the daemon, and clear preview attachments.
  - Added unit tests for JWT expiration detection and expired session auth status handling.
- **QML UI (`OmarchyBitwarden.qml` & `components/AuthView.qml`)**:
  - In `effectiveView`, enforce `has_session` requirement for `unlock` and `search` views. If `has_session` is false, always route to `login`.
  - In `syncVault()`, ensure an active session exists before attempting sync.
  - In `vaultSyncProc`, on session expiration errors (`Session expired` / `Please log in`), automatically invalidate `authState` to `unauthenticated`, clear in-memory items, and switch to the login view with the error banner displayed.
  - In `AuthView.qml`, only show the unlock Master Password prompt when `status === 'locked' && has_session`. If `has_session` is false, display the full login view (prefilled with email/server).