### PR TITLE
fix(ci): install libsecret-tools and ensure hermetic keyring in auth tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsecret-tools
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -812,6 +812,15 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
+    fn create_test_mock_keyring(dir: &std::path::Path) -> KeyringManager {
+        let script_path = dir.join("mock-secret-tool");
+        fs::write(&script_path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+        KeyringManager::new(script_path.to_str().unwrap())
+    }
+
     #[test]
     fn test_sanitize_auth_error_patterns() {
         assert_eq!(
@@ -990,8 +999,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage_path = dir.path().join("test_404_data.json");
         let storage_mgr = StorageManager::new(storage_path);
-
-        let auth_mgr = AuthManager::new(&server_url, Some(storage_mgr), None);
+        let mock_keyring = create_test_mock_keyring(dir.path());
+        let auth_mgr = AuthManager::new(&server_url, Some(storage_mgr), Some(mock_keyring));
         let res = auth_mgr.login_password("test@example.com", "password123", None);
         assert!(!res.ok);
         assert_eq!(
@@ -1043,8 +1052,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let storage_path = dir.path().join("test_2fa_data.json");
         let storage_mgr = StorageManager::new(storage_path);
+        let mock_keyring = create_test_mock_keyring(dir.path());
 
-        let auth_mgr = AuthManager::new(&server_url, Some(storage_mgr), None);
+        let auth_mgr = AuthManager::new(&server_url, Some(storage_mgr), Some(mock_keyring));
         let res = auth_mgr.login_password("user@example.com", "password123", None);
         assert!(!res.ok);
         assert_eq!(res.status.as_deref(), Some("unauthenticated"));
@@ -1674,11 +1684,12 @@ esac
         cfg.email = String::new();
         config_mgr.save(&cfg).unwrap();
 
+        let mock_keyring = create_test_mock_keyring(dir.path());
         let auth_mgr = AuthManager::with_config(
             &server_url,
             None,
             Some(storage_mgr),
-            None,
+            Some(mock_keyring.clone()),
             Some(config_mgr.clone()),
         );
 
@@ -1775,7 +1786,7 @@ esac
             &server_url2,
             None,
             Some(storage_mgr2),
-            None,
+            Some(mock_keyring),
             Some(config_mgr.clone()),
         );
 


### PR DESCRIPTION
## Root Cause
When enforcing keyring availability in password login (`login_password` fail-closed), 3 unit tests (`test_login_password_endpoint_404_error`, `test_login_password_two_factor_required`, `test_login_password_persists_email_to_config_based_on_remember_email`) passed `None` for `keyring_mgr`, defaulting to the host system `secret-tool`.

In GitHub Actions Ubuntu runners:
1. `secret-tool` (`libsecret-tools`) was not installed, so `keyring_mgr.is_available()` returned `false`.
2. `login_password` rejected immediately with `System keyring is not available` before making the network request to the mock servers, failing the tests.

## Solution
1. Added mock keyring fixture (`create_test_mock_keyring`) to the 3 affected unit tests so they are fully hermetic and do not depend on host binary presence.
2. Added `libsecret-tools` to `.github/workflows/ci.yml` system dependencies so the CI environment has native secret service tools installed.