### PR TITLE
sec(fs): unify atomic file operations and enforce strict 0600/0700 permissions

### DIFF
--- a/omawarden/src/attachment.rs
+++ b/omawarden/src/attachment.rs
@@ -234,7 +234,13 @@ pub fn get_attachment(
         PathBuf::from(expanded)
     };
 
-    if let Err(e) = fs::create_dir_all(&target_dir) {
+    let dir_res = if open_file || preview {
+        crate::fs_util::create_secure_dir_all(&target_dir, 0o700)
+    } else {
+        fs::create_dir_all(&target_dir)
+    };
+
+    if let Err(e) = dir_res {
         return AttachmentResponse {
             ok: false,
             error: Some(format!("Failed to create target directory: {}", e)),
@@ -248,12 +254,6 @@ pub fn get_attachment(
         };
     }
 
-    #[cfg(unix)]
-    if open_file || preview {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&target_dir, fs::Permissions::from_mode(0o700));
-    }
-
     let dest_path = target_dir.join(&safe_filename);
 
     let preview_cached_path = get_preview_dir(Some(item_id)).join(&safe_filename);
@@ -262,6 +262,7 @@ pub fn get_attachment(
     if (!open_file && !preview) && preview_cached_path.is_file() {
         if preview_cached_path != dest_path {
             let _ = fs::copy(&preview_cached_path, &dest_path);
+            let _ = crate::fs_util::ensure_secure_permissions(&dest_path, 0o600);
         }
         if let Ok(cached_bytes) = fs::read(&dest_path) {
             if is_cached_file_valid(&dest_path, expected_size, &cached_bytes) {
@@ -666,36 +667,10 @@ pub fn get_attachment(
         };
     };
 
-    let temp_part_path = target_dir.join(format!("{}.part_{}", safe_filename, std::process::id()));
-
-    #[cfg(unix)]
-    let write_res = {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        use std::os::unix::fs::PermissionsExt;
-        let mut options = fs::OpenOptions::new();
-        options.write(true).create(true).truncate(true);
-        options.mode(0o600);
-        options.open(&temp_part_path).and_then(|mut f| {
-            f.write_all(&bytes)?;
-            f.flush()?;
-            let metadata = f.metadata()?;
-            let mut perms = metadata.permissions();
-            if perms.mode() & 0o777 != 0o600 {
-                perms.set_mode(0o600);
-                let _ = fs::set_permissions(&temp_part_path, perms);
-            }
-            Ok(())
-        })
-    };
-
-    #[cfg(not(unix))]
-    let write_res = fs::write(&temp_part_path, &bytes);
-
-    if let Err(e) = write_res {
+    if let Err(e) = crate::fs_util::atomic_write_file(&dest_path, &bytes, 0o600) {
         return AttachmentResponse {
             ok: false,
-            error: Some(format!("Failed to write temporary file to disk: {}", e)),
+            error: Some(format!("Failed to write downloaded file: {}", e)),
             path: None,
             filename: None,
             action: None,
@@ -704,27 +679,6 @@ pub fn get_attachment(
             text_content: None,
             size: None,
         };
-    }
-
-    if let Err(e) = fs::rename(&temp_part_path, &dest_path) {
-        let _ = fs::remove_file(&temp_part_path);
-        return AttachmentResponse {
-            ok: false,
-            error: Some(format!("Failed to finalize downloaded file: {}", e)),
-            path: None,
-            filename: None,
-            action: None,
-            is_image: None,
-            is_text: None,
-            text_content: None,
-            size: None,
-        };
-    }
-
-    #[cfg(unix)]
-    if open_file || preview {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&dest_path, fs::Permissions::from_mode(0o600));
     }
 
     build_attachment_response(
@@ -1123,6 +1077,16 @@ mod tests {
             fs::read_to_string(&dest).unwrap(),
             "cached attachment secret content 12345"
         );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = fs::metadata(&dest).unwrap();
+            assert_eq!(
+                meta.permissions().mode() & 0o777,
+                0o600,
+                "Downloaded attachment must have 0600 permissions"
+            );
+        }
 
         // Cleanup
         let _ = fs::remove_file(&preview_file);

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -112,49 +112,12 @@ impl ConfigManager {
 
     pub fn save(&self, config: &Config) -> std::io::Result<()> {
         if let Some(parent) = self.config_path.parent() {
-            fs::create_dir_all(parent)?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                if let Ok(metadata) = fs::metadata(parent) {
-                    let mut perms = metadata.permissions();
-                    if perms.mode() & 0o777 != 0o700 {
-                        perms.set_mode(0o700);
-                        let _ = fs::set_permissions(parent, perms);
-                    }
-                }
-            }
+            crate::fs_util::create_secure_dir_all(parent, 0o700)?;
         }
         let content = serde_json::to_string_pretty(config)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-        #[cfg(unix)]
-        {
-            use std::io::Write;
-            use std::os::unix::fs::OpenOptionsExt;
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut options = fs::OpenOptions::new();
-            options.write(true).create(true).truncate(true);
-            options.mode(0o600);
-
-            let mut file = options.open(&self.config_path)?;
-            file.write_all(content.as_bytes())?;
-            file.flush()?;
-
-            let metadata = file.metadata()?;
-            let mut perms = metadata.permissions();
-            if perms.mode() & 0o777 != 0o600 {
-                perms.set_mode(0o600);
-                fs::set_permissions(&self.config_path, perms)?;
-            }
-            Ok(())
-        }
-
-        #[cfg(not(unix))]
-        {
-            fs::write(&self.config_path, content)
-        }
+        crate::fs_util::atomic_write_str(&self.config_path, &content, 0o600)
     }
 
     pub fn update_config(

--- a/omawarden/src/fs_util.rs
+++ b/omawarden/src/fs_util.rs
@@ -1,0 +1,217 @@
+use std::fs;
+use std::path::Path;
+
+use rand_core::{OsRng, RngCore};
+
+/// Recursively creates a directory and enforces the specified permission mode on Unix.
+/// Returns any I/O error instead of silently swallowing it.
+/// Skips permission modification if the path is a system shared directory like `/tmp` or `/`.
+pub fn create_secure_dir_all<P: AsRef<Path>>(path: P, mode: u32) -> std::io::Result<()> {
+    let p = path.as_ref();
+    fs::create_dir_all(p)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if p != Path::new("/tmp") && p != Path::new("/") {
+            let metadata = fs::metadata(p)?;
+            let mut perms = metadata.permissions();
+            if perms.mode() & 0o777 != mode {
+                perms.set_mode(mode);
+                fs::set_permissions(p, perms)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Atomically writes bytes to a file by first writing to a temporary file in the same
+/// parent directory with strict permissions, flushing, and then renaming into place.
+/// This guarantees crash safety, prevents partial writes, and eliminates permission race conditions.
+pub fn atomic_write_file<P: AsRef<Path>>(
+    path: P,
+    content: &[u8],
+    mode: u32,
+) -> std::io::Result<()> {
+    let dest = path.as_ref();
+    let parent = dest.parent().unwrap_or_else(|| Path::new("."));
+
+    if !parent.exists() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let filename = dest.file_name().and_then(|n| n.to_str()).unwrap_or("file");
+    let nonce = OsRng.next_u64();
+    let temp_path = parent.join(format!(
+        ".tmp_{}_{}_{}",
+        filename,
+        std::process::id(),
+        nonce
+    ));
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        options.mode(mode);
+
+        let mut file = options.open(&temp_path)?;
+        let write_res = (|| -> std::io::Result<()> {
+            file.write_all(content)?;
+            file.flush()?;
+
+            let metadata = file.metadata()?;
+            let mut perms = metadata.permissions();
+            if perms.mode() & 0o777 != mode {
+                perms.set_mode(mode);
+                fs::set_permissions(&temp_path, perms)?;
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = write_res {
+            let _ = fs::remove_file(&temp_path);
+            return Err(e);
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        if let Err(e) = fs::write(&temp_path, content) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(e);
+        }
+    }
+
+    if let Err(e) = fs::rename(&temp_path, dest) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(e);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = fs::metadata(dest) {
+            let mut perms = metadata.permissions();
+            if perms.mode() & 0o777 != mode {
+                perms.set_mode(mode);
+                fs::set_permissions(dest, perms)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Atomically writes a string slice to a file with strict permissions.
+pub fn atomic_write_str<P: AsRef<Path>>(path: P, content: &str, mode: u32) -> std::io::Result<()> {
+    atomic_write_file(path, content.as_bytes(), mode)
+}
+
+/// Enforces the given permission mode on an existing file or directory on Unix.
+pub fn ensure_secure_permissions<P: AsRef<Path>>(path: P, mode: u32) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = fs::metadata(path.as_ref())?;
+        let mut perms = metadata.permissions();
+        if perms.mode() & 0o777 != mode {
+            perms.set_mode(mode);
+            fs::set_permissions(path.as_ref(), perms)?;
+        }
+    }
+    let _ = path;
+    let _ = mode;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_create_secure_dir_all() {
+        let tmp = tempdir().unwrap();
+        let secure_dir = tmp.path().join("nested").join("secure_dir");
+
+        create_secure_dir_all(&secure_dir, 0o700).unwrap();
+        assert!(secure_dir.is_dir());
+
+        #[cfg(unix)]
+        {
+            let meta = fs::metadata(&secure_dir).unwrap();
+            assert_eq!(meta.permissions().mode() & 0o777, 0o700);
+        }
+
+        // Test updating existing directory permissions
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&secure_dir).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&secure_dir, perms).unwrap();
+            assert_eq!(
+                fs::metadata(&secure_dir).unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+
+            create_secure_dir_all(&secure_dir, 0o700).unwrap();
+            assert_eq!(
+                fs::metadata(&secure_dir).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+    }
+
+    #[test]
+    fn test_atomic_write_file_and_permissions() {
+        let tmp = tempdir().unwrap();
+        let target_file = tmp.path().join("secure.json");
+
+        let data = b"{\"sensitive\": \"data\"}";
+        atomic_write_file(&target_file, data, 0o600).unwrap();
+
+        assert!(target_file.is_file());
+        assert_eq!(fs::read(&target_file).unwrap(), data);
+
+        #[cfg(unix)]
+        {
+            let meta = fs::metadata(&target_file).unwrap();
+            assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        }
+
+        // Overwrite atomically
+        let updated = b"{\"sensitive\": \"new_data\"}";
+        atomic_write_file(&target_file, updated, 0o600).unwrap();
+        assert_eq!(fs::read(&target_file).unwrap(), updated);
+
+        #[cfg(unix)]
+        {
+            let meta = fs::metadata(&target_file).unwrap();
+            assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn test_atomic_write_str() {
+        let tmp = tempdir().unwrap();
+        let target_file = tmp.path().join("secure_text.txt");
+
+        atomic_write_str(&target_file, "secret text", 0o600).unwrap();
+        assert_eq!(fs::read_to_string(&target_file).unwrap(), "secret text");
+
+        #[cfg(unix)]
+        {
+            let meta = fs::metadata(&target_file).unwrap();
+            assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        }
+    }
+}

--- a/omawarden/src/lib.rs
+++ b/omawarden/src/lib.rs
@@ -5,6 +5,7 @@ pub mod clipboard;
 pub mod config;
 pub mod crypto;
 pub mod daemon;
+pub mod fs_util;
 pub mod health;
 pub mod hook;
 pub mod keyring;

--- a/omawarden/src/ssh.rs
+++ b/omawarden/src/ssh.rs
@@ -1,7 +1,4 @@
 use std::fmt;
-use std::fs::{self, OpenOptions};
-use std::io::Write;
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -187,38 +184,22 @@ pub fn write_keypair_files_named(
     private_key: &str,
     public_key: &str,
 ) -> std::io::Result<(PathBuf, PathBuf)> {
-    if !out_dir.exists() {
-        fs::create_dir_all(out_dir)?;
-    }
+    crate::fs_util::create_secure_dir_all(out_dir, 0o700)?;
 
     let priv_path = out_dir.join(priv_filename);
     let pub_path = out_dir.join(pub_filename);
 
-    // Write private key with strict 0600 permissions
-    let mut priv_file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&priv_path)?;
-    priv_file.write_all(private_key.as_bytes())?;
-    if !private_key.ends_with('\n') {
-        priv_file.write_all(b"\n")?;
+    let mut priv_content = private_key.to_string();
+    if !priv_content.ends_with('\n') {
+        priv_content.push('\n');
     }
-    priv_file.flush()?;
+    crate::fs_util::atomic_write_str(&priv_path, &priv_content, 0o600)?;
 
-    // Write public key with 0644 permissions
-    let mut pub_file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o644)
-        .open(&pub_path)?;
-    pub_file.write_all(public_key.as_bytes())?;
-    if !public_key.ends_with('\n') {
-        pub_file.write_all(b"\n")?;
+    let mut pub_content = public_key.to_string();
+    if !pub_content.ends_with('\n') {
+        pub_content.push('\n');
     }
-    pub_file.flush()?;
+    crate::fs_util::atomic_write_str(&pub_path, &pub_content, 0o644)?;
 
     Ok((priv_path, pub_path))
 }
@@ -242,7 +223,6 @@ pub fn write_keypair_files(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
     #[test]
@@ -287,23 +267,41 @@ mod tests {
     #[test]
     fn test_write_keypair_files_permissions() {
         let dir = tempdir().unwrap();
+        let sub_dir = dir.path().join("nested_ssh");
         let priv_content =
             "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----";
         let pub_content = "ssh-ed25519 AAAAC3 test@host";
 
         let (priv_path, pub_path) =
-            write_keypair_files(dir.path(), "id_ed25519", priv_content, pub_content).unwrap();
+            write_keypair_files(&sub_dir, "id_ed25519", priv_content, pub_content).unwrap();
 
         assert!(priv_path.exists());
         assert!(pub_path.exists());
 
-        let priv_meta = fs::metadata(&priv_path).unwrap();
-        let pub_meta = fs::metadata(&pub_path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::fs;
+            use std::os::unix::fs::PermissionsExt;
 
-        let priv_mode = priv_meta.permissions().mode() & 0o777;
-        let pub_mode = pub_meta.permissions().mode() & 0o777;
+            let dir_meta = fs::metadata(&sub_dir).unwrap();
+            let priv_meta = fs::metadata(&priv_path).unwrap();
+            let pub_meta = fs::metadata(&pub_path).unwrap();
 
-        assert_eq!(priv_mode, 0o600, "Private key must have 0600 permissions");
-        assert_eq!(pub_mode, 0o644, "Public key must have 0644 permissions");
+            assert_eq!(
+                dir_meta.permissions().mode() & 0o777,
+                0o700,
+                "SSH output directory must have 0700 permissions"
+            );
+            assert_eq!(
+                priv_meta.permissions().mode() & 0o777,
+                0o600,
+                "Private key must have 0600 permissions"
+            );
+            assert_eq!(
+                pub_meta.permissions().mode() & 0o777,
+                0o644,
+                "Public key must have 0644 permissions"
+            );
+        }
     }
 }

--- a/omawarden/src/storage.rs
+++ b/omawarden/src/storage.rs
@@ -79,50 +79,12 @@ impl StorageManager {
 
     pub fn save(&self, data: &VaultStorage) -> std::io::Result<()> {
         if let Some(parent) = self.file_path.parent() {
-            fs::create_dir_all(parent)?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                if let Ok(metadata) = fs::metadata(parent) {
-                    let mut perms = metadata.permissions();
-                    if perms.mode() & 0o777 != 0o700 {
-                        perms.set_mode(0o700);
-                        let _ = fs::set_permissions(parent, perms);
-                    }
-                }
-            }
+            crate::fs_util::create_secure_dir_all(parent, 0o700)?;
         }
         let content = serde_json::to_string_pretty(data)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-        #[cfg(unix)]
-        {
-            use std::io::Write;
-            use std::os::unix::fs::OpenOptionsExt;
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut options = fs::OpenOptions::new();
-            options.write(true).create(true).truncate(true);
-            options.mode(0o600);
-
-            let mut file = options.open(&self.file_path)?;
-            file.write_all(content.as_bytes())?;
-            file.flush()?;
-
-            let metadata = file.metadata()?;
-            let mut perms = metadata.permissions();
-            if perms.mode() & 0o777 != 0o600 {
-                perms.set_mode(0o600);
-                fs::set_permissions(&self.file_path, perms)?;
-            }
-        }
-
-        #[cfg(not(unix))]
-        {
-            fs::write(&self.file_path, content)?;
-        }
-
-        Ok(())
+        crate::fs_util::atomic_write_str(&self.file_path, &content, 0o600)
     }
 
     pub fn unlock_user_key(


### PR DESCRIPTION
## Summary of Changes

This PR implements **Candidate 2 (Unified SecureFs Adapter)** from the global security and architectural review, strictly adhering to **Principle 5 (Atomic 0600 Permissions)** of `docs/agents/security.md`.

### Key Improvements

1. **New Unified `omawarden::fs_util` Adapter**:
   - Provides `atomic_write_file` and `atomic_write_str` that create temporary files (`.tmp_*`) with `0o600` mode at creation time, flush buffers, double-check metadata permissions, and atomically rename them to destination paths.
   - Provides `create_secure_dir_all` to create directories with `0o700` on Unix while safely skipping root and `/tmp` directory mode alterations.
   - Eliminates file truncation race conditions and partial file corruption on power-loss or abrupt process exit.

2. **Full Permission Coverage for Attachments**:
   - Enforces `0o600` permissions across **all** downloaded files in `attachment.rs` (previously only applied when `open_file || preview` was true).
   - Enforces `0o700` permissions on preview/temporary cache directories.
   - Eliminates redundant/boilerplate file writing code across `attachment.rs`.

3. **Secure SSH Keypair Output**:
   - Enforces `0o700` mode on target output directories when generating or exporting SSH keypairs in `ssh.rs`.
   - Uses atomic writes for private keys (`0o600`) and public keys (`0o644`).

4. **Error Propagation & Code Quality**:
   - Replaced silent error swallowing (`let _ = fs::set_permissions`) in `storage.rs` and `config.rs` with strict error propagation.
   - Net reduction of 112 lines of fragmented boilerplate code.
   - Added unit tests for `fs_util`, SSH directory permission verification, and attachment permission assertions.