### PR TITLE
feat(daemon): auto-lock on screen lock, sleep, and Omarchy shell lock

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -21,6 +21,11 @@ Item {
   property var shell: null
   property var manifest: null
   property bool opened: false
+  onOpenedChanged: {
+    if (root.opened) {
+      root.refreshAuthStatus()
+    }
+  }
   function toLocalPath(url) {
     if (!url) return ""
     var str = url.toString ? url.toString() : String(url)
@@ -1501,7 +1506,7 @@ Item {
 
   Timer {
     id: lockSyncTimer
-    interval: 10000
+    interval: 3000
     running: Boolean(root.opened && root.authState && root.authState.status === "unlocked")
     repeat: true
     onTriggered: root.refreshAuthStatus()

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Powered by a dedicated pure Rust engine (`omawarden`), `omarchy-bitwarden` deliv
 | **Token & Secret Storage**     | **System Keyring Isolation** (0 plaintext tokens in local cache)     | Desktop Keychain / Electron store  | Stored in plaintext cache file or relies on insecure, leak-prone `BW_SESSION` env export |
 | **Local Data Caching**         | **Zero-Knowledge Ciphertext Cache** (fast offline search, no tokens) | Local cache file mixed with session tokens                         | Local cache file mixed with session tokens                                   |
 | **Token Expiry Handling**      | **Master Password Unlock Only** (Keyring renews tokens silently; never forces API Key re-login)      | Desktop app preserves login; prompts for master password          | Hard 2-hr expiry (`Session expired`); forces manual CLI re-login            |
-| **Lock-Screen Sync**           | **Native D-Bus / Hyprlock hooks**                                   | App idle timeout only              | None (manual lock required)                                                  |
+| **Lock-Screen Sync**           | **Native daemon auto-detection (Omarchy lock, Hyprlock, D-Bus/logind, sleep)** | App idle timeout only              | None (manual lock required)                                                  |
 | **Runtime Dependencies**       | **100% standalone binary** (Zero external deps)                      | Full Chromium/Node runtime         | Node.js environment required                                                 |
 ---
 
@@ -92,7 +92,6 @@ omarchy plugin update icyleaf.bitwarden
 ```bash
 killall omawarden
 omarchy plugin remove icyleaf.bitwarden
-rm -rf ~/.config/omarchy/hooks/system-lock.d/99-bitwarden-lock.sh
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@
 | **Token 与凭据存储** | **系统密钥环安全隔离**（本地缓存文件零明文 Token）     | 平台 Keychain / Electron 存储  | 曾默认明文写入本地缓存文件，或依赖不安全且易泄漏的 `BW_SESSION` 环境变量 |
 | **本地数据缓存**     | **纯零知识密文缓存**（离线毫秒级检索，无解密凭据）      | 本地缓存文件与认证凭据混杂                          | 本地缓存文件与认证凭据混杂                                     |
 | **Token 到期处理**   | **仅需主密码解锁，免重复登录**（后台静默续期 Token，无需频繁重输 API Key） | 桌面端支持记住登录，主要依赖主密码解锁 | 2 小时 Token 硬过期报 `Session expired`，需频繁手动重新登录 |
-| **锁屏联动**         | **原生 D-Bus / Hyprlock 挂钩**                          | 仅依赖应用内闲置超时           | 无（需手动执行锁定）                                         |
+| **锁屏联动**         | **守护进程原生自动检测（Omarchy 锁屏、Hyprlock、D-Bus/logind 睡眠与挂起）** | 仅依赖应用内闲置超时           | 无（需手动执行锁定）                                         |
 | **运行时依赖**       | **100% 独立二进制**（零外部运行时依赖）                 | 完整的 Chromium/Node 运行环境  | 需要 Node.js 环境                                            |
 ---
 
@@ -92,7 +92,6 @@ omarchy plugin update icyleaf.bitwarden
 ```bash
 killall omawarden
 omarchy plugin remove icyleaf.bitwarden
-rm -rf ~/.config/omarchy/hooks/system-lock.d/99-bitwarden-lock.sh
 ```
 
 ---

--- a/omawarden/src/daemon.rs
+++ b/omawarden/src/daemon.rs
@@ -130,6 +130,22 @@ impl DaemonState {
         false
     }
 
+    pub fn check_screen_lock(&self) -> bool {
+        self.check_screen_lock_with(is_system_or_screen_locked)
+    }
+
+    pub fn check_screen_lock_with<F>(&self, detector: F) -> bool
+    where
+        F: FnOnce() -> bool,
+    {
+        if self.vault_mgr.is_unlocked() && detector() {
+            self.lock();
+            crate::attachment::clear_preview_attachments(None);
+            return true;
+        }
+        false
+    }
+
     pub fn touch_activity(&self) {
         if let Ok(mut act) = self.last_activity.lock() {
             *act = Instant::now();
@@ -187,8 +203,15 @@ pub fn run_daemon_server(state: Arc<DaemonState>) -> std::io::Result<()> {
 
     let state_clone = state.clone();
     std::thread::spawn(move || loop {
-        std::thread::sleep(Duration::from_secs(5));
+        let is_unlocked = state_clone.vault_mgr.is_unlocked();
+        let sleep_duration = if is_unlocked {
+            Duration::from_secs(2)
+        } else {
+            Duration::from_secs(5)
+        };
+        std::thread::sleep(sleep_duration);
         state_clone.check_auto_lock();
+        state_clone.check_screen_lock();
     });
 
     for stream in listener.incoming() {
@@ -246,6 +269,115 @@ pub fn verify_peer_credentials(stream: &UnixStream) -> std::io::Result<()> {
 #[cfg(not(target_os = "linux"))]
 pub fn verify_peer_credentials(_stream: &UnixStream) -> std::io::Result<()> {
     Ok(())
+}
+
+pub const SCREEN_LOCKER_PROCESS_NAMES: &[&str] = &["hyprlock", "swaylock", "waylock", "gtklock"];
+
+pub fn get_omarchy_shell_cmd() -> Option<PathBuf> {
+    if which::which("omarchy-shell").is_ok() {
+        return Some(PathBuf::from("omarchy-shell"));
+    }
+    if let Ok(home) = env::var("HOME") {
+        let candidate = PathBuf::from(home).join(".local/share/omarchy/bin/omarchy-shell");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+pub fn is_omarchy_locked() -> bool {
+    let cmd_name = match get_omarchy_shell_cmd() {
+        Some(cmd) => cmd,
+        None => return false,
+    };
+
+    if let Ok(output) = Command::new(cmd_name).args(["lock", "isLocked"]).output() {
+        if output.status.success() {
+            let s = String::from_utf8_lossy(&output.stdout);
+            if s.trim() == "true" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+pub fn is_screen_locker_running() -> bool {
+    let locker_regex = SCREEN_LOCKER_PROCESS_NAMES.join("|");
+    if let Ok(output) = Command::new("pgrep").args(["-x", &locker_regex]).output() {
+        if output.status.success() && !output.stdout.is_empty() {
+            return true;
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(entries) = fs::read_dir("/proc") {
+            for entry in entries.flatten() {
+                let file_name = entry.file_name();
+                if let Some(name_str) = file_name.to_str() {
+                    if name_str.chars().all(|c| c.is_ascii_digit()) {
+                        let comm_path = entry.path().join("comm");
+                        if let Ok(comm) = fs::read_to_string(comm_path) {
+                            let comm = comm.trim();
+                            if SCREEN_LOCKER_PROCESS_NAMES.contains(&comm) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
+pub fn is_logind_locked_or_sleeping() -> bool {
+    // 1. Check session LockedHint
+    if let Ok(output) = Command::new("busctl")
+        .args([
+            "get-property",
+            "org.freedesktop.login1",
+            "/org/freedesktop/login1/session/auto",
+            "org.freedesktop.login1.Session",
+            "LockedHint",
+        ])
+        .output()
+    {
+        if output.status.success() {
+            let s = String::from_utf8_lossy(&output.stdout);
+            if s.trim() == "b true" {
+                return true;
+            }
+        }
+    }
+
+    // 2. Check Manager PreparingForSleep
+    if let Ok(output) = Command::new("busctl")
+        .args([
+            "get-property",
+            "org.freedesktop.login1",
+            "/org/freedesktop/login1",
+            "org.freedesktop.login1.Manager",
+            "PreparingForSleep",
+        ])
+        .output()
+    {
+        if output.status.success() {
+            let s = String::from_utf8_lossy(&output.stdout);
+            if s.trim() == "b true" {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+pub fn is_system_or_screen_locked() -> bool {
+    is_omarchy_locked() || is_screen_locker_running() || is_logind_locked_or_sleeping()
 }
 
 fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Result<()> {
@@ -737,5 +869,46 @@ mod tests {
         let (client, server) = UnixStream::pair().unwrap();
         assert!(verify_peer_credentials(&client).is_ok());
         assert!(verify_peer_credentials(&server).is_ok());
+    }
+
+    #[test]
+    fn test_check_screen_lock_custom_detector() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("daemon_data.json");
+        let storage_mgr = StorageManager::new(path);
+        let state = DaemonState::new(storage_mgr, 15);
+
+        // Vault is initially locked: detector should not be invoked or return false
+        let mut called = false;
+        assert!(!state.check_screen_lock_with(|| {
+            called = true;
+            true
+        }));
+        assert!(!called);
+        assert!(!state.vault_mgr.is_unlocked());
+
+        // Unlock the vault
+        *state.vault_mgr.is_unlocked.write().unwrap() = true;
+        assert!(state.vault_mgr.is_unlocked());
+
+        // Detector returns false -> vault remains unlocked
+        assert!(!state.check_screen_lock_with(|| false));
+        assert!(state.vault_mgr.is_unlocked());
+
+        // Detector returns true -> vault locks immediately
+        assert!(state.check_screen_lock_with(|| true));
+        assert!(!state.vault_mgr.is_unlocked());
+
+        // Subsequent call returns false because already locked
+        assert!(!state.check_screen_lock_with(|| true));
+    }
+
+    #[test]
+    fn test_screen_lock_detection_functions_safe() {
+        // Ensure detection functions execute safely without panicking
+        let _ = is_omarchy_locked();
+        let _ = is_screen_locker_running();
+        let _ = is_logind_locked_or_sleeping();
+        let _ = is_system_or_screen_locked();
     }
 }

--- a/omawarden/src/hook.rs
+++ b/omawarden/src/hook.rs
@@ -52,6 +52,11 @@ pub fn resolve_helper_executable(hint_path: Option<&str>) -> String {
     "omawarden".to_string()
 }
 
+/// Generates a bash script that executes `auth lock` when invoked by an external hook runner.
+///
+/// Note: In modern Omarchy and standard Linux desktop environments, the `omawarden daemon`
+/// automatically detects screen-locking (Omarchy shell lock, hyprlock, swaylock, waylock, gtklock)
+/// and system sleep/suspend via its background watchdog thread without requiring manual hook scripts.
 pub fn get_lock_hook_script(helper_path: &str) -> String {
     format!(
         r#"#!/usr/bin/env bash
@@ -62,6 +67,10 @@ pub fn get_lock_hook_script(helper_path: &str) -> String {
     )
 }
 
+/// Installs a system-lock hook script into `~/.config/omarchy/hooks/system-lock.d/`.
+///
+/// This provides compatibility with hook-runner environments. Modern Omarchy installations
+/// and Wayland compositors are also covered by the daemon's native auto-lock watchdog.
 pub fn install_lock_hook(
     helper_path: Option<&str>,
     hooks_base_dir: Option<&Path>,

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -174,7 +174,9 @@ enum AuthAction {
 
 #[derive(Subcommand)]
 enum HookAction {
-    #[command(about = "Install system-lock hook into Omarchy hooks directory")]
+    #[command(
+        about = "Install optional system-lock hook into Omarchy hooks directory (daemon also auto-detects locks natively)"
+    )]
     Install,
 }
 
@@ -617,7 +619,8 @@ fn main() -> ExitCode {
                 Ok(path) => {
                     let json_val = serde_json::json!({
                         "ok": true,
-                        "installed_path": path.to_string_lossy()
+                        "installed_path": path.to_string_lossy(),
+                        "note": "Lock hook installed. omawarden daemon also natively auto-detects screen lock, sleep, and Omarchy shell lock."
                     });
                     println!("{}", serde_json::to_string_pretty(&json_val).unwrap());
                     ExitCode::SUCCESS


### PR DESCRIPTION
## Summary of Changes

Modern Omarchy systems lock the screen using Quickshell IPC (`omarchy-shell lock lock`), rather than executing traditional scripts in `~/.config/omarchy/hooks/system-lock.d/`. Additionally, users may lock their screen via standard Wayland lockers (`hyprlock`, `swaylock`, etc.) or suspend/sleep their machine without an explicit hook runner.

This PR implements native, multi-layered screen-lock and sleep detection directly within the background `omawarden daemon` and front-end synchronization:

1. **Multi-Layer Screen Lock & Sleep Detection (`daemon.rs`)**:
   - **Omarchy Shell Lock**: Queries `omarchy-shell lock isLocked` via IPC.
   - **Wayland Screen Lockers**: Checks for active locker processes (`hyprlock`, `swaylock`, `waylock`, `gtklock`) using `pgrep` and direct Linux `/proc/*/comm` inspection fallback.
   - **systemd-logind Session & Sleep**: Queries `org.freedesktop.login1` for `LockedHint` on session and `PreparingForSleep` on Manager via `busctl`.
   - **Zero Overhead when Locked**: Detection only runs when the vault is currently unlocked. When unlocked, an adaptive watchdog thread checks every 2 seconds; when locked, it rests for 5 seconds.

2. **Frontend Responsiveness (`OmarchyBitwarden.qml`)**:
   - Added `onOpenedChanged` trigger to ensure immediate auth status refresh whenever the UI overlay is opened.
   - Reduced `lockSyncTimer` interval from 10s to 3s when unlocked and opened.

3. **Compatibility & Documentation**:
   - Updated `hook.rs` and CLI help to document that `omawarden daemon` provides built-in real-time screen-lock and sleep detection, while keeping `hook install` available for legacy/custom hook systems.
   - Updated feature comparison tables in `README.md` and `README.zh-CN.md`.

## Verification
- `cargo fmt --check` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed with 0 warnings.
- All 114 cargo unit tests passed.
- `test_download_engine.sh` passed (5/5 tests).