### PR TITLE
feat(config): support explicit identity_url in CLI and QML settings (#112)

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -329,11 +329,15 @@ Item {
     if (!url || !url.trim()) return "Default (https://vault.bitwarden.com)"
     var trimmed = url.trim()
     var lower = trimmed.toLowerCase()
-    if (lower === "https://vault.bitwarden.com" || lower === "http://vault.bitwarden.com") {
-      return "Official Cloud (https://vault.bitwarden.com)"
+    if (lower === "https://vault.bitwarden.com" || lower === "http://vault.bitwarden.com" ||
+        lower === "https://api.bitwarden.com" || lower === "https://identity.bitwarden.com" ||
+        lower === "https://bitwarden.com") {
+      return "Official Cloud (" + trimmed + ")"
     }
-    if (lower === "https://vault.bitwarden.eu" || lower === "http://vault.bitwarden.eu") {
-      return "Official Cloud (https://vault.bitwarden.eu)"
+    if (lower === "https://vault.bitwarden.eu" || lower === "http://vault.bitwarden.eu" ||
+        lower === "https://api.bitwarden.eu" || lower === "https://identity.bitwarden.eu" ||
+        lower === "https://bitwarden.eu") {
+      return "Official Cloud (" + trimmed + ")"
     }
     var scheme = (lower.indexOf("http://") === 0) ? "http" : "https"
     if (lower.indexOf("127.0.0.1") !== -1 || lower.indexOf("localhost") !== -1 || lower.indexOf("192.168.") !== -1 || lower.indexOf("10.") !== -1 || lower.indexOf("172.") !== -1) {
@@ -1299,6 +1303,7 @@ Item {
     root.statusMessage = "Saving configuration..."
     var cmd = [root.helperPath, "config", "set"]
     if (settings.server_url !== undefined) cmd.push("--server-url", settings.server_url)
+    if (settings.identity_url !== undefined) cmd.push("--identity-url", settings.identity_url)
     if (settings.download_dir !== undefined) cmd.push("--download-dir", settings.download_dir)
     if (settings.auto_lock_minutes !== undefined) cmd.push("--auto-lock", String(settings.auto_lock_minutes))
     if (settings.clipboard_clear_seconds !== undefined) cmd.push("--clipboard-clear", String(settings.clipboard_clear_seconds))
@@ -1314,6 +1319,8 @@ Item {
     var cliVer = (root.cliHealth && root.cliHealth.version) ? root.cliHealth.version : "Unknown"
     var rawUrl = (root.config && root.config.server_url) ? root.config.server_url : ""
     var sUrl = root.sanitizeServerUrl(rawUrl)
+    var rawIdUrl = (root.config && root.config.identity_url) ? root.config.identity_url : ""
+    var idUrl = rawIdUrl ? root.sanitizeServerUrl(rawIdUrl) : "Auto"
     var lLevel = (root.config && root.config.log_level) ? root.config.log_level : "error"
     var vStatus = (root.authState ? root.authState.status : "unknown")
 
@@ -1321,6 +1328,7 @@ Item {
     report += "- **Generated At**: " + ts + "\n"
     report += "- **omawarden Version**: " + cliVer + "\n"
     report += "- **Server URL**: " + sUrl + "\n"
+    report += "- **Identity URL**: " + idUrl + "\n"
     report += "- **Configured Log Level**: " + lLevel + "\n"
     report += "- **Vault Status**: " + vStatus + "\n"
     report += "- **Engine Ready**: " + (root.cliHealth && root.cliHealth.installed ? "Yes" : "No") + "\n"

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -1415,6 +1415,7 @@ Item {
 
   function doLogout() {
     root.logInfo("omarchy:auth", "Logging out session...")
+    root.show2FAField = false
     if (authViewComponent) authViewComponent.clearInputs()
     root.authState = ({
       status: "unauthenticated",
@@ -2440,8 +2441,24 @@ Item {
             root.errorMessage = data.error || "Login failed."
             root.logWarn("omarchy:auth", root.errorMessage)
             var errLower = (data.error || "").toLowerCase()
-            if (errLower.indexOf("two-step") !== -1 || errLower.indexOf("two-factor") !== -1 || errLower.indexOf("code") !== -1) {
+            var is2FA = Boolean(data.two_factor_required)
+                || errLower.indexOf("two-step") !== -1
+                || errLower.indexOf("two-factor") !== -1
+                || errLower.indexOf("two factor") !== -1
+                || errLower.indexOf("twofactor") !== -1
+                || errLower.indexOf("2fa") !== -1
+                || errLower.indexOf("verification code") !== -1
+                || errLower.indexOf("authenticator code") !== -1
+                || errLower.indexOf("security code") !== -1
+            if (is2FA) {
               root.show2FAField = true
+              if (authViewComponent && authViewComponent.twoFactorInput) {
+                Qt.callLater(function() {
+                  authViewComponent.twoFactorInput.forceActiveFocus()
+                })
+              }
+            } else {
+              root.show2FAField = false
             }
           }
         } catch (e) {

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -1396,7 +1396,7 @@ Item {
     if (code) {
       authLoginProc.secret = JSON.stringify({ password: password, code: code })
     } else {
-      authLoginProc.secret = password
+      authLoginProc.secret = JSON.stringify({ password: password })
     }
     authLoginProc.command = cmd
     authLoginProc.running = true

--- a/components/AuthView.qml
+++ b/components/AuthView.qml
@@ -26,6 +26,7 @@ Item {
   signal settingsRequested()
 
   property alias unlockInput: unlockPasswordField
+  property alias twoFactorInput: login2FAInput
 
   function clearInputs() {
     if (unlockPasswordField) unlockPasswordField.text = ""
@@ -38,6 +39,11 @@ Item {
     if (!visible) {
       clearInputs()
     }
+  }
+
+  onLoginMethodChanged: {
+    clearInputs()
+    authRoot.show2FAField = false
   }
 
   onAuthStateChanged: {
@@ -285,6 +291,13 @@ Item {
                   id: loginPwdInput
                   anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter
                   color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; echoMode: TextInput.Password; selectByMouse: true
+                  onAccepted: {
+                    if (authRoot.show2FAField && !login2FAInput.text.trim()) {
+                      login2FAInput.forceActiveFocus()
+                    } else {
+                      authRoot.loginPasswordRequested(loginEmailInput.text.trim(), loginPwdInput.text, login2FAInput.text.trim())
+                    }
+                  }
                 }
               }
             }
@@ -300,6 +313,9 @@ Item {
                   id: login2FAInput
                   anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter
                   color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                  onAccepted: {
+                    authRoot.loginPasswordRequested(loginEmailInput.text.trim(), loginPwdInput.text, login2FAInput.text.trim())
+                  }
                 }
               }
             }

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -22,6 +22,7 @@ Item {
   property color foreground: "#ffffff"
   property color accent: "#3b82f6"
   property color borderColor: Qt.rgba(1, 1, 1, 0.1)
+  property color mutedForeground: Qt.darker(foreground, 1.8)
   property string fontFamily: ""
 
   Timer {
@@ -452,6 +453,32 @@ Item {
             }
           }
 
+          // Identity URL
+          ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 3
+            RowLayout {
+              spacing: 4
+              Text { text: "Identity URL:"; color: settingsRoot.foreground; font.pixelSize: 11; font.weight: Font.Medium }
+              Text { text: "(Optional override, e.g. https://identity.bitwarden.com)"; color: settingsRoot.mutedForeground; font.pixelSize: 10 }
+            }
+            Rectangle {
+              Layout.fillWidth: true; height: 32; radius: 5; color: Qt.rgba(0, 0, 0, 0.25); border.color: idUrlInput.activeFocus ? settingsRoot.accent : settingsRoot.borderColor; border.width: 1
+              TextInput {
+                id: idUrlInput
+                anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: settingsRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                text: (settingsRoot.config && settingsRoot.config.identity_url) ? settingsRoot.config.identity_url : ""
+              }
+              Text {
+                anchors.left: parent.left; anchors.leftMargin: 10; anchors.verticalCenter: parent.verticalCenter
+                text: "Auto (default: identity.bitwarden.com or /identity)"
+                color: settingsRoot.mutedForeground
+                font.family: "sans-serif"; font.pixelSize: 11
+                visible: idUrlInput.text.length === 0
+              }
+            }
+          }
+
           // Download Directory
           ColumnLayout {
             Layout.fillWidth: true
@@ -595,6 +622,7 @@ Item {
               onClicked: {
                 var payload = {
                   server_url: sUrlInput.text.trim() || "https://vault.bitwarden.com",
+                  identity_url: idUrlInput.text.trim(),
                   download_dir: dlDirInput.text.trim() || "~/Downloads",
                   auto_lock_minutes: parseInt(lockMinInput.text.trim()) || 15,
                   clipboard_clear_seconds: parseInt(clipSecInput.text.trim()) || 30,

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -83,14 +83,108 @@ pub struct SyncResponse {
     pub ciphers: Vec<Value>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct EnvironmentUrls {
+    pub base_url: String,
+    pub api_url: String,
+    pub identity_url: String,
+    pub is_cloud: bool,
+    pub has_explicit_identity: bool,
+}
+
+impl EnvironmentUrls {
+    pub fn resolve(server_url: &str, explicit_identity_url: Option<&str>) -> Self {
+        let trimmed_server = server_url.trim();
+        let normalized_server = if trimmed_server.is_empty() {
+            "https://vault.bitwarden.com".to_string()
+        } else if !trimmed_server.starts_with("http://") && !trimmed_server.starts_with("https://")
+        {
+            format!("https://{}", trimmed_server)
+        } else {
+            trimmed_server.to_string()
+        };
+
+        let parsed = url::Url::parse(&normalized_server).ok();
+        let host = parsed
+            .as_ref()
+            .and_then(|u| u.host_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        let mut is_cloud = false;
+        let (base_url, api_url, mut identity_url) =
+            if host == "bitwarden.eu" || host.ends_with(".bitwarden.eu") {
+                is_cloud = true;
+                (
+                    "https://vault.bitwarden.eu".to_string(),
+                    "https://api.bitwarden.eu".to_string(),
+                    "https://identity.bitwarden.eu".to_string(),
+                )
+            } else if host == "bitwarden.com" || host.ends_with(".bitwarden.com") {
+                is_cloud = true;
+                (
+                    "https://vault.bitwarden.com".to_string(),
+                    "https://api.bitwarden.com".to_string(),
+                    "https://identity.bitwarden.com".to_string(),
+                )
+            } else {
+                let clean = normalized_server.trim_end_matches('/');
+                let root = if let Some(stripped) = clean.strip_suffix("/api") {
+                    stripped.trim_end_matches('/')
+                } else if let Some(stripped) = clean.strip_suffix("/identity") {
+                    stripped.trim_end_matches('/')
+                } else {
+                    clean
+                };
+                (
+                    root.to_string(),
+                    format!("{}/api", root),
+                    format!("{}/identity", root),
+                )
+            };
+
+        let mut has_explicit_identity = false;
+        if let Some(explicit) = explicit_identity_url {
+            let exp_trimmed = explicit.trim();
+            if !exp_trimmed.is_empty() {
+                has_explicit_identity = true;
+                let mut norm_explicit = if !exp_trimmed.starts_with("http://")
+                    && !exp_trimmed.starts_with("https://")
+                {
+                    format!("https://{}", exp_trimmed.trim_end_matches('/'))
+                } else {
+                    exp_trimmed.trim_end_matches('/').to_string()
+                };
+                if let Some(stripped) = norm_explicit.strip_suffix("/connect/token") {
+                    norm_explicit = stripped.trim_end_matches('/').to_string();
+                }
+                identity_url = norm_explicit;
+            }
+        }
+
+        Self {
+            base_url,
+            api_url,
+            identity_url,
+            is_cloud,
+            has_explicit_identity,
+        }
+    }
+}
+
 pub struct BitwardenApiClient {
     pub server_url: String,
+    pub urls: EnvironmentUrls,
     client: Client,
 }
 
 impl BitwardenApiClient {
     pub fn new(server_url: &str) -> Self {
-        let base = server_url.trim_end_matches('/');
+        Self::with_identity_url(server_url, None)
+    }
+
+    pub fn with_identity_url(server_url: &str, explicit_identity_url: Option<&str>) -> Self {
+        let urls = EnvironmentUrls::resolve(server_url, explicit_identity_url);
         let mut default_headers = reqwest::header::HeaderMap::new();
         default_headers.insert(
             reqwest::header::USER_AGENT,
@@ -115,20 +209,36 @@ impl BitwardenApiClient {
             .build()
             .unwrap_or_default();
         Self {
-            server_url: base.to_string(),
+            server_url: urls.base_url.clone(),
+            urls,
             client,
         }
     }
 
     pub fn prelogin(&self, email: &str) -> Result<PreloginResponse, ApiError> {
-        let url = format!("{}/api/accounts/prelogin", self.server_url);
-        let resp = self
-            .client
-            .post(&url)
-            .json(&json!({ "email": email.trim().to_lowercase() }))
-            .send()
-            .map_err(|e| ApiError::Http(e.to_string()))?;
+        let try_identity_first = self.urls.is_cloud || self.urls.has_explicit_identity;
+        let (primary_url, fallback_url) = if try_identity_first {
+            (
+                format!("{}/accounts/prelogin", self.urls.identity_url),
+                Some(format!("{}/accounts/prelogin", self.urls.api_url)),
+            )
+        } else {
+            (
+                format!("{}/accounts/prelogin", self.urls.api_url),
+                Some(format!("{}/accounts/prelogin", self.urls.identity_url)),
+            )
+        };
 
+        let email_payload = json!({ "email": email.trim().to_lowercase() });
+        let mut resp = self.client.post(&primary_url).json(&email_payload).send();
+
+        if let (Some(ref fb_url), Ok(ref r)) = (fallback_url, &resp) {
+            if r.status() == reqwest::StatusCode::NOT_FOUND {
+                resp = self.client.post(fb_url).json(&email_payload).send();
+            }
+        }
+
+        let resp = resp.map_err(|e| ApiError::Http(e.to_string()))?;
         if !resp.status().is_success() {
             return Err(ApiError::Http(format!(
                 "Prelogin returned status {}",
@@ -138,6 +248,27 @@ impl BitwardenApiClient {
 
         resp.json::<PreloginResponse>()
             .map_err(|e| ApiError::Json(e.to_string()))
+    }
+
+    fn post_identity_connect_token(
+        &self,
+        form_params: &HashMap<&str, String>,
+    ) -> Result<reqwest::blocking::Response, ApiError> {
+        let primary_url = format!("{}/connect/token", self.urls.identity_url);
+        let fallback_url = if self.urls.is_cloud {
+            None
+        } else {
+            Some(format!("{}/connect/token", self.urls.base_url))
+        };
+
+        let mut resp = self.client.post(&primary_url).form(form_params).send();
+        if let (Some(ref fb_url), Ok(ref r)) = (fallback_url, &resp) {
+            if r.status() == reqwest::StatusCode::NOT_FOUND {
+                resp = self.client.post(fb_url).form(form_params).send();
+            }
+        }
+
+        resp.map_err(|e| ApiError::Http(e.to_string()))
     }
 
     pub fn login_password(
@@ -162,10 +293,6 @@ impl BitwardenApiClient {
 
         let password_hash = derive_master_password_hash(&master_key, password);
 
-        // Connect token endpoint (supports both Bitwarden official cloud and Vaultwarden)
-        let identity_url = format!("{}/identity/connect/token", self.server_url);
-        let fallback_url = format!("{}/connect/token", self.server_url);
-
         let mut form_params: HashMap<&str, String> = HashMap::new();
         form_params.insert("grant_type", "password".to_string());
         form_params.insert("username", email.trim().to_lowercase());
@@ -182,14 +309,7 @@ impl BitwardenApiClient {
             form_params.insert("twoFactorRemember", "1".to_string());
         }
 
-        let mut resp = self.client.post(&identity_url).form(&form_params).send();
-        if let Ok(ref r) = resp {
-            if r.status() == reqwest::StatusCode::NOT_FOUND {
-                resp = self.client.post(&fallback_url).form(&form_params).send();
-            }
-        }
-
-        let resp = resp.map_err(|e| ApiError::Http(e.to_string()))?;
+        let resp = self.post_identity_connect_token(&form_params)?;
         let status = resp.status();
         let body_text = resp.text().map_err(|e| ApiError::Http(e.to_string()))?;
 
@@ -246,9 +366,6 @@ impl BitwardenApiClient {
         client_id: &str,
         client_secret: &str,
     ) -> Result<TokenResponse, ApiError> {
-        let identity_url = format!("{}/identity/connect/token", self.server_url);
-        let fallback_url = format!("{}/connect/token", self.server_url);
-
         let mut form_params: HashMap<&str, String> = HashMap::new();
         form_params.insert("grant_type", "client_credentials".to_string());
         form_params.insert("client_id", client_id.trim().to_string());
@@ -258,14 +375,7 @@ impl BitwardenApiClient {
         form_params.insert("deviceIdentifier", "omarchy-bitwarden".to_string());
         form_params.insert("deviceName", "Omarchy Bitwarden".to_string());
 
-        let mut resp = self.client.post(&identity_url).form(&form_params).send();
-        if let Ok(ref r) = resp {
-            if r.status() == reqwest::StatusCode::NOT_FOUND {
-                resp = self.client.post(&fallback_url).form(&form_params).send();
-            }
-        }
-
-        let resp = resp.map_err(|e| ApiError::Http(e.to_string()))?;
+        let resp = self.post_identity_connect_token(&form_params)?;
         let status = resp.status();
         let body_text = resp.text().map_err(|e| ApiError::Http(e.to_string()))?;
 
@@ -286,22 +396,12 @@ impl BitwardenApiClient {
     }
 
     pub fn refresh_token_grant(&self, refresh_token: &str) -> Result<TokenResponse, ApiError> {
-        let identity_url = format!("{}/identity/connect/token", self.server_url);
-        let fallback_url = format!("{}/connect/token", self.server_url);
-
         let mut form_params = HashMap::new();
         form_params.insert("grant_type", "refresh_token".to_string());
         form_params.insert("client_id", "web".to_string());
         form_params.insert("refresh_token", refresh_token.to_string());
 
-        let mut resp = self.client.post(&identity_url).form(&form_params).send();
-        if let Ok(ref r) = resp {
-            if r.status() == reqwest::StatusCode::NOT_FOUND {
-                resp = self.client.post(&fallback_url).form(&form_params).send();
-            }
-        }
-
-        let resp = resp.map_err(|e| ApiError::Http(e.to_string()))?;
+        let resp = self.post_identity_connect_token(&form_params)?;
         let status = resp.status();
         let body_text = resp.text().map_err(|e| ApiError::Http(e.to_string()))?;
 
@@ -317,7 +417,7 @@ impl BitwardenApiClient {
     }
 
     pub fn sync_vault(&self, access_token: &str) -> Result<SyncResponse, ApiError> {
-        let url = format!("{}/api/sync", self.server_url);
+        let url = format!("{}/sync", self.urls.api_url);
         let resp = self
             .client
             .get(&url)
@@ -327,7 +427,7 @@ impl BitwardenApiClient {
 
         if !resp.status().is_success() {
             return Err(ApiError::Http(format!(
-                "Sync returned status {}",
+                "Sync vault failed with HTTP status {}",
                 resp.status()
             )));
         }
@@ -337,7 +437,7 @@ impl BitwardenApiClient {
     }
 
     pub fn create_cipher(&self, access_token: &str, payload: &Value) -> Result<Value, ApiError> {
-        let url = format!("{}/api/ciphers", self.server_url);
+        let url = format!("{}/ciphers", self.urls.api_url);
         let resp = self
             .client
             .post(&url)
@@ -1569,5 +1669,276 @@ mod tests {
             .and_then(|v| v.as_array())
             .unwrap();
         assert!(hist_1.is_empty());
+    }
+
+    #[test]
+    fn test_endpoint_resolver_official_us_cloud() {
+        let cases = [
+            "https://vault.bitwarden.com",
+            "https://vault.bitwarden.com/",
+            "https://api.bitwarden.com",
+            "https://identity.bitwarden.com",
+            "https://bitwarden.com",
+            "vault.bitwarden.com",
+            "bitwarden.com",
+        ];
+
+        for url in cases {
+            let urls = EnvironmentUrls::resolve(url, None);
+            assert!(urls.is_cloud, "Expected is_cloud for {}", url);
+            assert_eq!(urls.base_url, "https://vault.bitwarden.com");
+            assert_eq!(urls.api_url, "https://api.bitwarden.com");
+            assert_eq!(urls.identity_url, "https://identity.bitwarden.com");
+            assert!(!urls.has_explicit_identity);
+        }
+    }
+
+    #[test]
+    fn test_endpoint_resolver_official_eu_cloud() {
+        let cases = [
+            "https://vault.bitwarden.eu",
+            "https://vault.bitwarden.eu/",
+            "https://api.bitwarden.eu",
+            "https://identity.bitwarden.eu",
+            "https://bitwarden.eu",
+            "vault.bitwarden.eu",
+            "bitwarden.eu",
+        ];
+
+        for url in cases {
+            let urls = EnvironmentUrls::resolve(url, None);
+            assert!(urls.is_cloud, "Expected is_cloud for {}", url);
+            assert_eq!(urls.base_url, "https://vault.bitwarden.eu");
+            assert_eq!(urls.api_url, "https://api.bitwarden.eu");
+            assert_eq!(urls.identity_url, "https://identity.bitwarden.eu");
+            assert!(!urls.has_explicit_identity);
+        }
+    }
+
+    #[test]
+    fn test_endpoint_resolver_self_hosted_and_suffixes() {
+        let urls = EnvironmentUrls::resolve("https://vaultwarden.example.com", None);
+        assert!(!urls.is_cloud);
+        assert_eq!(urls.base_url, "https://vaultwarden.example.com");
+        assert_eq!(urls.api_url, "https://vaultwarden.example.com/api");
+        assert_eq!(
+            urls.identity_url,
+            "https://vaultwarden.example.com/identity"
+        );
+
+        // Trailing slash
+        let urls = EnvironmentUrls::resolve("https://vaultwarden.example.com/", None);
+        assert_eq!(urls.base_url, "https://vaultwarden.example.com");
+        assert_eq!(urls.api_url, "https://vaultwarden.example.com/api");
+        assert_eq!(
+            urls.identity_url,
+            "https://vaultwarden.example.com/identity"
+        );
+
+        // Redundant /api suffix
+        let urls = EnvironmentUrls::resolve("https://vaultwarden.example.com/api", None);
+        assert_eq!(urls.base_url, "https://vaultwarden.example.com");
+        assert_eq!(urls.api_url, "https://vaultwarden.example.com/api");
+        assert_eq!(
+            urls.identity_url,
+            "https://vaultwarden.example.com/identity"
+        );
+
+        // Redundant /identity suffix
+        let urls = EnvironmentUrls::resolve("https://vaultwarden.example.com/identity/", None);
+        assert_eq!(urls.base_url, "https://vaultwarden.example.com");
+        assert_eq!(urls.api_url, "https://vaultwarden.example.com/api");
+        assert_eq!(
+            urls.identity_url,
+            "https://vaultwarden.example.com/identity"
+        );
+
+        // Localhost with port
+        let urls = EnvironmentUrls::resolve("http://127.0.0.1:8080", None);
+        assert!(!urls.is_cloud);
+        assert_eq!(urls.base_url, "http://127.0.0.1:8080");
+        assert_eq!(urls.api_url, "http://127.0.0.1:8080/api");
+        assert_eq!(urls.identity_url, "http://127.0.0.1:8080/identity");
+
+        // Subpath deployment
+        let urls = EnvironmentUrls::resolve("https://example.com/vw/api", None);
+        assert_eq!(urls.base_url, "https://example.com/vw");
+        assert_eq!(urls.api_url, "https://example.com/vw/api");
+        assert_eq!(urls.identity_url, "https://example.com/vw/identity");
+    }
+
+    #[test]
+    fn test_endpoint_resolver_explicit_identity_override() {
+        // Cloud base with custom identity override
+        let urls = EnvironmentUrls::resolve(
+            "https://vault.bitwarden.com",
+            Some("https://custom-auth.corp.net/identity/"),
+        );
+        assert!(urls.is_cloud);
+        assert!(urls.has_explicit_identity);
+        assert_eq!(urls.base_url, "https://vault.bitwarden.com");
+        assert_eq!(urls.api_url, "https://api.bitwarden.com");
+        assert_eq!(urls.identity_url, "https://custom-auth.corp.net/identity");
+
+        // Self-hosted with custom identity override
+        let urls =
+            EnvironmentUrls::resolve("https://vaultwarden.corp.net", Some("https://id.corp.net"));
+        assert!(!urls.is_cloud);
+        assert!(urls.has_explicit_identity);
+        assert_eq!(urls.base_url, "https://vaultwarden.corp.net");
+        assert_eq!(urls.api_url, "https://vaultwarden.corp.net/api");
+        assert_eq!(urls.identity_url, "https://id.corp.net");
+
+        // Empty string explicit identity is treated as None
+        let urls = EnvironmentUrls::resolve("https://vaultwarden.corp.net", Some("   "));
+        assert!(!urls.has_explicit_identity);
+        assert_eq!(urls.identity_url, "https://vaultwarden.corp.net/identity");
+    }
+
+    #[test]
+    fn test_endpoint_resolver_non_official_bitwarden_domain() {
+        // Host has bitwarden in domain name but is not the official cloud
+        let urls = EnvironmentUrls::resolve("https://mybitwarden.com", None);
+        assert!(!urls.is_cloud);
+        assert_eq!(urls.base_url, "https://mybitwarden.com");
+        assert_eq!(urls.api_url, "https://mybitwarden.com/api");
+        assert_eq!(urls.identity_url, "https://mybitwarden.com/identity");
+    }
+
+    #[test]
+    fn test_client_prelogin_fallback_from_api_to_identity() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let handle = thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = stream.unwrap();
+                let mut buf = [0u8; 1024];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+
+                if req.contains("POST /api/accounts/prelogin") {
+                    // First request to /api/accounts/prelogin returns 404
+                    let resp =
+                        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("POST /identity/accounts/prelogin") {
+                    // Fallback to /identity/accounts/prelogin returns 200
+                    let body = r#"{"kdf":0,"kdfIterations":600000}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    break;
+                }
+            }
+        });
+
+        let client = BitwardenApiClient::new(&server_url);
+        let res = client.prelogin("fallback@example.com").unwrap();
+        assert_eq!(res.kdf, Some(0));
+        assert_eq!(res.kdf_iterations, Some(600_000));
+        let _ = handle.join();
+    }
+
+    #[test]
+    fn test_client_connect_token_fallback() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let handle = thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = stream.unwrap();
+                let mut buf = [0u8; 1024];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+
+                if req.contains("POST /identity/connect/token") {
+                    // Primary returns 404
+                    let resp =
+                        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("POST /connect/token") {
+                    // Fallback returns 200
+                    let body = r#"{"access_token":"token_fallback_123","token_type":"Bearer","expires_in":3600}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    break;
+                }
+            }
+        });
+
+        let client = BitwardenApiClient::new(&server_url);
+        let res = client.login_apikey("client_id_val", "client_sec").unwrap();
+        assert_eq!(res.access_token, "token_fallback_123");
+        let _ = handle.join();
+    }
+
+    #[test]
+    fn test_endpoint_resolver_explicit_identity_strips_redundant_token_path() {
+        let urls = EnvironmentUrls::resolve(
+            "https://vault.bitwarden.com",
+            Some("https://identity.bitwarden.com/connect/token/"),
+        );
+        assert_eq!(urls.identity_url, "https://identity.bitwarden.com");
+    }
+
+    #[test]
+    fn test_client_connect_token_400_does_not_fallback() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = Arc::clone(&request_count);
+
+        let handle = thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = stream.unwrap();
+                let mut buf = [0u8; 1024];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                count_clone.fetch_add(1, Ordering::SeqCst);
+
+                if req.contains("POST /identity/connect/token") {
+                    // HTTP 400 Bad Request (e.g. invalid credentials)
+                    let body = r#"{"error":"invalid_grant","error_description":"Invalid username or password."}"#;
+                    let resp = format!(
+                        "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    break;
+                }
+            }
+        });
+
+        let client = BitwardenApiClient::new(&server_url);
+        let err = client.login_apikey("bad_client", "bad_secret").unwrap_err();
+        assert!(err.to_string().contains("Invalid username or password"));
+        let _ = handle.join();
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -418,20 +418,36 @@ impl BitwardenApiClient {
                 format!("Password login endpoint error: HTTP {}", status),
             ))
         } else {
+            let body_lower = body_text.to_lowercase();
             if let Ok(err_json) = serde_json::from_str::<Value>(&body_text) {
                 let has_2fa_field = err_json.get("TwoFactorProviders").is_some()
-                    || err_json.get("twoFactorProviders").is_some();
+                    || err_json.get("twoFactorProviders").is_some()
+                    || err_json.get("TwoFactorProviders2").is_some()
+                    || err_json.get("twoFactorProviders2").is_some()
+                    || body_lower.contains("twofactorproviders");
                 let err_desc = err_json
                     .get("error_description")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                let err_msg = err_json
+                    .get("Message")
+                    .or_else(|| err_json.get("message"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
                 let err_desc_lower = err_desc.to_lowercase();
+                let err_msg_lower = err_msg.to_lowercase();
 
                 if has_2fa_field
                     || err_desc_lower.contains("two factor")
                     || err_desc_lower.contains("two-factor")
                     || err_desc_lower.contains("twofactor")
                     || err_desc_lower.contains("two-step")
+                    || err_desc_lower.contains("2fa")
+                    || err_msg_lower.contains("two factor")
+                    || err_msg_lower.contains("two-factor")
+                    || err_msg_lower.contains("twofactor")
+                    || err_msg_lower.contains("two-step")
+                    || err_msg_lower.contains("2fa")
                 {
                     let mut providers = vec![0];
                     if let Some(arr) = err_json

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -200,6 +200,43 @@ impl EnvironmentUrls {
     }
 }
 
+/// Returns a stable device identifier (UUID format) for Bitwarden identity endpoints.
+/// Uses `/etc/machine-id` or `/var/lib/dbus/machine-id` if available,
+/// or falls back to an RFC 4122 v4 UUID.
+pub fn get_device_identifier() -> String {
+    for path in &["/etc/machine-id", "/var/lib/dbus/machine-id"] {
+        if let Ok(id) = std::fs::read_to_string(path) {
+            let trimmed = id.trim();
+            if trimmed.len() == 32 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+                return format!(
+                    "{}-{}-{}-{}-{}",
+                    &trimmed[0..8],
+                    &trimmed[8..12],
+                    &trimmed[12..16],
+                    &trimmed[16..20],
+                    &trimmed[20..32]
+                );
+            }
+        }
+    }
+
+    use rand_core::RngCore;
+    let mut bytes = [0u8; 16];
+    let mut rng = rand_core::OsRng;
+    rng.fill_bytes(&mut bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3],
+        bytes[4], bytes[5],
+        bytes[6], bytes[7],
+        bytes[8], bytes[9],
+        bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+    )
+}
+
 pub struct BitwardenApiClient {
     pub server_url: String,
     pub urls: EnvironmentUrls,
@@ -228,7 +265,7 @@ impl BitwardenApiClient {
         );
         default_headers.insert(
             reqwest::header::HeaderName::from_static("device-type"),
-            reqwest::header::HeaderValue::from_static("linux"),
+            reqwest::header::HeaderValue::from_static("8"),
         );
 
         let client = Client::builder()
@@ -329,9 +366,9 @@ impl BitwardenApiClient {
         form_params.insert("password", password_hash);
         form_params.insert("scope", "api offline_access".to_string());
         form_params.insert("client_id", "web".to_string());
-        form_params.insert("deviceType", "linux".to_string());
-        form_params.insert("deviceIdentifier", "omarchy-bitwarden".to_string());
-        form_params.insert("deviceName", "Omarchy Bitwarden".to_string());
+        form_params.insert("deviceType", "8".to_string());
+        form_params.insert("deviceIdentifier", get_device_identifier());
+        form_params.insert("deviceName", "linux".to_string());
 
         if let Some(code) = two_factor_token {
             form_params.insert("twoFactorToken", code.trim().to_string());
@@ -382,10 +419,46 @@ impl BitwardenApiClient {
             ))
         } else {
             if let Ok(err_json) = serde_json::from_str::<Value>(&body_text) {
-                if let Some(err_desc) = err_json.get("error_description").and_then(|v| v.as_str()) {
-                    if err_desc.contains("TwoFactor") || err_desc.contains("Two-factor") {
-                        return Err(ApiError::TwoFactorRequired { providers: vec![0] });
+                let has_2fa_field = err_json.get("TwoFactorProviders").is_some()
+                    || err_json.get("twoFactorProviders").is_some();
+                let err_desc = err_json
+                    .get("error_description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let err_desc_lower = err_desc.to_lowercase();
+
+                if has_2fa_field
+                    || err_desc_lower.contains("two factor")
+                    || err_desc_lower.contains("two-factor")
+                    || err_desc_lower.contains("twofactor")
+                    || err_desc_lower.contains("two-step")
+                {
+                    let mut providers = vec![0];
+                    if let Some(arr) = err_json
+                        .get("TwoFactorProviders")
+                        .or_else(|| err_json.get("twoFactorProviders"))
+                        .and_then(|v| v.as_array())
+                    {
+                        let parsed: Vec<i32> = arr
+                            .iter()
+                            .filter_map(|p| {
+                                if let Some(n) = p.as_i64() {
+                                    Some(n as i32)
+                                } else if let Some(s) = p.as_str() {
+                                    s.parse::<i32>().ok()
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+                        if !parsed.is_empty() {
+                            providers = parsed;
+                        }
                     }
+                    return Err(ApiError::TwoFactorRequired { providers });
+                }
+
+                if !err_desc.is_empty() {
                     return Err(ApiError::AuthFailed(err_desc.to_string()));
                 }
                 if let Some(err_msg) = err_json.get("Message").and_then(|v| v.as_str()) {
@@ -412,9 +485,9 @@ impl BitwardenApiClient {
         form_params.insert("client_id", client_id.trim().to_string());
         form_params.insert("client_secret", client_secret.trim().to_string());
         form_params.insert("scope", "api".to_string());
-        form_params.insert("deviceType", "linux".to_string());
-        form_params.insert("deviceIdentifier", "omarchy-bitwarden".to_string());
-        form_params.insert("deviceName", "Omarchy Bitwarden".to_string());
+        form_params.insert("deviceType", "8".to_string());
+        form_params.insert("deviceIdentifier", get_device_identifier());
+        form_params.insert("deviceName", "linux".to_string());
 
         let resp = self.post_identity_connect_token(&form_params)?;
         let status = resp.status();
@@ -2016,5 +2089,90 @@ mod tests {
         assert!(err.to_string().contains("Invalid username or password"));
         let _ = handle.join();
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_get_device_identifier_format() {
+        let id = get_device_identifier();
+        assert_eq!(id.len(), 36);
+        let parts: Vec<&str> = id.split('-').collect();
+        assert_eq!(parts.len(), 5);
+        assert_eq!(parts[0].len(), 8);
+        assert_eq!(parts[1].len(), 4);
+        assert_eq!(parts[2].len(), 4);
+        assert_eq!(parts[3].len(), 4);
+        assert_eq!(parts[4].len(), 12);
+        for c in id.chars() {
+            assert!(c == '-' || c.is_ascii_hexdigit());
+        }
+    }
+
+    #[test]
+    fn test_client_device_parameters_and_2fa_response() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let handle = thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+
+                if req.contains("POST /identity/accounts/prelogin")
+                    || req.contains("POST /api/accounts/prelogin")
+                {
+                    let body = r#"{"kdf":0,"kdfIterations":600000}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("POST /identity/connect/token") {
+                    // Verify device parameters in request body
+                    assert!(
+                        req.contains("deviceType=8"),
+                        "Expected deviceType=8, got: {}",
+                        req
+                    );
+                    assert!(
+                        req.contains("deviceName=linux"),
+                        "Expected deviceName=linux, got: {}",
+                        req
+                    );
+                    assert!(
+                        req.contains("deviceIdentifier="),
+                        "Expected deviceIdentifier in request: {}",
+                        req
+                    );
+
+                    // Return official Bitwarden 2FA challenge
+                    let body = r#"{"error":"invalid_grant","error_description":"Two factor required.","TwoFactorProviders":["0","1"]}"#;
+                    let resp = format!(
+                        "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    break;
+                }
+            }
+        });
+
+        let client = BitwardenApiClient::new(&server_url);
+        let pwd = zeroize::Zeroizing::new("master_password".to_string());
+        let res = client.login_password("user@example.com", &pwd, None);
+        match res {
+            Err(ApiError::TwoFactorRequired { providers }) => {
+                assert_eq!(providers, vec![0, 1]);
+            }
+            other => panic!("Expected TwoFactorRequired, got {:?}", other),
+        }
+        let _ = handle.join();
     }
 }

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -11,6 +11,8 @@ use crate::vault::{parse_ssh_key_fields, SshMetadata, VaultItem};
 
 #[derive(Debug, Clone)]
 pub enum ApiError {
+    Network(String),
+    HttpStatus(reqwest::StatusCode, String),
     Http(String),
     Json(String),
     AuthFailed(String),
@@ -21,7 +23,9 @@ pub enum ApiError {
 impl std::fmt::Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ApiError::Http(s) => write!(f, "Network HTTP error: {}", s),
+            ApiError::Network(s) => write!(f, "Network error: {}", s),
+            ApiError::HttpStatus(code, s) => write!(f, "HTTP error {}: {}", code, s),
+            ApiError::Http(s) => write!(f, "HTTP error: {}", s),
             ApiError::Json(s) => write!(f, "JSON decode error: {}", s),
             ApiError::AuthFailed(s) => write!(f, "API authentication failed: {}", s),
             ApiError::TwoFactorRequired { .. } => write!(f, "Two-factor authentication required"),
@@ -30,6 +34,30 @@ impl std::fmt::Display for ApiError {
     }
 }
 impl std::error::Error for ApiError {}
+
+impl From<reqwest::Error> for ApiError {
+    fn from(e: reqwest::Error) -> Self {
+        if e.is_connect() || e.is_timeout() {
+            ApiError::Network(e.to_string())
+        } else if let Some(status) = e.status() {
+            ApiError::HttpStatus(status, e.to_string())
+        } else {
+            let msg = e.to_string();
+            let lower = msg.to_lowercase();
+            if lower.contains("dns")
+                || lower.contains("connection refused")
+                || lower.contains("connect")
+                || lower.contains("timeout")
+                || lower.contains("timed out")
+                || lower.contains("unreachable")
+            {
+                ApiError::Network(msg)
+            } else {
+                ApiError::Http(msg)
+            }
+        }
+    }
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct PreloginResponse {
@@ -238,12 +266,14 @@ impl BitwardenApiClient {
             }
         }
 
-        let resp = resp.map_err(|e| ApiError::Http(e.to_string()))?;
+        let resp = resp.map_err(ApiError::from)?;
         if !resp.status().is_success() {
-            return Err(ApiError::Http(format!(
-                "Prelogin returned status {}",
-                resp.status()
-            )));
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            return Err(ApiError::HttpStatus(
+                status,
+                format!("Prelogin returned HTTP {} ({})", status, body),
+            ));
         }
 
         resp.json::<PreloginResponse>()
@@ -268,7 +298,7 @@ impl BitwardenApiClient {
             }
         }
 
-        resp.map_err(|e| ApiError::Http(e.to_string()))
+        resp.map_err(ApiError::from)
     }
 
     pub fn login_password(
@@ -345,6 +375,11 @@ impl BitwardenApiClient {
                 .map_err(|e| ApiError::Crypto(format!("{:?}", e)))?;
 
             Ok((token_resp, user_key))
+        } else if status.is_server_error() || status == reqwest::StatusCode::NOT_FOUND {
+            Err(ApiError::HttpStatus(
+                status,
+                format!("Password login endpoint error: HTTP {}", status),
+            ))
         } else {
             if let Ok(err_json) = serde_json::from_str::<Value>(&body_text) {
                 if let Some(err_desc) = err_json.get("error_description").and_then(|v| v.as_str()) {
@@ -357,7 +392,13 @@ impl BitwardenApiClient {
                     return Err(ApiError::AuthFailed(err_msg.to_string()));
                 }
             }
-            Err(ApiError::AuthFailed(format!("HTTP {}", status)))
+            if status == reqwest::StatusCode::UNAUTHORIZED
+                || status == reqwest::StatusCode::BAD_REQUEST
+            {
+                Err(ApiError::AuthFailed(format!("HTTP {}", status)))
+            } else {
+                Err(ApiError::HttpStatus(status, format!("HTTP {}", status)))
+            }
         }
     }
 
@@ -382,6 +423,11 @@ impl BitwardenApiClient {
         if status.is_success() {
             serde_json::from_str::<TokenResponse>(&body_text)
                 .map_err(|e| ApiError::Json(e.to_string()))
+        } else if status.is_server_error() || status == reqwest::StatusCode::NOT_FOUND {
+            Err(ApiError::HttpStatus(
+                status,
+                format!("API key login endpoint error: HTTP {}", status),
+            ))
         } else {
             if let Ok(err_json) = serde_json::from_str::<Value>(&body_text) {
                 if let Some(err_desc) = err_json.get("error_description").and_then(|v| v.as_str()) {
@@ -391,7 +437,13 @@ impl BitwardenApiClient {
                     return Err(ApiError::AuthFailed(err_msg.to_string()));
                 }
             }
-            Err(ApiError::AuthFailed(format!("HTTP {}", status)))
+            if status == reqwest::StatusCode::UNAUTHORIZED
+                || status == reqwest::StatusCode::BAD_REQUEST
+            {
+                Err(ApiError::AuthFailed(format!("HTTP {}", status)))
+            } else {
+                Err(ApiError::HttpStatus(status, format!("HTTP {}", status)))
+            }
         }
     }
 
@@ -408,11 +460,33 @@ impl BitwardenApiClient {
         if status.is_success() {
             serde_json::from_str::<TokenResponse>(&body_text)
                 .map_err(|e| ApiError::Json(e.to_string()))
+        } else if status.is_server_error() || status == reqwest::StatusCode::NOT_FOUND {
+            Err(ApiError::HttpStatus(
+                status,
+                format!("Refresh token endpoint error: HTTP {}", status),
+            ))
         } else {
-            Err(ApiError::AuthFailed(format!(
-                "Refresh token failed: HTTP {}",
-                status
-            )))
+            if let Ok(err_json) = serde_json::from_str::<Value>(&body_text) {
+                if let Some(err_desc) = err_json.get("error_description").and_then(|v| v.as_str()) {
+                    return Err(ApiError::AuthFailed(err_desc.to_string()));
+                }
+                if let Some(err_msg) = err_json.get("Message").and_then(|v| v.as_str()) {
+                    return Err(ApiError::AuthFailed(err_msg.to_string()));
+                }
+            }
+            if status == reqwest::StatusCode::UNAUTHORIZED
+                || status == reqwest::StatusCode::BAD_REQUEST
+            {
+                Err(ApiError::AuthFailed(format!(
+                    "Refresh token rejected: HTTP {}",
+                    status
+                )))
+            } else {
+                Err(ApiError::HttpStatus(
+                    status,
+                    format!("Refresh token HTTP {}", status),
+                ))
+            }
         }
     }
 
@@ -423,13 +497,15 @@ impl BitwardenApiClient {
             .get(&url)
             .header("Authorization", format!("Bearer {}", access_token))
             .send()
-            .map_err(|e| ApiError::Http(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
         if !resp.status().is_success() {
-            return Err(ApiError::Http(format!(
-                "Sync vault failed with HTTP status {}",
-                resp.status()
-            )));
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            return Err(ApiError::HttpStatus(
+                status,
+                format!("Sync vault failed with HTTP status {} ({})", status, body),
+            ));
         }
 
         resp.json::<SyncResponse>()
@@ -444,15 +520,15 @@ impl BitwardenApiClient {
             .header("Authorization", format!("Bearer {}", access_token))
             .json(payload)
             .send()
-            .map_err(|e| ApiError::Http(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().unwrap_or_default();
-            return Err(ApiError::Http(format!(
-                "Create cipher failed ({}): {}",
-                status, body
-            )));
+            return Err(ApiError::HttpStatus(
+                status,
+                format!("Create cipher failed (HTTP {}): {}", status, body),
+            ));
         }
 
         resp.json::<Value>()

--- a/omawarden/src/attachment.rs
+++ b/omawarden/src/attachment.rs
@@ -295,15 +295,20 @@ pub fn get_attachment(
     }
 
     // Direct HTTP download via REST API
-    let server_url = if !storage.server_url.is_empty() {
-        storage.server_url.trim_end_matches('/')
+    let raw_server_url = if !storage.server_url.is_empty() {
+        &storage.server_url
     } else {
-        cfg.server_url.trim_end_matches('/')
+        &cfg.server_url
     };
+    let effective_id_url = cfg
+        .identity_url
+        .as_deref()
+        .or(storage.identity_url.as_deref());
+    let env_urls = crate::api::EnvironmentUrls::resolve(raw_server_url, effective_id_url);
 
     let download_url = format!(
-        "{}/api/ciphers/{}/attachment/{}",
-        server_url, item_id, attachment_id
+        "{}/ciphers/{}/attachment/{}",
+        env_urls.api_url, item_id, attachment_id
     );
 
     let client = reqwest::blocking::Client::builder()
@@ -328,9 +333,12 @@ pub fn get_attachment(
                 item_id,
                 attachment_id
             );
-            if let Some(new_token) =
-                attempt_attachment_token_refresh(server_url, &storage_mgr, &keyring_mgr, &storage)
-            {
+            if let Some(new_token) = attempt_attachment_token_refresh(
+                raw_server_url,
+                &storage_mgr,
+                &keyring_mgr,
+                &storage,
+            ) {
                 active_token = new_token;
                 crate::log_info!(
                     "omawarden:attachment",
@@ -386,13 +394,13 @@ pub fn get_attachment(
                         if url_str.starts_with("http://") || url_str.starts_with("https://") {
                             url_str.to_string()
                         } else if url_str.starts_with('/') {
-                            format!("{}{}", server_url, url_str)
+                            format!("{}{}", env_urls.base_url, url_str)
                         } else {
-                            format!("{}/{}", server_url, url_str)
+                            format!("{}/{}", env_urls.base_url, url_str)
                         };
 
                     let mut req = client.get(&full_signed_url);
-                    if full_signed_url.starts_with(server_url)
+                    if full_signed_url.starts_with(&env_urls.base_url)
                         && !full_signed_url.contains("token=")
                     {
                         req = req.header("Authorization", format!("Bearer {}", active_token));
@@ -704,7 +712,13 @@ fn attempt_attachment_token_refresh(
     keyring_mgr: &KeyringManager,
     storage: &VaultStorage,
 ) -> Option<String> {
-    let api_client = crate::api::BitwardenApiClient::new(server_url);
+    let effective_id_url = if server_url.is_empty() || server_url == storage.server_url {
+        storage.identity_url.as_deref()
+    } else {
+        None
+    };
+    let api_client =
+        crate::api::BitwardenApiClient::with_identity_url(server_url, effective_id_url);
 
     // 1. Try refresh_token
     let refresh_token = keyring_mgr

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -93,6 +93,7 @@ pub struct AuthResult {
 
 pub struct AuthManager {
     pub server_url: String,
+    pub identity_url: Option<String>,
     pub storage_mgr: StorageManager,
     pub keyring_mgr: KeyringManager,
 }
@@ -103,9 +104,34 @@ impl AuthManager {
         storage_mgr: Option<StorageManager>,
         keyring_mgr: Option<KeyringManager>,
     ) -> Self {
+        Self::with_identity_url(server_url, None, storage_mgr, keyring_mgr)
+    }
+
+    pub fn with_identity_url(
+        server_url: &str,
+        identity_url: Option<&str>,
+        storage_mgr: Option<StorageManager>,
+        keyring_mgr: Option<KeyringManager>,
+    ) -> Self {
+        let sm = storage_mgr.unwrap_or_default();
+        let storage = sm.load();
+        let effective_identity_url = if let Some(id) = identity_url {
+            let id_trim = id.trim();
+            if !id_trim.is_empty() {
+                Some(id_trim.to_string())
+            } else {
+                None
+            }
+        } else if server_url.is_empty() || server_url == storage.server_url {
+            storage.identity_url.clone()
+        } else {
+            None
+        };
+
         Self {
             server_url: server_url.to_string(),
-            storage_mgr: storage_mgr.unwrap_or_default(),
+            identity_url: effective_identity_url,
+            storage_mgr: sm,
             keyring_mgr: keyring_mgr.unwrap_or_default(),
         }
     }
@@ -268,7 +294,8 @@ impl AuthManager {
             "Starting login with password for {}",
             email
         );
-        let client = BitwardenApiClient::new(&self.server_url);
+        let client =
+            BitwardenApiClient::with_identity_url(&self.server_url, self.identity_url.as_deref());
         let password_zeroizing = Zeroizing::new(password.to_string());
 
         let (token_resp, _user_key) = match client.login_password(email, &password_zeroizing, code)
@@ -288,6 +315,7 @@ impl AuthManager {
 
         let mut storage = self.storage_mgr.load();
         storage.server_url = self.server_url.clone();
+        storage.identity_url = self.identity_url.clone();
         storage.user_email = email.trim().to_lowercase();
         storage.enc_user_key = token_resp.key;
         storage.enc_private_key = token_resp.private_key;
@@ -379,7 +407,8 @@ impl AuthManager {
             "Starting login with API Key client_id: {}",
             client_id
         );
-        let client = BitwardenApiClient::new(&self.server_url);
+        let client =
+            BitwardenApiClient::with_identity_url(&self.server_url, self.identity_url.as_deref());
         let token_resp = match client.login_apikey(client_id, client_secret) {
             Ok(r) => r,
             Err(e) => {
@@ -396,6 +425,7 @@ impl AuthManager {
 
         let mut storage = self.storage_mgr.load();
         storage.server_url = self.server_url.clone();
+        storage.identity_url = self.identity_url.clone();
         storage.client_id = Some(client_id.trim().to_string());
         storage.enc_user_key = token_resp.key;
         storage.enc_private_key = token_resp.private_key;
@@ -1151,5 +1181,63 @@ esac
         let st = auth_mgr.get_status(false);
         assert!(st.has_session);
         assert_eq!(st.status, "locked");
+    }
+
+    #[test]
+    fn test_auth_manager_identity_url_isolation_and_clearing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("storage_isolation.json");
+        let storage_mgr = StorageManager::new(path);
+
+        // Pre-save storage for custom server with an identity URL
+        let initial_storage = VaultStorage {
+            server_url: "https://vaultwarden.custom.local".to_string(),
+            identity_url: Some("https://id.custom.local".to_string()),
+            user_email: "user@custom.local".to_string(),
+            ..Default::default()
+        };
+        storage_mgr.save(&initial_storage).unwrap();
+
+        // 1. When switching to a new server, old storage identity_url must NOT be inherited
+        let auth_mgr_cloud = AuthManager::with_identity_url(
+            "https://vault.bitwarden.com",
+            None,
+            Some(storage_mgr.clone()),
+            None,
+        );
+        assert_eq!(auth_mgr_cloud.identity_url, None);
+
+        // 2. When same server URL is used, storage identity_url is inherited
+        let auth_mgr_same = AuthManager::with_identity_url(
+            "https://vaultwarden.custom.local",
+            None,
+            Some(storage_mgr.clone()),
+            None,
+        );
+        assert_eq!(
+            auth_mgr_same.identity_url,
+            Some("https://id.custom.local".to_string())
+        );
+
+        // 3. When empty string is explicitly provided, identity_url is cleared (None)
+        let auth_mgr_cleared = AuthManager::with_identity_url(
+            "https://vaultwarden.custom.local",
+            Some(""),
+            Some(storage_mgr.clone()),
+            None,
+        );
+        assert_eq!(auth_mgr_cleared.identity_url, None);
+
+        // 4. When explicit non-empty identity URL is provided, it is used
+        let auth_mgr_override = AuthManager::with_identity_url(
+            "https://vaultwarden.custom.local",
+            Some("https://new-id.custom.local"),
+            Some(storage_mgr.clone()),
+            None,
+        );
+        assert_eq!(
+            auth_mgr_override.identity_url,
+            Some("https://new-id.custom.local".to_string())
+        );
     }
 }

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -27,7 +27,15 @@ pub fn sanitize_auth_error(err_str: Option<&str>) -> String {
     if lower.contains("decryption") || lower.contains("not the expected type") {
         return "Decryption failed. Incorrect master password.".to_string();
     }
-    if lower.contains("two-step") || lower.contains("two-factor") || lower.contains("code") {
+    if lower.contains("two-step")
+        || lower.contains("two-factor")
+        || lower.contains("two factor")
+        || lower.contains("twofactor")
+        || lower.contains("2fa")
+        || lower.contains("verification code")
+        || lower.contains("authenticator code")
+        || lower.contains("security code")
+    {
         return "Two-factor authentication required or invalid code.".to_string();
     }
     if lower.contains("already logged in") {
@@ -115,12 +123,16 @@ pub struct AuthStatus {
     pub has_session: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuthResult {
     pub ok: bool,
     pub status: Option<String>,
     pub session: Option<String>,
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub two_factor_required: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub two_factor_providers: Option<Vec<i32>>,
 }
 
 pub struct AuthManager {
@@ -333,14 +345,34 @@ impl AuthManager {
         let (token_resp, _user_key) = match client.login_password(email, &password_zeroizing, code)
         {
             Ok(r) => r,
+            Err(crate::api::ApiError::TwoFactorRequired { providers }) => {
+                crate::log_info!(
+                    "omawarden:auth",
+                    "Two-factor authentication required for {}",
+                    email
+                );
+                return AuthResult {
+                    ok: false,
+                    status: Some("unauthenticated".to_string()),
+                    session: None,
+                    error: Some("Two-factor authentication required or invalid code.".to_string()),
+                    two_factor_required: Some(true),
+                    two_factor_providers: Some(providers),
+                };
+            }
             Err(e) => {
                 let err_msg = sanitize_auth_error(Some(&e.to_string()));
+                let is_2fa = err_msg.to_lowercase().contains("two-factor")
+                    || err_msg.to_lowercase().contains("two factor")
+                    || err_msg.to_lowercase().contains("2fa");
                 crate::log_warn!("omawarden:auth", "Login failed for {}: {}", email, err_msg);
                 return AuthResult {
                     ok: false,
                     status: Some("unauthenticated".to_string()),
                     session: None,
                     error: Some(err_msg),
+                    two_factor_required: if is_2fa { Some(true) } else { None },
+                    two_factor_providers: None,
                 };
             }
         };
@@ -429,7 +461,7 @@ impl AuthManager {
             ok: true,
             status: Some("unlocked".to_string()),
             session: Some(token_resp.access_token),
-            error: None,
+            ..Default::default()
         }
     }
 
@@ -451,6 +483,7 @@ impl AuthManager {
                     status: Some("unauthenticated".to_string()),
                     session: None,
                     error: Some(err_msg),
+                    ..Default::default()
                 };
             }
         };
@@ -562,7 +595,7 @@ impl AuthManager {
             ok: true,
             status: Some("locked".to_string()),
             session: Some(token_resp.access_token),
-            error: None,
+            ..Default::default()
         }
     }
 
@@ -576,6 +609,7 @@ impl AuthManager {
                 status: Some("unauthenticated".to_string()),
                 session: None,
                 error: Some("Account is not logged in.".to_string()),
+                ..Default::default()
             };
         }
 
@@ -613,7 +647,7 @@ impl AuthManager {
                     ok: true,
                     status: Some("unlocked".to_string()),
                     session: session_val,
-                    error: None,
+                    ..Default::default()
                 }
             }
             Err(e) => {
@@ -624,6 +658,7 @@ impl AuthManager {
                     status: Some("locked".to_string()),
                     session: None,
                     error: Some(err_msg),
+                    ..Default::default()
                 }
             }
         }
@@ -640,7 +675,7 @@ impl AuthManager {
             ok: true,
             status: Some("locked".to_string()),
             session: None,
-            error: None,
+            ..Default::default()
         }
     }
 
@@ -660,7 +695,7 @@ impl AuthManager {
             ok: true,
             status: Some("unauthenticated".to_string()),
             session: None,
-            error: None,
+            ..Default::default()
         }
     }
 }
@@ -731,6 +766,14 @@ mod tests {
         assert_eq!(
             sanitize_auth_error(Some("Username not found")),
             "Invalid username, email, or master password."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("Two factor required.")),
+            "Two-factor authentication required or invalid code."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("2FA code invalid")),
+            "Two-factor authentication required or invalid code."
         );
         assert_eq!(
             sanitize_auth_error(Some("Vault is locked")),
@@ -841,6 +884,62 @@ mod tests {
         assert_eq!(
             res.error.as_deref(),
             Some("Bitwarden server endpoint not found (HTTP 404). Please verify your server URL.")
+        );
+        let _ = handle.join();
+    }
+
+    #[test]
+    fn test_login_password_two_factor_required() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let handle = thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                let mut buf = [0u8; 1024];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+
+                if req.contains("POST /identity/accounts/prelogin")
+                    || req.contains("POST /api/accounts/prelogin")
+                {
+                    let body = r#"{"kdf":0,"kdfIterations":600000}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("POST /identity/connect/token") {
+                    let body = r#"{"error":"invalid_grant","error_description":"Two factor required.","TwoFactorProviders":["0"]}"#;
+                    let resp = format!(
+                        "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    break;
+                }
+            }
+        });
+
+        let dir = tempdir().unwrap();
+        let storage_path = dir.path().join("test_2fa_data.json");
+        let storage_mgr = StorageManager::new(storage_path);
+
+        let auth_mgr = AuthManager::new(&server_url, Some(storage_mgr), None);
+        let res = auth_mgr.login_password("user@example.com", "password123", None);
+        assert!(!res.ok);
+        assert_eq!(res.status.as_deref(), Some("unauthenticated"));
+        assert_eq!(res.two_factor_required, Some(true));
+        assert_eq!(res.two_factor_providers, Some(vec![0]));
+        assert_eq!(
+            res.error.as_deref(),
+            Some("Two-factor authentication required or invalid code.")
         );
         let _ = handle.join();
     }

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -16,8 +16,11 @@ pub fn sanitize_auth_error(err_str: Option<&str>) -> String {
     if lower.contains("mac mismatch:") {
         return raw.to_string();
     }
-    if lower.contains("invalid")
-        && (lower.contains("password") || lower.contains("username") || lower.contains("email"))
+    if (lower.contains("invalid") || lower.contains("incorrect") || lower.contains("not found"))
+        && (lower.contains("password")
+            || lower.contains("username")
+            || lower.contains("email")
+            || lower.contains("user"))
     {
         return "Invalid username, email, or master password.".to_string();
     }
@@ -30,10 +33,39 @@ pub fn sanitize_auth_error(err_str: Option<&str>) -> String {
     if lower.contains("already logged in") {
         return "Already logged in.".to_string();
     }
+    if lower.contains("404") || lower.contains("endpoint not found") {
+        return "Bitwarden server endpoint not found (HTTP 404). Please verify your server URL."
+            .to_string();
+    }
+    if lower.contains("http error 500")
+        || lower.contains("http 500")
+        || lower.contains("status 500")
+        || lower.contains("internal server error")
+    {
+        return "Bitwarden server encountered an internal error (HTTP 500).".to_string();
+    }
+    if lower.contains("http error 502")
+        || lower.contains("http 502")
+        || lower.contains("status 502")
+        || lower.contains("bad gateway")
+    {
+        return "Bitwarden server is unavailable (HTTP 502 Bad Gateway).".to_string();
+    }
+    if lower.contains("http error 503")
+        || lower.contains("http 503")
+        || lower.contains("status 503")
+        || lower.contains("service unavailable")
+    {
+        return "Bitwarden server is temporarily unavailable (HTTP 503).".to_string();
+    }
     if lower.contains("network")
         || lower.contains("failed to fetch")
         || lower.contains("econnrefused")
+        || lower.contains("connection refused")
         || lower.contains("timeout")
+        || lower.contains("timed out")
+        || lower.contains("unable to reach")
+        || lower.contains("dns")
     {
         return "Network error: unable to reach Bitwarden server.".to_string();
     }
@@ -661,6 +693,46 @@ mod tests {
             "Network error: unable to reach Bitwarden server."
         );
         assert_eq!(
+            sanitize_auth_error(Some("Network error: dns lookup failed")),
+            "Network error: unable to reach Bitwarden server."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("HTTP error 404: Not Found")),
+            "Bitwarden server endpoint not found (HTTP 404). Please verify your server URL."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("Prelogin returned HTTP 404 Not Found")),
+            "Bitwarden server endpoint not found (HTTP 404). Please verify your server URL."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("HTTP error 500: Internal Server Error")),
+            "Bitwarden server encountered an internal error (HTTP 500)."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("HTTP error 502: Bad Gateway")),
+            "Bitwarden server is unavailable (HTTP 502 Bad Gateway)."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("HTTP error 503: Service Unavailable")),
+            "Bitwarden server is temporarily unavailable (HTTP 503)."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("Connection timed out")),
+            "Network error: unable to reach Bitwarden server."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("operation timed out")),
+            "Network error: unable to reach Bitwarden server."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("Invalid username or password (kdf 500000 iterations)")),
+            "Invalid username, email, or master password."
+        );
+        assert_eq!(
+            sanitize_auth_error(Some("Username not found")),
+            "Invalid username, email, or master password."
+        );
+        assert_eq!(
             sanitize_auth_error(Some("Vault is locked")),
             "Vault is locked."
         );
@@ -728,7 +800,49 @@ mod tests {
         let res = auth_mgr.login_apikey("user.client-id-123", "secret-xyz");
         assert!(!res.ok);
         assert_eq!(res.status.as_deref(), Some("unauthenticated"));
-        assert!(res.error.is_some());
+        assert_eq!(
+            res.error.as_deref(),
+            Some("Network error: unable to reach Bitwarden server.")
+        );
+    }
+
+    #[test]
+    fn test_login_password_endpoint_404_error() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let handle = thread::spawn(move || {
+            let mut count = 0;
+            for mut stream in listener.incoming().flatten() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let resp =
+                    "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                let _ = stream.write_all(resp.as_bytes());
+                count += 1;
+                if count >= 2 {
+                    break;
+                }
+            }
+        });
+
+        let dir = tempdir().unwrap();
+        let storage_path = dir.path().join("test_404_data.json");
+        let storage_mgr = StorageManager::new(storage_path);
+
+        let auth_mgr = AuthManager::new(&server_url, Some(storage_mgr), None);
+        let res = auth_mgr.login_password("test@example.com", "password123", None);
+        assert!(!res.ok);
+        assert_eq!(
+            res.error.as_deref(),
+            Some("Bitwarden server endpoint not found (HTTP 404). Please verify your server URL.")
+        );
+        let _ = handle.join();
     }
 
     #[test]

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -17,6 +17,8 @@ pub const DEFAULT_LOG_LEVEL: &str = "error";
 pub struct Config {
     #[serde(default = "default_server_url")]
     pub server_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_url: Option<String>,
     #[serde(default = "default_bw_path")]
     pub bw_path: String,
     #[serde(default = "default_download_dir")]
@@ -67,6 +69,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             server_url: default_server_url(),
+            identity_url: None,
             bw_path: default_bw_path(),
             download_dir: default_download_dir(),
             auto_lock_minutes: default_auto_lock_minutes(),
@@ -133,6 +136,7 @@ mod tests {
     fn test_default_config() {
         let cfg = Config::default();
         assert_eq!(cfg.server_url, DEFAULT_SERVER_URL);
+        assert_eq!(cfg.identity_url, None);
         assert_eq!(cfg.bw_path, DEFAULT_BW_PATH);
         assert_eq!(cfg.download_dir, DEFAULT_DOWNLOAD_DIR);
         assert_eq!(cfg.auto_lock_minutes, 15);
@@ -179,6 +183,7 @@ mod tests {
         assert_eq!(loaded.email, "partial@test.com");
         assert_eq!(loaded.auto_lock_minutes, 5);
         assert_eq!(loaded.server_url, DEFAULT_SERVER_URL);
+        assert_eq!(loaded.identity_url, None);
         assert_eq!(loaded.bw_path, DEFAULT_BW_PATH);
         assert!(loaded.remember_email);
     }
@@ -192,5 +197,39 @@ mod tests {
         let mgr = ConfigManager::new(Some(&path));
         let loaded = mgr.load();
         assert_eq!(loaded, Config::default());
+    }
+
+    #[test]
+    fn test_identity_url_serialization_and_load() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mgr = ConfigManager::new(Some(&path));
+
+        let cfg = Config {
+            server_url: "https://api.bitwarden.com".to_string(),
+            identity_url: Some("https://identity.bitwarden.com".to_string()),
+            ..Default::default()
+        };
+
+        mgr.save(&cfg).unwrap();
+        let json_content = fs::read_to_string(&path).unwrap();
+        assert!(json_content.contains("\"identity_url\": \"https://identity.bitwarden.com\""));
+
+        let loaded = mgr.load();
+        assert_eq!(loaded.server_url, "https://api.bitwarden.com");
+        assert_eq!(
+            loaded.identity_url,
+            Some("https://identity.bitwarden.com".to_string())
+        );
+
+        // Test that skipping identity_url omits it from JSON when None
+        let mut cfg_no_id = cfg;
+        cfg_no_id.identity_url = None;
+        mgr.save(&cfg_no_id).unwrap();
+        let json_content_none = fs::read_to_string(&path).unwrap();
+        assert!(!json_content_none.contains("\"identity_url\""));
+
+        let loaded_none = mgr.load();
+        assert_eq!(loaded_none.identity_url, None);
     }
 }

--- a/omawarden/src/health.rs
+++ b/omawarden/src/health.rs
@@ -29,9 +29,15 @@ pub fn check_system_health(server_url: &str) -> HealthStatus {
         .build()
         .unwrap_or_default();
 
-    let prelogin_url = format!("{}/api/accounts/prelogin", server_clean);
-    let server_reachable =
-        client.get(&prelogin_url).send().is_ok() || client.get(server_clean).send().is_ok();
+    let env_urls = crate::api::EnvironmentUrls::resolve(server_url, None);
+    let prelogin_url = if env_urls.is_cloud {
+        format!("{}/accounts/prelogin", env_urls.identity_url)
+    } else {
+        format!("{}/accounts/prelogin", env_urls.api_url)
+    };
+    let server_reachable = client.get(&prelogin_url).send().is_ok()
+        || client.get(&env_urls.base_url).send().is_ok()
+        || client.get(server_clean).send().is_ok();
 
     // 2. Check Keyring (secret-tool)
     let keyring_available = which::which("secret-tool").is_ok();

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -155,6 +155,8 @@ enum AuthAction {
     LoginPassword {
         #[arg(long, required = true)]
         email: String,
+        #[arg(long, help = "Optional two-factor authentication (2FA) code")]
+        code: Option<String>,
     },
     #[command(about = "Login using API Key (client_secret read from stdin)")]
     LoginApikey {
@@ -302,12 +304,13 @@ fn read_clipboard_stdin() -> String {
 }
 
 fn read_auth_payload() -> (String, Option<String>) {
+    use std::io::Read;
     let stdin = io::stdin();
     if stdin.is_terminal() {
         return (String::new(), None);
     }
     let mut raw = String::new();
-    let _ = stdin.lock().read_line(&mut raw);
+    let _ = stdin.lock().read_to_string(&mut raw);
     let raw = raw.trim();
     if raw.is_empty() {
         return (String::new(), None);
@@ -328,7 +331,7 @@ fn read_auth_payload() -> (String, Option<String>) {
         }
     }
 
-    let mut lines = raw.splitn(2, '\n');
+    let mut lines = raw.lines();
     let first = lines
         .next()
         .unwrap_or("")
@@ -506,15 +509,16 @@ fn main() -> ExitCode {
                     println!("{}", serde_json::to_string_pretty(&st).unwrap());
                     ExitCode::SUCCESS
                 }
-                AuthAction::LoginPassword { email } => {
-                    let (pwd, code_val) = if io::stdin().is_terminal() {
+                AuthAction::LoginPassword { email, code } => {
+                    let (pwd, stdin_code) = if io::stdin().is_terminal() {
                         let p = rpassword::prompt_password("Enter Master Password: ")
                             .unwrap_or_default();
                         (p, None)
                     } else {
                         read_auth_payload()
                     };
-                    let res = auth_mgr.login_password(&email, &pwd, code_val.as_deref());
+                    let effective_code = code.or(stdin_code);
+                    let res = auth_mgr.login_password(&email, &pwd, effective_code.as_deref());
                     println!("{}", serde_json::to_string_pretty(&res).unwrap());
                     if res.ok {
                         ExitCode::SUCCESS

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -493,7 +493,12 @@ fn main() -> ExitCode {
         }
 
         Commands::Auth { action } => {
-            let auth_mgr = AuthManager::new(&cfg.server_url, None, None);
+            let auth_mgr = AuthManager::with_identity_url(
+                &cfg.server_url,
+                cfg.identity_url.as_deref(),
+                None,
+                None,
+            );
             match action {
                 AuthAction::Status => {
                     omawarden::daemon::ensure_daemon_running();
@@ -592,7 +597,12 @@ fn main() -> ExitCode {
         },
 
         Commands::Vault { action } => {
-            let vault_mgr = VaultManager::new(&cfg.server_url, None, None);
+            let vault_mgr = VaultManager::with_identity_url(
+                &cfg.server_url,
+                cfg.identity_url.as_deref(),
+                None,
+                None,
+            );
             match action {
                 VaultAction::Sync => {
                     omawarden::daemon::ensure_daemon_running();
@@ -762,7 +772,12 @@ fn main() -> ExitCode {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
 
-            let vault_mgr = VaultManager::new(&cfg.server_url, None, None);
+            let vault_mgr = VaultManager::with_identity_url(
+                &cfg.server_url,
+                cfg.identity_url.as_deref(),
+                None,
+                None,
+            );
             let item: Option<omawarden::vault::VaultItem> = if is_unlocked {
                 let daemon_res = send_daemon_request(&json!({
                     "action": "get_item",
@@ -1004,7 +1019,12 @@ fn main() -> ExitCode {
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
 
-                    let vault_mgr = VaultManager::new(&cfg.server_url, None, None);
+                    let vault_mgr = VaultManager::with_identity_url(
+                        &cfg.server_url,
+                        cfg.identity_url.as_deref(),
+                        None,
+                        None,
+                    );
                     let item: Option<omawarden::vault::VaultItem> = if is_unlocked {
                         let daemon_res = send_daemon_request(&json!({
                             "action": "get_item",
@@ -1186,7 +1206,12 @@ fn main() -> ExitCode {
         },
 
         Commands::SshKey { action } => {
-            let vault_mgr = VaultManager::new(&cfg.server_url, None, None);
+            let vault_mgr = VaultManager::with_identity_url(
+                &cfg.server_url,
+                cfg.identity_url.as_deref(),
+                None,
+                None,
+            );
             match action {
                 SshKeyAction::Create {
                     name,

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -303,20 +303,13 @@ fn read_clipboard_stdin() -> String {
     String::new()
 }
 
-fn read_auth_payload() -> (String, Option<String>) {
-    use std::io::Read;
-    let stdin = io::stdin();
-    if stdin.is_terminal() {
-        return (String::new(), None);
-    }
-    let mut raw = String::new();
-    let _ = stdin.lock().read_to_string(&mut raw);
-    let raw = raw.trim();
-    if raw.is_empty() {
+fn parse_auth_payload(raw: &str) -> (String, Option<String>) {
+    let trimmed = raw.trim_end_matches(&['\r', '\n'][..]).trim();
+    if trimmed.is_empty() {
         return (String::new(), None);
     }
 
-    if let Ok(val) = serde_json::from_str::<Value>(raw) {
+    if let Ok(val) = serde_json::from_str::<Value>(trimmed) {
         if let Some(map) = val.as_object() {
             let pwd = map
                 .get("password")
@@ -331,19 +324,26 @@ fn read_auth_payload() -> (String, Option<String>) {
         }
     }
 
-    let mut lines = raw.lines();
-    let first = lines
-        .next()
-        .unwrap_or("")
-        .trim_end_matches('\r')
-        .to_string();
-    if let Some(second) = lines.next() {
-        let second_trimmed = second.trim().to_string();
-        if !second_trimmed.is_empty() {
-            return (first, Some(second_trimmed));
+    let mut pwd = trimmed.to_string();
+    if pwd.starts_with('"') && pwd.ends_with('"') && pwd.len() >= 2 {
+        if let Ok(unescaped) = serde_json::from_str::<String>(&pwd) {
+            pwd = unescaped;
         }
     }
-    (first, None)
+
+    (pwd, None)
+}
+
+fn read_auth_payload() -> (String, Option<String>) {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return (String::new(), None);
+    }
+    let mut buffer = String::new();
+    if stdin.lock().read_line(&mut buffer).is_err() {
+        return (String::new(), None);
+    }
+    parse_auth_payload(&buffer)
 }
 
 fn main() -> ExitCode {
@@ -1630,4 +1630,37 @@ fn ensure_unlocked_user_key(
     let _ = send_daemon_request(&json!({ "action": "unlock", "password": pwd }));
 
     Ok(user_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_auth_payload_plain() {
+        let (pwd, code) = parse_auth_payload("mypassword\n");
+        assert_eq!(pwd, "mypassword");
+        assert_eq!(code, None);
+    }
+
+    #[test]
+    fn test_parse_auth_payload_json_with_code() {
+        let (pwd, code) = parse_auth_payload("{\"password\": \"secret123\", \"code\": \"654321\"}\n");
+        assert_eq!(pwd, "secret123");
+        assert_eq!(code.as_deref(), Some("654321"));
+    }
+
+    #[test]
+    fn test_parse_auth_payload_json_without_code() {
+        let (pwd, code) = parse_auth_payload("{\"password\": \"secret123\"}\n");
+        assert_eq!(pwd, "secret123");
+        assert_eq!(code, None);
+    }
+
+    #[test]
+    fn test_parse_auth_payload_empty() {
+        let (pwd, code) = parse_auth_payload("  \r\n");
+        assert_eq!(pwd, "");
+        assert_eq!(code, None);
+    }
 }

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -117,12 +117,17 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum ConfigAction {
-    #[command(about = "Get current configuration")]
-    Get,
+    #[command(about = "Get current configuration or a specific key")]
+    Get {
+        #[arg(help = "Optional configuration key to query")]
+        key: Option<String>,
+    },
     #[command(about = "Set configuration options")]
     Set {
         #[arg(long)]
         server_url: Option<String>,
+        #[arg(long)]
+        identity_url: Option<String>,
         #[arg(long)]
         bw_path: Option<String>,
         #[arg(long)]
@@ -357,12 +362,34 @@ fn main() -> ExitCode {
         }
 
         Commands::Config { action } => match action {
-            ConfigAction::Get => {
-                println!("{}", serde_json::to_string_pretty(&cfg).unwrap());
+            ConfigAction::Get { key } => {
+                if let Some(k) = key {
+                    match k.as_str() {
+                        "server_url" => println!("{}", cfg.server_url),
+                        "identity_url" => println!("{}", cfg.identity_url.as_deref().unwrap_or("")),
+                        "bw_path" => println!("{}", cfg.bw_path),
+                        "download_dir" => println!("{}", cfg.download_dir),
+                        "auto_lock_minutes" | "auto_lock" => println!("{}", cfg.auto_lock_minutes),
+                        "clipboard_clear_seconds" | "clipboard_clear" => {
+                            println!("{}", cfg.clipboard_clear_seconds)
+                        }
+                        "max_output_mb" => println!("{}", cfg.max_output_mb),
+                        "email" => println!("{}", cfg.email),
+                        "remember_email" => println!("{}", cfg.remember_email),
+                        "log_level" => println!("{}", cfg.log_level),
+                        _ => {
+                            eprintln!("Unknown configuration key: {}", k);
+                            return ExitCode::FAILURE;
+                        }
+                    }
+                } else {
+                    println!("{}", serde_json::to_string_pretty(&cfg).unwrap());
+                }
                 ExitCode::SUCCESS
             }
             ConfigAction::Set {
                 server_url,
+                identity_url,
                 bw_path,
                 download_dir,
                 auto_lock,
@@ -374,6 +401,14 @@ fn main() -> ExitCode {
             } => {
                 if let Some(v) = server_url {
                     cfg.server_url = v;
+                }
+                if let Some(v) = identity_url {
+                    let trimmed = v.trim();
+                    if trimmed.is_empty() {
+                        cfg.identity_url = None;
+                    } else {
+                        cfg.identity_url = Some(trimmed.to_string());
+                    }
                 }
                 if let Some(v) = bw_path {
                     cfg.bw_path = v;
@@ -403,18 +438,48 @@ fn main() -> ExitCode {
                 let _ = config_mgr.save(&cfg);
                 let safe_url = if cfg.server_url.is_empty() {
                     "default (official)".to_string()
-                } else if cfg.server_url.contains("vault.bitwarden.com")
-                    || cfg.server_url.contains("vault.bitwarden.eu")
-                {
-                    cfg.server_url.clone()
+                } else if let Ok(parsed) = url::Url::parse(&cfg.server_url) {
+                    if let Some(host) = parsed.host_str() {
+                        if host == "vault.bitwarden.com"
+                            || host == "api.bitwarden.com"
+                            || host == "bitwarden.com"
+                            || host == "vault.bitwarden.eu"
+                            || host == "api.bitwarden.eu"
+                            || host == "bitwarden.eu"
+                        {
+                            format!("{}://{}", parsed.scheme(), host)
+                        } else {
+                            "<REDACTED_CUSTOM_HOST>".to_string()
+                        }
+                    } else {
+                        "<REDACTED_CUSTOM_HOST>".to_string()
+                    }
                 } else {
                     "<REDACTED_CUSTOM_HOST>".to_string()
                 };
+                let safe_id_url = if let Some(ref u) = cfg.identity_url {
+                    if let Ok(parsed) = url::Url::parse(u) {
+                        if let Some(host) = parsed.host_str() {
+                            if host == "identity.bitwarden.com" || host == "identity.bitwarden.eu" {
+                                format!("{}://{}", parsed.scheme(), host)
+                            } else {
+                                "<REDACTED_CUSTOM_HOST>".to_string()
+                            }
+                        } else {
+                            "<REDACTED_CUSTOM_HOST>".to_string()
+                        }
+                    } else {
+                        "<REDACTED_CUSTOM_HOST>".to_string()
+                    }
+                } else {
+                    "auto".to_string()
+                };
                 omawarden::log_info!(
                     "omawarden:config",
-                    "Updated configuration (log_level: {}, server_url: {}).",
+                    "Updated configuration (log_level: {}, server_url: {}, identity_url: {}).",
                     cfg.log_level,
-                    safe_url
+                    safe_url,
+                    safe_id_url
                 );
                 println!("{}", serde_json::to_string_pretty(&cfg).unwrap());
                 ExitCode::SUCCESS

--- a/omawarden/src/storage.rs
+++ b/omawarden/src/storage.rs
@@ -11,8 +11,10 @@ pub const DEFAULT_STORAGE_FILENAME: &str = "data.json";
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct VaultStorage {
     pub server_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_url: Option<String>,
     pub user_email: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
     pub user_id: Option<String>,
     pub access_token: Option<String>,
@@ -134,6 +136,7 @@ mod tests {
         let storage = VaultStorage {
             user_email: "tester@domain.com".to_string(),
             server_url: "https://vaultwarden.local".to_string(),
+            identity_url: Some("https://identity.vaultwarden.local".to_string()),
             client_id: Some("user.12345678".to_string()),
             ..Default::default()
         };
@@ -142,6 +145,10 @@ mod tests {
         let loaded = mgr.load();
         assert_eq!(loaded.user_email, "tester@domain.com");
         assert_eq!(loaded.server_url, "https://vaultwarden.local");
+        assert_eq!(
+            loaded.identity_url,
+            Some("https://identity.vaultwarden.local".to_string())
+        );
         assert_eq!(loaded.client_id, Some("user.12345678".to_string()));
     }
 }

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -440,6 +440,25 @@ impl VaultManager {
 
         let sync_resp = match sync_resp_res {
             Ok(resp) => resp,
+            Err(ApiError::HttpStatus(code, _))
+                if code == reqwest::StatusCode::UNAUTHORIZED
+                    || code == reqwest::StatusCode::FORBIDDEN =>
+            {
+                crate::log_warn!(
+                    "omawarden:vault",
+                    "HTTP {} on sync. Attempting session renewal...",
+                    code
+                );
+                let renewed_token = self.renew_session()?;
+                client.sync_vault(&renewed_token).map_err(|e| {
+                    crate::log_error!(
+                        "omawarden:vault",
+                        "Sync failed after token renewal: {:?}",
+                        e
+                    );
+                    format!("Sync failed: {:?}", e)
+                })?
+            }
             Err(ApiError::Http(ref msg)) if msg.contains("401") || msg.contains("403") => {
                 crate::log_warn!(
                     "omawarden:vault",
@@ -550,10 +569,12 @@ impl VaultManager {
                     auth_failed = true;
                     last_error = Some(format!("Authentication failed: {}", msg));
                 }
-                Err(ApiError::Http(msg)) => {
+                Err(ApiError::Network(msg))
+                | Err(ApiError::Http(msg))
+                | Err(ApiError::HttpStatus(_, msg)) => {
                     crate::log_warn!(
                         "omawarden:vault",
-                        "Refresh token grant encountered network error: {}. Falling back...",
+                        "Refresh token grant encountered network or server error: {}. Falling back...",
                         msg
                     );
                     last_error = Some(format!("Network error during token refresh: {}", msg));
@@ -595,10 +616,12 @@ impl VaultManager {
                         auth_failed = true;
                         last_error = Some(format!("Authentication failed: {}", msg));
                     }
-                    Err(ApiError::Http(msg)) => {
+                    Err(ApiError::Network(msg))
+                    | Err(ApiError::Http(msg))
+                    | Err(ApiError::HttpStatus(_, msg)) => {
                         crate::log_error!(
                             "omawarden:vault",
-                            "API key silent re-auth encountered network error: {}",
+                            "API key silent re-auth encountered network or server error: {}",
                             msg
                         );
                         last_error = Some(format!(
@@ -897,6 +920,20 @@ impl VaultManager {
 
         let created_cipher = match client.create_cipher(&active_token, &payload) {
             Ok(c) => c,
+            Err(ApiError::HttpStatus(code, _))
+                if code == reqwest::StatusCode::UNAUTHORIZED
+                    || code == reqwest::StatusCode::FORBIDDEN =>
+            {
+                crate::log_warn!(
+                    "omawarden:vault",
+                    "HTTP {} creating SSH key. Attempting session renewal...",
+                    code
+                );
+                let renewed = self.renew_session()?;
+                client
+                    .create_cipher(&renewed, &payload)
+                    .map_err(|e| format!("Failed to create SSH key on server: {:?}", e))?
+            }
             Err(ApiError::Http(ref msg)) if msg.contains("401") || msg.contains("403") => {
                 crate::log_warn!(
                     "omawarden:vault",
@@ -2110,5 +2147,140 @@ esac
             fresh_storage.refresh_token,
             Some("valid_ref_token".to_string())
         );
+    }
+
+    #[test]
+    fn test_vault_sync_server_502_error_preserves_tokens() {
+        use std::fs;
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::os::unix::fs::PermissionsExt;
+        use std::thread;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let handle = thread::spawn(move || {
+            let mut count = 0;
+            for mut stream in listener.incoming().flatten() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let resp =
+                    "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                let _ = stream.write_all(resp.as_bytes());
+                count += 1;
+                if count >= 2 {
+                    break;
+                }
+            }
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage_path = dir.path().join("vault_502_preserves.json");
+        let storage_mgr = StorageManager::new(storage_path);
+
+        let store_dir = dir.path().join("store");
+        fs::create_dir_all(&store_dir).unwrap();
+        let script_path = dir.path().join("mock-secret-tool");
+
+        let script = format!(
+            r#"#!/bin/sh
+STORE_DIR="{}"
+cmd="$1"
+shift
+case "$1" in
+    --label=*)
+        shift
+        ;;
+esac
+
+key=""
+while [ $# -gt 0 ]; do
+    k="$1"
+    v="$2"
+    safe_v=$(printf '%s' "$v" | tr '/:' '_')
+    key="${{key}}__${{k}}=${{safe_v}}"
+    shift 2 2>/dev/null || shift 1
+done
+
+case "$cmd" in
+    store)
+        cat > "${{STORE_DIR}}/${{key}}"
+        exit 0
+        ;;
+    lookup)
+        if [ -f "${{STORE_DIR}}/${{key}}" ]; then
+            cat "${{STORE_DIR}}/${{key}}"
+            exit 0
+        else
+            exit 1
+        fi
+        ;;
+    clear)
+        if [ -z "$key" ] || [ "$key" = "__service=omarchy-bitwarden" ]; then
+            rm -f "${{STORE_DIR}}"/*
+        else
+            rm -f "${{STORE_DIR}}/${{key}}"*
+        fi
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+"#,
+            store_dir.display()
+        );
+
+        fs::write(&script_path, script).unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+
+        let mock_keyring = KeyringManager::new(script_path.to_str().unwrap());
+
+        // Set refresh token and api secret
+        assert!(mock_keyring.store_token(crate::keyring::KIND_REFRESH_TOKEN, "valid_ref_token"));
+        assert!(mock_keyring.store_api_secret(&server_url, "test_client_id", "test_secret"));
+
+        let storage = VaultStorage {
+            server_url: server_url.clone(),
+            user_email: "gateway502@example.com".to_string(),
+            client_id: Some("test_client_id".to_string()),
+            refresh_token: Some("valid_ref_token".to_string()),
+            ..Default::default()
+        };
+        storage_mgr.save(&storage).unwrap();
+
+        let vault_mgr = VaultManager::new(
+            &server_url,
+            Some(storage_mgr.clone()),
+            Some(mock_keyring.clone()),
+        );
+
+        // renew_session should fail due to 502 without wiping tokens
+        let res = vault_mgr.renew_session();
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Network error"));
+
+        // Keyring refresh token and api secret NOT purged
+        assert_eq!(
+            mock_keyring.get_token(crate::keyring::KIND_REFRESH_TOKEN),
+            Some("valid_ref_token".to_string())
+        );
+        assert_eq!(
+            mock_keyring.get_api_secret(&server_url, "test_client_id"),
+            Some("test_secret".to_string())
+        );
+
+        // Storage tokens NOT purged
+        let fresh_storage = storage_mgr.load();
+        assert_eq!(
+            fresh_storage.refresh_token,
+            Some("valid_ref_token".to_string())
+        );
+
+        let _ = handle.join();
     }
 }

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -263,6 +263,7 @@ pub fn parse_ssh_key_fields(
 
 pub struct VaultManager {
     pub server_url: String,
+    pub identity_url: Option<String>,
     pub storage_mgr: StorageManager,
     pub keyring_mgr: KeyringManager,
     pub storage: RwLock<VaultStorage>,
@@ -277,6 +278,15 @@ impl VaultManager {
         storage_mgr: Option<StorageManager>,
         keyring_mgr: Option<KeyringManager>,
     ) -> Self {
+        Self::with_identity_url(server_url, None, storage_mgr, keyring_mgr)
+    }
+
+    pub fn with_identity_url(
+        server_url: &str,
+        identity_url: Option<&str>,
+        storage_mgr: Option<StorageManager>,
+        keyring_mgr: Option<KeyringManager>,
+    ) -> Self {
         let sm = storage_mgr.unwrap_or_default();
         let storage = sm.load();
         let effective_url = if server_url.is_empty() {
@@ -284,9 +294,22 @@ impl VaultManager {
         } else {
             server_url.to_string()
         };
+        let effective_identity_url = if let Some(id) = identity_url {
+            let id_trim = id.trim();
+            if !id_trim.is_empty() {
+                Some(id_trim.to_string())
+            } else {
+                None
+            }
+        } else if server_url.is_empty() || server_url == storage.server_url {
+            storage.identity_url.clone()
+        } else {
+            None
+        };
 
         Self {
             server_url: effective_url,
+            identity_url: effective_identity_url,
             storage_mgr: sm,
             keyring_mgr: keyring_mgr.unwrap_or_default(),
             storage: RwLock::new(storage),
@@ -372,7 +395,11 @@ impl VaultManager {
         } else {
             &self.server_url
         };
-        let client = BitwardenApiClient::new(s_url);
+        let id_url = self
+            .identity_url
+            .as_deref()
+            .or(storage.identity_url.as_deref());
+        let client = BitwardenApiClient::with_identity_url(s_url, id_url);
 
         let initial_token = self
             .keyring_mgr
@@ -486,7 +513,11 @@ impl VaultManager {
         } else {
             &self.server_url
         };
-        let client = BitwardenApiClient::new(s_url);
+        let id_url = self
+            .identity_url
+            .as_deref()
+            .or(storage.identity_url.as_deref());
+        let client = BitwardenApiClient::with_identity_url(s_url, id_url);
 
         let mut had_credentials = false;
         let mut auth_failed = false;
@@ -853,11 +884,16 @@ impl VaultManager {
             }
         });
 
-        let client = BitwardenApiClient::new(if !storage.server_url.is_empty() {
+        let s_url = if !storage.server_url.is_empty() {
             &storage.server_url
         } else {
             &self.server_url
-        });
+        };
+        let id_url = self
+            .identity_url
+            .as_deref()
+            .or(storage.identity_url.as_deref());
+        let client = BitwardenApiClient::with_identity_url(s_url, id_url);
 
         let created_cipher = match client.create_cipher(&active_token, &payload) {
             Ok(c) => c,


### PR DESCRIPTION
Relates to #112 (Ticket 1 of 3).

## Summary of Changes
- **Configuration**: Added `identity_url: Option<String>` to `Config` in [`omawarden/src/config.rs`](file:///home/icyleaf/Development/linux/omarchy-bitwarden/omawarden/src/config.rs) with serde default handling and unit tests.
- **CLI Commands**:
  - `omawarden config set --identity-url <URL>` allows explicitly setting or clearing (passing `""`) the identity service endpoint.
  - `omawarden config get identity_url` now retrieves individual configuration keys.
- **QML Plugin**:
  - Added `Identity URL` input field in [`components/SettingsModal.qml`](file:///home/icyleaf/Development/linux/omarchy-bitwarden/components/SettingsModal.qml) right under `Server URL` with placeholder `Auto (default: identity.bitwarden.com or /identity)`.
  - Updated [`OmarchyBitwarden.qml`](file:///home/icyleaf/Development/linux/omarchy-bitwarden/OmarchyBitwarden.qml) to pass `--identity-url` when saving settings and include sanitized identity host in diagnostics.

## Verification
- [x] Unit tests: 71 passed
- [x] Clippy: clean (`-D warnings`)
- [x] QML lint: clean