### PR TITLE
feat(config): purge cache on server change, persist remembered email, and enable tab navigation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,7 +10,7 @@
 
 ### Vault & Session Lifecycle
 - **Vault**: The encrypted collection of user credentials, folders, organization collections, and attachments synced from a Bitwarden / Vaultwarden server.
-- **Server Address (`server_url`)**: The base endpoint of the Bitwarden instance (e.g., official cloud `https://vault.bitwarden.com` or custom self-hosted Vaultwarden instance).
+- **Server Address (`server_url`) & Instance Isolation**: The base endpoint of the Bitwarden instance (e.g., official cloud `https://vault.bitwarden.com` or custom self-hosted Vaultwarden instance). Updating the configuration to a different `server_url` automatically triggers instance-isolation cleanup, atomically wiping stale credentials (email, API key `client_id`, API `client_secret`), destroying active sessions (tokens and daemon memory), and purging local cache files (`data.json`, `/tmp` attachments) to prevent cross-server credential or data contamination (see `docs/adr/0008-server-switching-credential-and-cache-invalidation.md`).
 - **Authentication Modes**:
   - **Master Password Login**: Email + Master Password with PBKDF2/Argon2id client-side key derivation and 2FA challenge support.
   - **API Key Login**: Standard OAuth2 `client_credentials` flow using `client_id` and `client_secret`.
@@ -22,7 +22,7 @@
 ### Keyring & Security Policies
 - **System Keyring & Credential Persistence**: Secret storage backend (via FreeDesktop Secret Service / `secret-tool` / D-Bus) used to securely persist `access_token`, `refresh_token`, and API `client_secret` across app invocations, ensuring `data.json` on disk remains a pure zero-knowledge ciphertext store (see `docs/adr/0007-keyring-credential-persistence-and-silent-reauth.md`).
 - **Silent Background Re-authentication**: Seamless re-authentication via API `client_secret` or OAuth2 `refresh_token` when tokens expire (~2h TTL) or return 401/403, preventing disruption during background sync.
-- **Atomic Credential Erasure**: Calling `auth logout` triggers `clear_all()` across all `service=omarchy-bitwarden` entries in the OS keyring.
+- **Atomic Credential Erasure**: Calling `auth logout` or updating to a different `server_url` triggers `clear_all()` across all `service=omarchy-bitwarden` entries in the OS keyring and purges local storage (see `docs/adr/0008-server-switching-credential-and-cache-invalidation.md`).
 - **Zero-Leakage Memory Policy**: Sensitive cryptographic keys (`SymmetricCryptoKey`) and intermediate hashes derive `Zeroize` and `#[zeroize(drop)]` to enforce volatile memory destruction on drop.
 - **Zero-Argv / Zero-Environ Security Seam**: To prevent credential leakage across Linux processes (`/proc/<pid>/cmdline` and `/proc/<pid>/environ`), secrets (Master Passwords, API Secrets, TOTP seeds, Clipboard text) are delivered exclusively through protected `stdin` streams or `0600` Unix Domain Sockets.
 - **Strict File & Socket Permissions**: Disk storage (`data.json`) and the daemon Unix socket (`omawarden.sock`) enforce `0600` owner-only permissions.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,7 +57,7 @@
   - **Conjunctive Filter Pipeline**: Orthogonal multi-layer query evaluation (`Query ∧ Category ∧ VaultScope ∧ FolderScope`), enabling precise credential narrowing.
 - **Inspector Pane**: Side panel rendering details, masked secrets, live TOTP countdown, custom fields, organization/folder tags, attachments, and password history entry.
 - **Action Palette (`Ctrl+K`)**: Modal listing all contextual operations (Copy Password `↵`, Copy TOTP `Ctrl+↵`, Copy Username `Ctrl+U`, Toggle Field Visibility `Ctrl+T`, View Password History `Ctrl+H`, Open Website `Ctrl+O`, Filter by Vault/Org, Filter by Folder, Copy Organization Name, Copy Folder Name, Copy Card/Identity attributes, Copy Public/Private Key, View/Download Attachments, Lock Vault `Ctrl+L`, Sync `Ctrl+R`).
-- **Config & Settings View**: Allows user configuration of `server_url`, `download_dir`, `auto_lock_minutes`, `clipboard_clear_seconds`, `max_output_mb`, and `log_level`, with real-time CLI readiness indicators and an embedded Logs Viewer.
+- **Config & Settings View**: Allows user configuration of `server_url`, `download_dir`, `auto_lock_minutes`, `clipboard_clear_seconds`, and `log_level`, with real-time CLI readiness indicators and an embedded Logs Viewer.
 - **Observability & Diagnostics**: Dual-channel structured logging across `omawarden` (`stderr`) and Quickshell (`console.error`), featuring module prefixes (`[omawarden:cli]`, `[omarchy:ui]`), configurable log levels (`error` by default), zero-knowledge credential and custom server URL redaction, and one-click "Copy Diagnostics" for privacy-safe GitHub issue reporting (see `docs/adr/0004-structured-logging-and-diagnostics.md`).
 
 ## Boundaries & Non-Goals

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -1393,6 +1393,11 @@ Item {
     root.errorMessage = ""
     root.statusMessage = "Logging in to Bitwarden..."
     var cmd = [root.helperPath, "auth", "login-password", "--email", email]
+    if (root.rememberEmailChecked) {
+      cmd.push("--remember-email", "true")
+    } else {
+      cmd.push("--remember-email", "false")
+    }
     if (code) {
       authLoginProc.secret = JSON.stringify({ password: password, code: code })
     } else {
@@ -2142,6 +2147,7 @@ Item {
           root.config = data
           root.statusMessage = "Configuration saved successfully."
           root.refreshHealth()
+          root.refreshAuthStatus()
         } catch (e) {
           root.statusMessage = "Failed to update config."
           root.logError("omarchy:ui", "Failed to parse updated config: " + e)
@@ -2433,6 +2439,7 @@ Item {
               has_session: true
             })
             root.refreshAuthStatus()
+            root.refreshConfig()
             if (statusVal === "unlocked") {
               root.loadVaultItems()
               root.syncVault(true, true)

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -43,7 +43,6 @@ Item {
     download_dir: "~/Downloads",
     auto_lock_minutes: 15,
     clipboard_clear_seconds: 30,
-    max_output_mb: 10,
     email: "",
     remember_email: true
   })
@@ -206,19 +205,6 @@ Item {
   function refreshConfig() {
     configGetProc.command = [root.helperPath, "config", "get"]
     configGetProc.running = true
-  }
-
-  function updateConfig(options) {
-    var cmd = [root.helperPath, "config", "set"]
-    if (options.server_url !== undefined) cmd.push("--server-url", options.server_url)
-    if (options.download_dir !== undefined) cmd.push("--download-dir", options.download_dir)
-    if (options.auto_lock_minutes !== undefined) cmd.push("--auto-lock", String(options.auto_lock_minutes))
-    if (options.clipboard_clear_seconds !== undefined) cmd.push("--clipboard-clear", String(options.clipboard_clear_seconds))
-    if (options.max_output_mb !== undefined) cmd.push("--max-output-mb", String(options.max_output_mb))
-    if (options.email !== undefined) cmd.push("--email", options.email)
-    if (options.remember_email !== undefined) cmd.push("--remember-email", options.remember_email ? "true" : "false")
-    configSetProc.command = cmd
-    configSetProc.running = true
   }
 
   function downloadCli() {
@@ -1307,7 +1293,6 @@ Item {
     if (settings.download_dir !== undefined) cmd.push("--download-dir", settings.download_dir)
     if (settings.auto_lock_minutes !== undefined) cmd.push("--auto-lock", String(settings.auto_lock_minutes))
     if (settings.clipboard_clear_seconds !== undefined) cmd.push("--clipboard-clear", String(settings.clipboard_clear_seconds))
-    if (settings.max_output_mb !== undefined) cmd.push("--max-output-mb", String(settings.max_output_mb))
     if (settings.log_level !== undefined) cmd.push("--log-level", settings.log_level)
 
     configSetProc.command = cmd

--- a/components/AuthView.qml
+++ b/components/AuthView.qml
@@ -57,6 +57,14 @@ Item {
     }
   }
 
+  onConfigChanged: {
+    if (loginEmailInput && authRoot.config && authRoot.config.email && authRoot.rememberEmailChecked) {
+      if (!loginEmailInput.text || loginEmailInput.text.trim() === "") {
+        loginEmailInput.text = authRoot.config.email
+      }
+    }
+  }
+
   Flickable {
     id: authFlickable
     anchors.fill: parent

--- a/components/AuthView.qml
+++ b/components/AuthView.qml
@@ -284,7 +284,11 @@ Item {
                   id: loginEmailInput
                   anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter
                   color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: loginPwdInput
+                  KeyNavigation.backtab: authRoot.show2FAField ? login2FAInput : loginPwdInput
                   text: (authRoot.config && authRoot.config.email) ? authRoot.config.email : ""
+                  onAccepted: loginPwdInput.forceActiveFocus()
                 }
               }
             }
@@ -299,6 +303,9 @@ Item {
                   id: loginPwdInput
                   anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter
                   color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; echoMode: TextInput.Password; selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: authRoot.show2FAField ? login2FAInput : loginEmailInput
+                  KeyNavigation.backtab: loginEmailInput
                   onAccepted: {
                     if (authRoot.show2FAField && !login2FAInput.text.trim()) {
                       login2FAInput.forceActiveFocus()
@@ -321,6 +328,9 @@ Item {
                   id: login2FAInput
                   anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter
                   color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: loginEmailInput
+                  KeyNavigation.backtab: loginPwdInput
                   onAccepted: {
                     authRoot.loginPasswordRequested(loginEmailInput.text.trim(), loginPwdInput.text, login2FAInput.text.trim())
                   }
@@ -371,7 +381,15 @@ Item {
               Text { text: "API Client ID (`user.xxxxxxxx`):"; color: authRoot.foreground; font.pixelSize: 11; font.weight: Font.Medium }
               Rectangle {
                 Layout.fillWidth: true; height: 32; radius: 5; color: Qt.rgba(0, 0, 0, 0.25); border.color: apiClientIdInput.activeFocus ? authRoot.accent : authRoot.borderColor; border.width: 1
-                TextInput { id: apiClientIdInput; anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true }
+                TextInput {
+                  id: apiClientIdInput
+                  anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter
+                  color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: apiClientSecInput
+                  KeyNavigation.backtab: apiClientSecInput
+                  onAccepted: apiClientSecInput.forceActiveFocus()
+                }
               }
             }
 
@@ -381,7 +399,17 @@ Item {
               Text { text: "API Client Secret:"; color: authRoot.foreground; font.pixelSize: 11; font.weight: Font.Medium }
               Rectangle {
                 Layout.fillWidth: true; height: 32; radius: 5; color: Qt.rgba(0, 0, 0, 0.25); border.color: apiClientSecInput.activeFocus ? authRoot.accent : authRoot.borderColor; border.width: 1
-                TextInput { id: apiClientSecInput; anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; echoMode: TextInput.Password; selectByMouse: true }
+                TextInput {
+                  id: apiClientSecInput
+                  anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter
+                  color: authRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; echoMode: TextInput.Password; selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: apiClientIdInput
+                  KeyNavigation.backtab: apiClientIdInput
+                  onAccepted: {
+                    authRoot.loginApiKeyRequested(apiClientIdInput.text.trim(), apiClientSecInput.text.trim())
+                  }
+                }
               }
             }
 

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -448,6 +448,9 @@ Item {
               TextInput {
                 id: sUrlInput
                 anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: settingsRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                activeFocusOnTab: true
+                KeyNavigation.tab: idUrlInput
+                KeyNavigation.backtab: clipSecInput
                 text: (settingsRoot.config && settingsRoot.config.server_url) ? settingsRoot.config.server_url : "https://vault.bitwarden.com"
               }
             }
@@ -467,6 +470,9 @@ Item {
               TextInput {
                 id: idUrlInput
                 anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: settingsRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                activeFocusOnTab: true
+                KeyNavigation.tab: dlDirInput
+                KeyNavigation.backtab: sUrlInput
                 text: (settingsRoot.config && settingsRoot.config.identity_url) ? settingsRoot.config.identity_url : ""
               }
               Text {
@@ -489,6 +495,9 @@ Item {
               TextInput {
                 id: dlDirInput
                 anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: settingsRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                activeFocusOnTab: true
+                KeyNavigation.tab: lockMinInput
+                KeyNavigation.backtab: idUrlInput
                 text: (settingsRoot.config && settingsRoot.config.download_dir) ? settingsRoot.config.download_dir : "~/Downloads"
               }
             }
@@ -509,6 +518,9 @@ Item {
                 TextInput {
                   id: lockMinInput
                   anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: settingsRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: clipSecInput
+                  KeyNavigation.backtab: dlDirInput
                   text: (settingsRoot.config && settingsRoot.config.auto_lock_minutes) ? String(settingsRoot.config.auto_lock_minutes) : "15"
                 }
               }
@@ -524,6 +536,9 @@ Item {
                 TextInput {
                   id: clipSecInput
                   anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: 10; anchors.rightMargin: 10; anchors.verticalCenter: parent.verticalCenter; color: settingsRoot.foreground; font.family: "sans-serif"; font.pixelSize: 12; selectByMouse: true
+                  activeFocusOnTab: true
+                  KeyNavigation.tab: sUrlInput
+                  KeyNavigation.backtab: lockMinInput
                   text: (settingsRoot.config && settingsRoot.config.clipboard_clear_seconds) ? String(settingsRoot.config.clipboard_clear_seconds) : "30"
                 }
               }

--- a/docs/adr/0008-server-switching-credential-and-cache-invalidation.md
+++ b/docs/adr/0008-server-switching-credential-and-cache-invalidation.md
@@ -1,0 +1,38 @@
+# ADR 0008: Server Switching Credential and Cache Invalidation Lifecycle
+
+## Status
+Accepted
+
+## Context
+When managing Bitwarden credentials across multiple environments (such as switching between official Bitwarden cloud `https://vault.bitwarden.com` and a self-hosted Vaultwarden instance), changing the configured server URL previously only updated the `server_url` field in `config.json`.
+
+This created critical security, data integrity, and user experience issues:
+1. **Cross-Server Data Contamination**: The local ciphertext cache (`data.json`), in-memory daemon index, and temporary decrypted attachment previews (`/tmp/omarchy-bitwarden/attachments/`) retained the vault items, ciphers, folders, and organization keys belonging to the previous server.
+2. **Stale Session & Authentication Mismatches**: OAuth2 access tokens, refresh tokens, and API key secrets persisted in the OS Keyring (`service=omarchy-bitwarden`) and `data.json` were issued by the old server. Attempting to synchronize or check status against the new server with old tokens triggered HTTP 401/404 errors, broken silent re-auth loops, or silent failure modes.
+3. **Stale Credential Pre-filling**: Stored user email and API client ID from the old server remained in `config.json` and were displayed on the login screen, risking credential submission against the wrong server instance.
+
+## Decision
+1. **Normalized Server URL Comparison**:
+   - In `ConfigManager::update_config`, normalize both existing and incoming server URLs by stripping whitespace and trailing slashes (`trim().trim_end_matches('/')`).
+   - If the normalized server URL has not changed (e.g. updating unrelated settings like `auto_lock_minutes`, or saving `https://vault.bitwarden.com/` when `https://vault.bitwarden.com` is configured), the update proceeds without purging data.
+
+2. **Atomic Multi-tier Cascade Purge on Server Change**:
+   When a genuine server URL change is detected (`!new_server.is_empty() && old_server != new_server`):
+   - **Configuration (`config.json`)**: Reset `identity_url` to `None` (preventing an old server's identity endpoint from contaminating the new server unless explicitly provided). The remembered login email (`email`) in `config.json` is preserved for user convenience across server changes, whereas session-associated credentials in the vault storage and keyring are purged.
+   - **Local Ciphertext Cache (`data.json`)**: Atomically delete `data.json` (`fs::remove_file`) so no ciphers, user keys, or authenticated user session records (`storage.user_email`) from the previous server remain on disk.
+   - **System Keyring**: Execute `keyring_mgr.clear_all()` and `keyring_mgr.clear_session()`, purging all bearer tokens (`access_token`, `refresh_token`), API secrets (`api_secret`), and legacy session entries matching `service=omarchy-bitwarden`.
+   - **Daemon In-Memory Scrubbing**: Send `{"action": "stop"}` IPC to the running `omawarden` daemon process. The daemon exits immediately, destroying all decrypted in-memory vault items, cryptographic keys, and active search indices. The CLI will automatically respawn a clean daemon upon the next request.
+   - **Decrypted Temporary Files**: Call `attachment::clear_preview_attachments(None)` to recursively delete any ephemeral decrypted attachment files cached in `/tmp/omarchy-bitwarden/attachments/`.
+
+3. **Frontend UI Reactive Synchronization**:
+   - In `OmarchyBitwarden.qml`, upon completion of `configSetProc`, immediately invoke `root.refreshAuthStatus()`.
+   - The CLI responds with `status: "unauthenticated"`, `has_session: false`, and `user_email: ""`.
+   - The UI resets `rawVaultItems = []` and `filteredItems = []`, clearing any stale items from the view, and transitions directly to a clean login screen for the new server.
+
+## Consequences
+- **Positive**:
+  - **Zero Cross-Server Contamination**: Eliminates any possibility of mixing vault items, organization keys, or attachments across different Bitwarden instances.
+  - **Security & Privacy Guarantee**: Complete erasure of bearer tokens, API secrets, and cached credentials upon switching instances.
+  - **Predictable UX**: Users are presented with a clean login form targeted at the new server without confusing authentication failures caused by mismatched tokens.
+- **Trade-off**:
+  - Switching servers forces a full re-authentication and fresh vault synchronization on the newly configured instance (which is the intended and secure behavior).

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
 use crate::api::BitwardenApiClient;
+use crate::config::ConfigManager;
 use crate::keyring::{KeyringManager, KIND_ACCESS_TOKEN, KIND_REFRESH_TOKEN};
 use crate::storage::{StorageManager, VaultStorage};
 
@@ -140,6 +141,7 @@ pub struct AuthManager {
     pub identity_url: Option<String>,
     pub storage_mgr: StorageManager,
     pub keyring_mgr: KeyringManager,
+    pub config_mgr: Option<ConfigManager>,
 }
 
 impl AuthManager {
@@ -156,6 +158,16 @@ impl AuthManager {
         identity_url: Option<&str>,
         storage_mgr: Option<StorageManager>,
         keyring_mgr: Option<KeyringManager>,
+    ) -> Self {
+        Self::with_config(server_url, identity_url, storage_mgr, keyring_mgr, None)
+    }
+
+    pub fn with_config(
+        server_url: &str,
+        identity_url: Option<&str>,
+        storage_mgr: Option<StorageManager>,
+        keyring_mgr: Option<KeyringManager>,
+        config_mgr: Option<ConfigManager>,
     ) -> Self {
         let sm = storage_mgr.unwrap_or_default();
         let storage = sm.load();
@@ -177,6 +189,7 @@ impl AuthManager {
             identity_url: effective_identity_url,
             storage_mgr: sm,
             keyring_mgr: keyring_mgr.unwrap_or_default(),
+            config_mgr,
         }
     }
 
@@ -443,6 +456,14 @@ impl AuthManager {
 
         let _ = self.storage_mgr.save(&storage);
 
+        if let Some(ref cm) = self.config_mgr {
+            let mut cfg = cm.load();
+            if cfg.remember_email {
+                cfg.email = email.trim().to_lowercase();
+                let _ = cm.save(&cfg);
+            }
+        }
+
         // Auto-unlock daemon with decrypted items in memory
         crate::daemon::ensure_daemon_running();
         let _ = crate::daemon::send_daemon_request(&serde_json::json!({
@@ -588,6 +609,14 @@ impl AuthManager {
         }
 
         let _ = self.storage_mgr.save(&storage);
+
+        if let Some(ref cm) = self.config_mgr {
+            let mut cfg = cm.load();
+            if cfg.remember_email && cfg.email.is_empty() && !storage.user_email.is_empty() {
+                cfg.email = storage.user_email.clone();
+                let _ = cm.save(&cfg);
+            }
+        }
 
         crate::log_info!("omawarden:auth", "API key authentication successful.");
 
@@ -1452,5 +1481,226 @@ esac
             auth_mgr_override.identity_url,
             Some("https://new-id.custom.local".to_string())
         );
+    }
+
+    #[test]
+    fn test_login_password_persists_email_to_config_based_on_remember_email() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+
+        use aes::Aes256;
+        use base64::engine::general_purpose::STANDARD as BASE64;
+        use base64::Engine;
+        use cbc::cipher::block_padding::Pkcs7;
+        use cbc::cipher::BlockEncryptMut;
+        use cbc::cipher::KeyIvInit;
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        use crate::crypto::{derive_master_key, KdfType, SymmetricCryptoKey};
+
+        let email = "user@example.com";
+        let password = "password123";
+        let master_key =
+            derive_master_key(email, password, KdfType::Pbkdf2Sha256, 5000, None, None).unwrap();
+        let sym_key = SymmetricCryptoKey::from_master_key(&master_key);
+
+        let iv = [1u8; 16];
+        let plaintext = [2u8; 64];
+        type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+        let enc = Aes256CbcEnc::new_from_slices(&sym_key.enc_key, &iv).unwrap();
+        let mut buf = vec![0u8; 128];
+        let ct_len = enc
+            .encrypt_padded_b2b_mut::<Pkcs7>(&plaintext, &mut buf)
+            .unwrap()
+            .len();
+        let ct = &buf[..ct_len];
+
+        let mut hmac = Hmac::<Sha256>::new_from_slice(sym_key.mac_key.as_ref().unwrap()).unwrap();
+        hmac.update(&iv);
+        hmac.update(ct);
+        let mac = hmac.finalize().into_bytes();
+
+        let enc_user_key = format!(
+            "2.{}|{}|{}",
+            BASE64.encode(iv),
+            BASE64.encode(ct),
+            BASE64.encode(mac)
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let key_clone = enc_user_key.clone();
+        let handle = thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+
+                if req.contains("POST /identity/accounts/prelogin")
+                    || req.contains("POST /api/accounts/prelogin")
+                {
+                    let body = r#"{"kdf":0,"kdfIterations":5000}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("POST /identity/connect/token") {
+                    let body = format!(
+                        r#"{{"access_token":"mock_token_abc","token_type":"Bearer","Key":"{}"}}"#,
+                        key_clone
+                    );
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("GET /api/sync") {
+                    let body = r#"{"profile":{"id":"user-1","email":"user@example.com"},"ciphers":[],"folders":[],"collections":[]}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    break;
+                }
+            }
+        });
+
+        let dir = tempdir().unwrap();
+        let storage_path = dir.path().join("test_data.json");
+        let storage_mgr = StorageManager::new(storage_path);
+        let config_path = dir.path().join("config.json");
+        let config_mgr = ConfigManager::new(Some(&config_path));
+
+        // Initial state: remember_email is true, but email is empty in config.json
+        let mut cfg = config_mgr.load();
+        cfg.remember_email = true;
+        cfg.email = String::new();
+        config_mgr.save(&cfg).unwrap();
+
+        let auth_mgr = AuthManager::with_config(
+            &server_url,
+            None,
+            Some(storage_mgr),
+            None,
+            Some(config_mgr.clone()),
+        );
+
+        let res = auth_mgr.login_password("User@Example.COM", password, None);
+        assert!(res.ok, "Login should succeed: {:?}", res.error);
+
+        // Verify config.json email was populated with normalized email
+        let updated_cfg = config_mgr.load();
+        assert_eq!(
+            updated_cfg.email, "user@example.com",
+            "Config email must be saved on successful login when remember_email is true"
+        );
+        assert!(updated_cfg.remember_email);
+
+        let _ = handle.join();
+
+        // 2. When remember_email is false, email is not saved into config.json
+        let mut cfg_no_remember = config_mgr.load();
+        cfg_no_remember.remember_email = false;
+        cfg_no_remember.email = String::new();
+        config_mgr.save(&cfg_no_remember).unwrap();
+
+        let email2 = "other@example.com";
+        let master_key2 =
+            derive_master_key(email2, password, KdfType::Pbkdf2Sha256, 5000, None, None).unwrap();
+        let sym_key2 = SymmetricCryptoKey::from_master_key(&master_key2);
+        let enc2 = Aes256CbcEnc::new_from_slices(&sym_key2.enc_key, &iv).unwrap();
+        let mut buf2 = vec![0u8; 128];
+        let ct_len2 = enc2
+            .encrypt_padded_b2b_mut::<Pkcs7>(&plaintext, &mut buf2)
+            .unwrap()
+            .len();
+        let ct2 = &buf2[..ct_len2];
+
+        let mut hmac2 = Hmac::<Sha256>::new_from_slice(sym_key2.mac_key.as_ref().unwrap()).unwrap();
+        hmac2.update(&iv);
+        hmac2.update(ct2);
+        let mac2 = hmac2.finalize().into_bytes();
+
+        let key_clone2 = format!(
+            "2.{}|{}|{}",
+            BASE64.encode(iv),
+            BASE64.encode(ct2),
+            BASE64.encode(mac2)
+        );
+
+        let listener2 = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port2 = listener2.local_addr().unwrap().port();
+        let server_url2 = format!("http://127.0.0.1:{}", port2);
+
+        let handle2 = thread::spawn(move || {
+            for mut stream in listener2.incoming().flatten() {
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+
+                if req.contains("POST /identity/accounts/prelogin")
+                    || req.contains("POST /api/accounts/prelogin")
+                {
+                    let body = r#"{"kdf":0,"kdfIterations":5000}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("POST /identity/connect/token") {
+                    let body = format!(
+                        r#"{{"access_token":"mock_token_abc","token_type":"Bearer","Key":"{}"}}"#,
+                        key_clone2
+                    );
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                } else if req.contains("GET /api/sync") {
+                    let body = r#"{"profile":{"id":"user-1","email":"user@example.com"},"ciphers":[],"folders":[],"collections":[]}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    break;
+                }
+            }
+        });
+
+        let storage_path2 = dir.path().join("test_data2.json");
+        let storage_mgr2 = StorageManager::new(storage_path2);
+        let auth_mgr2 = AuthManager::with_config(
+            &server_url2,
+            None,
+            Some(storage_mgr2),
+            None,
+            Some(config_mgr.clone()),
+        );
+
+        let res2 = auth_mgr2.login_password("other@example.com", password, None);
+        assert!(res2.ok, "Login should succeed: {:?}", res2.error);
+
+        let updated_cfg2 = config_mgr.load();
+        assert_eq!(
+            updated_cfg2.email, "",
+            "Config email must remain empty when remember_email is false"
+        );
+        assert!(!updated_cfg2.remember_email);
+
+        let _ = handle2.join();
     }
 }

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -82,8 +82,15 @@ impl Default for Config {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct ConfigManager {
     pub config_path: PathBuf,
+}
+
+impl Default for ConfigManager {
+    fn default() -> Self {
+        Self::new(None)
+    }
 }
 
 impl ConfigManager {
@@ -125,6 +132,103 @@ impl ConfigManager {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
         fs::write(&self.config_path, content)
     }
+
+    pub fn update_config(
+        &self,
+        options: ConfigUpdateOptions,
+        storage_mgr: &crate::storage::StorageManager,
+        keyring_mgr: &crate::keyring::KeyringManager,
+    ) -> std::io::Result<(Config, bool)> {
+        let mut cfg = self.load();
+
+        let old_server_norm = cfg.server_url.trim().trim_end_matches('/');
+        let server_changed = if let Some(ref new_url) = options.server_url {
+            let new_server_norm = new_url.trim().trim_end_matches('/');
+            !new_server_norm.is_empty() && old_server_norm != new_server_norm
+        } else {
+            false
+        };
+
+        if let Some(v) = options.server_url {
+            cfg.server_url = v.trim().to_string();
+        }
+
+        if server_changed {
+            // Server address changed: purge identity_url (if not explicitly provided),
+            // vault cache (data.json), keyring credentials (api_secret, access_token, refresh_token, session),
+            // in-memory daemon state, and temporary preview attachments.
+            // Note: Remembered login email (cfg.email) is preserved for user convenience.
+            if options.identity_url.is_none() {
+                cfg.identity_url = None;
+            }
+
+            if storage_mgr.file_path.exists() {
+                let _ = fs::remove_file(&storage_mgr.file_path);
+            }
+
+            keyring_mgr.clear_all();
+            keyring_mgr.clear_session();
+
+            let _ = crate::daemon::send_daemon_request(&serde_json::json!({ "action": "stop" }));
+            crate::attachment::clear_preview_attachments(None);
+
+            crate::log_info!(
+                "omawarden:config",
+                "Bitwarden server URL changed to '{}'. Previous session, API credentials, and vault cache purged.",
+                cfg.server_url
+            );
+        }
+
+        if let Some(v) = options.identity_url {
+            let trimmed = v.trim();
+            if trimmed.is_empty() {
+                cfg.identity_url = None;
+            } else {
+                cfg.identity_url = Some(trimmed.to_string());
+            }
+        }
+        if let Some(v) = options.bw_path {
+            cfg.bw_path = v;
+        }
+        if let Some(v) = options.download_dir {
+            cfg.download_dir = v;
+        }
+        if let Some(v) = options.auto_lock_minutes {
+            cfg.auto_lock_minutes = v;
+        }
+        if let Some(v) = options.clipboard_clear_seconds {
+            cfg.clipboard_clear_seconds = v;
+        }
+        if let Some(v) = options.max_output_mb {
+            cfg.max_output_mb = v;
+        }
+        if let Some(v) = options.email {
+            cfg.email = v;
+        }
+        if let Some(v) = options.remember_email {
+            cfg.remember_email = v;
+        }
+        if let Some(v) = options.log_level {
+            cfg.log_level = v.to_lowercase();
+        }
+
+        self.save(&cfg)?;
+        Ok((cfg, server_changed))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ConfigUpdateOptions {
+    pub server_url: Option<String>,
+    pub identity_url: Option<String>,
+    pub bw_path: Option<String>,
+    pub download_dir: Option<String>,
+    pub auto_lock_minutes: Option<i64>,
+    pub clipboard_clear_seconds: Option<i64>,
+    pub max_output_mb: Option<i64>,
+    pub email: Option<String>,
+    pub remember_email: Option<bool>,
+    pub log_level: Option<String>,
 }
 
 #[cfg(test)]
@@ -231,5 +335,203 @@ mod tests {
 
         let loaded_none = mgr.load();
         assert_eq!(loaded_none.identity_url, None);
+    }
+
+    fn create_mock_secret_tool(dir: &std::path::Path) -> String {
+        let script_path = dir.join("mock_secret_tool.sh");
+        let store_dir = dir.join("keyring_store");
+        let _ = fs::create_dir_all(&store_dir);
+
+        let script = format!(
+            r#"#!/bin/sh
+STORE_DIR="{}"
+cmd="$1"
+shift
+
+key=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --*)
+            shift 1
+            ;;
+        *)
+            k="$1"
+            v="$2"
+            safe_v=$(printf '%s' "$v" | tr '/:' '_')
+            key="${{key}}__${{k}}=${{safe_v}}"
+            shift 2 2>/dev/null || shift 1
+            ;;
+    esac
+done
+
+case "$cmd" in
+    store)
+        cat > "${{STORE_DIR}}/${{key}}"
+        exit 0
+        ;;
+    lookup)
+        if [ -f "${{STORE_DIR}}/${{key}}" ]; then
+            cat "${{STORE_DIR}}/${{key}}"
+            exit 0
+        else
+            exit 1
+        fi
+        ;;
+    clear)
+        if [ -z "$key" ] || [ "$key" = "__service=omarchy-bitwarden" ]; then
+            rm -f "${{STORE_DIR}}"/*
+        else
+            rm -f "${{STORE_DIR}}/${{key}}"*
+        fi
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+"#,
+            store_dir.display()
+        );
+
+        fs::write(&script_path, script).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            let _ = fs::set_permissions(&script_path, perms);
+        }
+        script_path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn test_server_url_change_purges_credentials_and_cache() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        let storage_path = dir.path().join("data.json");
+        let mock_script = create_mock_secret_tool(dir.path());
+
+        let config_mgr = ConfigManager::new(Some(&config_path));
+        let storage_mgr = crate::storage::StorageManager::new(storage_path.clone());
+        let keyring_mgr = crate::keyring::KeyringManager::new(&mock_script);
+
+        // 1. Initial state on official vault server
+        let initial_cfg = Config {
+            server_url: "https://vault.bitwarden.com".to_string(),
+            email: "user@example.com".to_string(),
+            ..Default::default()
+        };
+        config_mgr.save(&initial_cfg).unwrap();
+
+        let initial_storage = crate::storage::VaultStorage {
+            server_url: "https://vault.bitwarden.com".to_string(),
+            user_email: "user@example.com".to_string(),
+            client_id: Some("user.test-api-key-id".to_string()),
+            access_token: Some("old-access-token".to_string()),
+            refresh_token: Some("old-refresh-token".to_string()),
+            ciphers: vec![serde_json::json!({"id": "cipher-1", "name": "Google"})],
+            ..Default::default()
+        };
+        storage_mgr.save(&initial_storage).unwrap();
+
+        assert!(keyring_mgr.store_token("access_token", "old-access-token"));
+        assert!(keyring_mgr.store_api_secret(
+            "https://vault.bitwarden.com",
+            "user.test-api-key-id",
+            "old-api-secret"
+        ));
+
+        assert_eq!(config_mgr.load().email, "user@example.com");
+        assert!(storage_path.exists());
+        assert!(keyring_mgr.get_token("access_token").is_some());
+        assert!(keyring_mgr
+            .get_api_secret("https://vault.bitwarden.com", "user.test-api-key-id")
+            .is_some());
+
+        // 2. Change server_url to a different server
+        let (updated_cfg, server_changed) = config_mgr
+            .update_config(
+                ConfigUpdateOptions {
+                    server_url: Some("https://vaultwarden.custom.corp".to_string()),
+                    ..Default::default()
+                },
+                &storage_mgr,
+                &keyring_mgr,
+            )
+            .unwrap();
+
+        // 3. Assert server_changed is true and previous session/tokens/data cache are purged,
+        // but remembered email in config.json is preserved
+        assert!(server_changed, "Server change must be detected");
+        assert_eq!(
+            updated_cfg.email, "user@example.com",
+            "Remembered email in config.json must be preserved when server changes"
+        );
+        assert!(
+            !storage_path.exists(),
+            "data.json cache file must be deleted when server changes"
+        );
+        assert!(
+            keyring_mgr.get_token("access_token").is_none(),
+            "Session/token in keyring must be cleared when server changes"
+        );
+        assert!(
+            keyring_mgr
+                .get_api_secret("https://vault.bitwarden.com", "user.test-api-key-id")
+                .is_none(),
+            "API secret in keyring must be cleared when server changes"
+        );
+    }
+
+    #[test]
+    fn test_same_server_url_preserves_credentials_and_cache() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        let storage_path = dir.path().join("data.json");
+        let mock_script = create_mock_secret_tool(dir.path());
+
+        let config_mgr = ConfigManager::new(Some(&config_path));
+        let storage_mgr = crate::storage::StorageManager::new(storage_path.clone());
+        let keyring_mgr = crate::keyring::KeyringManager::new(&mock_script);
+
+        let initial_cfg = Config {
+            server_url: "https://vault.bitwarden.com".to_string(),
+            email: "user@example.com".to_string(),
+            auto_lock_minutes: 15,
+            ..Default::default()
+        };
+        config_mgr.save(&initial_cfg).unwrap();
+
+        let initial_storage = crate::storage::VaultStorage {
+            server_url: "https://vault.bitwarden.com".to_string(),
+            user_email: "user@example.com".to_string(),
+            client_id: Some("user.test-api-key-id".to_string()),
+            access_token: Some("valid-token".to_string()),
+            ..Default::default()
+        };
+        storage_mgr.save(&initial_storage).unwrap();
+        assert!(keyring_mgr.store_token("access_token", "valid-token"));
+
+        // Update other settings, with same server_url (even with trailing slash)
+        let (updated_cfg, server_changed) = config_mgr
+            .update_config(
+                ConfigUpdateOptions {
+                    server_url: Some("https://vault.bitwarden.com/".to_string()),
+                    auto_lock_minutes: Some(30),
+                    ..Default::default()
+                },
+                &storage_mgr,
+                &keyring_mgr,
+            )
+            .unwrap();
+
+        assert!(!server_changed, "Same server URL must not trigger purge");
+        assert_eq!(updated_cfg.email, "user@example.com");
+        assert_eq!(updated_cfg.auto_lock_minutes, 30);
+        assert!(storage_path.exists());
+        assert_eq!(
+            keyring_mgr.get_token("access_token"),
+            Some("valid-token".to_string())
+        );
     }
 }

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -4,11 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 pub const DEFAULT_SERVER_URL: &str = "https://vault.bitwarden.com";
-pub const DEFAULT_BW_PATH: &str = "bw";
 pub const DEFAULT_DOWNLOAD_DIR: &str = "~/Downloads";
 pub const DEFAULT_AUTO_LOCK_MINUTES: i64 = 15;
 pub const DEFAULT_CLIPBOARD_CLEAR_SECONDS: i64 = 30;
-pub const DEFAULT_MAX_OUTPUT_MB: i64 = 10;
 pub const DEFAULT_EMAIL: &str = "";
 pub const DEFAULT_REMEMBER_EMAIL: bool = true;
 pub const DEFAULT_LOG_LEVEL: &str = "error";
@@ -19,16 +17,12 @@ pub struct Config {
     pub server_url: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity_url: Option<String>,
-    #[serde(default = "default_bw_path")]
-    pub bw_path: String,
     #[serde(default = "default_download_dir")]
     pub download_dir: String,
     #[serde(default = "default_auto_lock_minutes")]
     pub auto_lock_minutes: i64,
     #[serde(default = "default_clipboard_clear_seconds")]
     pub clipboard_clear_seconds: i64,
-    #[serde(default = "default_max_output_mb")]
-    pub max_output_mb: i64,
     #[serde(default = "default_email")]
     pub email: String,
     #[serde(default = "default_remember_email")]
@@ -40,9 +34,6 @@ pub struct Config {
 fn default_server_url() -> String {
     DEFAULT_SERVER_URL.to_string()
 }
-fn default_bw_path() -> String {
-    DEFAULT_BW_PATH.to_string()
-}
 fn default_download_dir() -> String {
     DEFAULT_DOWNLOAD_DIR.to_string()
 }
@@ -51,9 +42,6 @@ fn default_auto_lock_minutes() -> i64 {
 }
 fn default_clipboard_clear_seconds() -> i64 {
     DEFAULT_CLIPBOARD_CLEAR_SECONDS
-}
-fn default_max_output_mb() -> i64 {
-    DEFAULT_MAX_OUTPUT_MB
 }
 fn default_email() -> String {
     DEFAULT_EMAIL.to_string()
@@ -70,11 +58,9 @@ impl Default for Config {
         Self {
             server_url: default_server_url(),
             identity_url: None,
-            bw_path: default_bw_path(),
             download_dir: default_download_dir(),
             auto_lock_minutes: default_auto_lock_minutes(),
             clipboard_clear_seconds: default_clipboard_clear_seconds(),
-            max_output_mb: default_max_output_mb(),
             email: default_email(),
             remember_email: default_remember_email(),
             log_level: default_log_level(),
@@ -187,9 +173,6 @@ impl ConfigManager {
                 cfg.identity_url = Some(trimmed.to_string());
             }
         }
-        if let Some(v) = options.bw_path {
-            cfg.bw_path = v;
-        }
         if let Some(v) = options.download_dir {
             cfg.download_dir = v;
         }
@@ -198,9 +181,6 @@ impl ConfigManager {
         }
         if let Some(v) = options.clipboard_clear_seconds {
             cfg.clipboard_clear_seconds = v;
-        }
-        if let Some(v) = options.max_output_mb {
-            cfg.max_output_mb = v;
         }
         if let Some(v) = options.email {
             cfg.email = v;
@@ -221,11 +201,9 @@ impl ConfigManager {
 pub struct ConfigUpdateOptions {
     pub server_url: Option<String>,
     pub identity_url: Option<String>,
-    pub bw_path: Option<String>,
     pub download_dir: Option<String>,
     pub auto_lock_minutes: Option<i64>,
     pub clipboard_clear_seconds: Option<i64>,
-    pub max_output_mb: Option<i64>,
     pub email: Option<String>,
     pub remember_email: Option<bool>,
     pub log_level: Option<String>,
@@ -241,11 +219,9 @@ mod tests {
         let cfg = Config::default();
         assert_eq!(cfg.server_url, DEFAULT_SERVER_URL);
         assert_eq!(cfg.identity_url, None);
-        assert_eq!(cfg.bw_path, DEFAULT_BW_PATH);
         assert_eq!(cfg.download_dir, DEFAULT_DOWNLOAD_DIR);
         assert_eq!(cfg.auto_lock_minutes, 15);
         assert_eq!(cfg.clipboard_clear_seconds, 30);
-        assert_eq!(cfg.max_output_mb, 10);
         assert_eq!(cfg.email, "");
         assert!(cfg.remember_email);
         assert_eq!(cfg.log_level, "error");
@@ -288,7 +264,6 @@ mod tests {
         assert_eq!(loaded.auto_lock_minutes, 5);
         assert_eq!(loaded.server_url, DEFAULT_SERVER_URL);
         assert_eq!(loaded.identity_url, None);
-        assert_eq!(loaded.bw_path, DEFAULT_BW_PATH);
         assert!(loaded.remember_email);
     }
 

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -42,10 +42,7 @@ enum Commands {
         action: ConfigAction,
     },
     #[command(about = "Check CLI health and installation")]
-    Health {
-        #[arg(long, help = "Override bw binary path to check")]
-        bw_path: Option<String>,
-    },
+    Health,
     #[command(about = "Manage Bitwarden authentication and vault sessions")]
     Auth {
         #[command(subcommand)]
@@ -130,15 +127,11 @@ enum ConfigAction {
         #[arg(long)]
         identity_url: Option<String>,
         #[arg(long)]
-        bw_path: Option<String>,
-        #[arg(long)]
         download_dir: Option<String>,
         #[arg(long)]
         auto_lock: Option<i64>,
         #[arg(long)]
         clipboard_clear: Option<i64>,
-        #[arg(long)]
-        max_output_mb: Option<i64>,
         #[arg(long)]
         email: Option<String>,
         #[arg(long)]
@@ -378,13 +371,11 @@ fn main() -> ExitCode {
                     match k.as_str() {
                         "server_url" => println!("{}", cfg.server_url),
                         "identity_url" => println!("{}", cfg.identity_url.as_deref().unwrap_or("")),
-                        "bw_path" => println!("{}", cfg.bw_path),
                         "download_dir" => println!("{}", cfg.download_dir),
                         "auto_lock_minutes" | "auto_lock" => println!("{}", cfg.auto_lock_minutes),
                         "clipboard_clear_seconds" | "clipboard_clear" => {
                             println!("{}", cfg.clipboard_clear_seconds)
                         }
-                        "max_output_mb" => println!("{}", cfg.max_output_mb),
                         "email" => println!("{}", cfg.email),
                         "remember_email" => println!("{}", cfg.remember_email),
                         "log_level" => println!("{}", cfg.log_level),
@@ -401,11 +392,9 @@ fn main() -> ExitCode {
             ConfigAction::Set {
                 server_url,
                 identity_url,
-                bw_path,
                 download_dir,
                 auto_lock,
                 clipboard_clear,
-                max_output_mb,
                 email,
                 remember_email,
                 log_level,
@@ -432,11 +421,9 @@ fn main() -> ExitCode {
                 let options = ConfigUpdateOptions {
                     server_url,
                     identity_url,
-                    bw_path,
                     download_dir,
                     auto_lock_minutes: auto_lock,
                     clipboard_clear_seconds: clipboard_clear,
-                    max_output_mb,
                     email,
                     remember_email: parsed_remember_email,
                     log_level,
@@ -501,7 +488,7 @@ fn main() -> ExitCode {
             }
         },
 
-        Commands::Health { bw_path: _ } => {
+        Commands::Health => {
             let status = check_system_health(&cfg.server_url);
             println!("{}", serde_json::to_string_pretty(&status).unwrap());
             ExitCode::SUCCESS

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -2,10 +2,11 @@ use clap::{Parser, Subcommand};
 use omawarden::attachment::get_attachment;
 use omawarden::auth::AuthManager;
 use omawarden::clipboard::ClipboardManager;
-use omawarden::config::ConfigManager;
+use omawarden::config::{ConfigManager, ConfigUpdateOptions};
 use omawarden::daemon::{run_daemon_server, send_daemon_request, DaemonState};
 use omawarden::health::check_system_health;
 use omawarden::hook::install_lock_hook;
+use omawarden::keyring::KeyringManager;
 use omawarden::ssh::{
     generate_keypair, parse_private_key, write_keypair_files, write_keypair_files_named,
     SshAlgorithm,
@@ -157,6 +158,13 @@ enum AuthAction {
         email: String,
         #[arg(long, help = "Optional two-factor authentication (2FA) code")]
         code: Option<String>,
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_missing_value = "true",
+            help = "Remember email address in configuration"
+        )]
+        remember_email: Option<String>,
     },
     #[command(about = "Login using API Key (client_secret read from stdin)")]
     LoginApikey {
@@ -402,43 +410,47 @@ fn main() -> ExitCode {
                 remember_email,
                 log_level,
             } => {
-                if let Some(v) = server_url {
-                    cfg.server_url = v;
-                }
-                if let Some(v) = identity_url {
-                    let trimmed = v.trim();
-                    if trimmed.is_empty() {
-                        cfg.identity_url = None;
-                    } else {
-                        cfg.identity_url = Some(trimmed.to_string());
+                let storage_mgr = match cli.config.as_deref() {
+                    Some(cp) => {
+                        if let Some(parent) = cp.parent() {
+                            StorageManager::new(
+                                parent.join(omawarden::storage::DEFAULT_STORAGE_FILENAME),
+                            )
+                        } else {
+                            StorageManager::default()
+                        }
                     }
-                }
-                if let Some(v) = bw_path {
-                    cfg.bw_path = v;
-                }
-                if let Some(v) = download_dir {
-                    cfg.download_dir = v;
-                }
-                if let Some(v) = auto_lock {
-                    cfg.auto_lock_minutes = v;
-                }
-                if let Some(v) = clipboard_clear {
-                    cfg.clipboard_clear_seconds = v;
-                }
-                if let Some(v) = max_output_mb {
-                    cfg.max_output_mb = v;
-                }
-                if let Some(v) = email {
-                    cfg.email = v;
-                }
-                if let Some(v) = remember_email {
+                    None => StorageManager::default(),
+                };
+                let keyring_mgr = KeyringManager::default();
+
+                let parsed_remember_email = remember_email.map(|v| {
                     let lower = v.trim().to_lowercase();
-                    cfg.remember_email = matches!(lower.as_str(), "true" | "1" | "yes");
-                }
-                if let Some(v) = log_level {
-                    cfg.log_level = v.to_lowercase();
-                }
-                let _ = config_mgr.save(&cfg);
+                    matches!(lower.as_str(), "true" | "1" | "yes")
+                });
+
+                let options = ConfigUpdateOptions {
+                    server_url,
+                    identity_url,
+                    bw_path,
+                    download_dir,
+                    auto_lock_minutes: auto_lock,
+                    clipboard_clear_seconds: clipboard_clear,
+                    max_output_mb,
+                    email,
+                    remember_email: parsed_remember_email,
+                    log_level,
+                };
+
+                let (updated_cfg, _server_changed) =
+                    match config_mgr.update_config(options, &storage_mgr, &keyring_mgr) {
+                        Ok(res) => res,
+                        Err(e) => {
+                            eprintln!("Failed to save configuration: {}", e);
+                            return ExitCode::FAILURE;
+                        }
+                    };
+                cfg = updated_cfg;
                 let safe_url = if cfg.server_url.is_empty() {
                     "default (official)".to_string()
                 } else if let Ok(parsed) = url::Url::parse(&cfg.server_url) {
@@ -496,11 +508,12 @@ fn main() -> ExitCode {
         }
 
         Commands::Auth { action } => {
-            let auth_mgr = AuthManager::with_identity_url(
+            let auth_mgr = AuthManager::with_config(
                 &cfg.server_url,
                 cfg.identity_url.as_deref(),
                 None,
                 None,
+                Some(config_mgr.clone()),
             );
             match action {
                 AuthAction::Status => {
@@ -509,7 +522,11 @@ fn main() -> ExitCode {
                     println!("{}", serde_json::to_string_pretty(&st).unwrap());
                     ExitCode::SUCCESS
                 }
-                AuthAction::LoginPassword { email, code } => {
+                AuthAction::LoginPassword {
+                    email,
+                    code,
+                    remember_email,
+                } => {
                     let (pwd, stdin_code) = if io::stdin().is_terminal() {
                         let p = rpassword::prompt_password("Enter Master Password: ")
                             .unwrap_or_default();
@@ -519,6 +536,20 @@ fn main() -> ExitCode {
                     };
                     let effective_code = code.or(stdin_code);
                     let res = auth_mgr.login_password(&email, &pwd, effective_code.as_deref());
+                    if res.ok {
+                        if let Some(ref rem) = remember_email {
+                            let should_remember =
+                                matches!(rem.to_lowercase().as_str(), "true" | "1" | "yes");
+                            let mut latest_cfg = config_mgr.load();
+                            latest_cfg.remember_email = should_remember;
+                            if should_remember {
+                                latest_cfg.email = email.trim().to_lowercase();
+                            } else {
+                                latest_cfg.email.clear();
+                            }
+                            let _ = config_mgr.save(&latest_cfg);
+                        }
+                    }
                     println!("{}", serde_json::to_string_pretty(&res).unwrap());
                     if res.ok {
                         ExitCode::SUCCESS


### PR DESCRIPTION
## Summary of Changes

### 1. Server URL Invalidation & Cache Purging (ADR 0008)
- Atomically purge local vault cache (`data.json`), keyring credentials (`api_secret`, `access_token`, `refresh_token`, `session`), in-memory daemon state, and temporary decrypted attachment previews when Bitwarden server address changes.
- Documented in [ADR 0008](docs/adr/0008-server-switching-credential-and-cache-invalidation.md) and bound into `CONTEXT.md`.
- Cleaned up obsolete `bw_path` and `max_output_mb` configuration entries.

### 2. Tab & Backtab Key Focus Navigation
- Added `activeFocusOnTab: true` and configured `KeyNavigation.tab` and `KeyNavigation.backtab` across all inputs in:
  - `components/AuthView.qml`: Master Password form (Email, Password, 2FA) and API Key form (Client ID, Client Secret).
  - `components/SettingsModal.qml`: Server URL, Identity URL, Download Directory, Auto-lock Minutes, Clipboard Clear Seconds.
- Added `onAccepted` handlers to support pressing Enter for field navigation and form submission.

### 3. Remembered Email Persistence & Preservation
- Persist verified email address into `config.json` upon successful Master Password and API Key logins when `remember_email` is enabled.
- Support `--remember-email [true|false]` CLI option in `omawarden auth login-password` and pass checkbox state from QML.
- Preserve remembered login email in `config.json` across server changes for UI convenience while continuing to purge credentials, session, daemon state, and vault cache.
- Synchronize remembered email from config into `AuthView` on config updates.

## Verification
- `qmllint`: 0 errors, 0 warnings
- `cargo fmt --check`: passed
- `cargo clippy --all-targets --all-features -- -D warnings`: passed (0 warnings)
- `cargo test`: 89 lib tests + 4 bin tests passed