### PR TITLE
sec(cli): enforce stdin for totp secrets and harden script arguments

### DIFF
--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -91,7 +91,15 @@ enum Commands {
     Totp {
         #[arg(index = 1, help = "Vault item ID, name query, secret, or otpauth URI")]
         query: Option<String>,
-        #[arg(long, help = "Explicit TOTP secret or otpauth URI")]
+        #[arg(
+            long,
+            help = "Read secret, otpauth URI, or query JSON from standard input"
+        )]
+        stdin: bool,
+        #[arg(
+            long,
+            help = "Explicit TOTP secret or otpauth URI (deprecated: use STDIN for secret hygiene)"
+        )]
         secret: Option<String>,
         #[arg(long, help = "Copy generated code directly to clipboard")]
         copy: bool,
@@ -1039,16 +1047,72 @@ fn main() -> ExitCode {
 
         Commands::Totp {
             query,
+            stdin,
             secret,
             copy,
         } => {
             let clip_mgr = ClipboardManager::default();
 
-            let (totp_res, item_info) = if let Some(sec) = secret {
+            let (totp_res, item_info) = if stdin {
+                let stdin_val = read_secret_stdin();
+                if stdin_val.is_empty() {
+                    (None, None)
+                } else if let Ok(val) = serde_json::from_str::<Value>(&stdin_val) {
+                    if let Some(sec) = val.get("secret").and_then(|v| v.as_str()) {
+                        (generate_totp(sec, None, 6, 30), None)
+                    } else if let Some(q) = val
+                        .get("query")
+                        .or_else(|| val.get("id"))
+                        .and_then(|v| v.as_str())
+                    {
+                        let daemon_res = send_daemon_request(&json!({
+                            "action": "totp",
+                            "query": q
+                        }));
+                        if let Some(res) = daemon_res {
+                            if res.get("ok").and_then(|v| v.as_bool()) == Some(true) {
+                                let code = res
+                                    .get("code")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default()
+                                    .to_string();
+                                let ttl = res.get("ttl").and_then(|v| v.as_u64()).unwrap_or(30);
+                                let period =
+                                    res.get("period").and_then(|v| v.as_u64()).unwrap_or(30);
+                                let name =
+                                    res.get("name").and_then(|v| v.as_str()).map(String::from);
+                                let id = res.get("id").and_then(|v| v.as_str()).map(String::from);
+                                (
+                                    Some(omawarden::totp::TotpResult { code, ttl, period }),
+                                    if let (Some(id), Some(name)) = (id, name) {
+                                        Some((id, name))
+                                    } else {
+                                        None
+                                    },
+                                )
+                            } else {
+                                (None, None)
+                            }
+                        } else {
+                            (None, None)
+                        }
+                    } else {
+                        (generate_totp(&stdin_val, None, 6, 30), None)
+                    }
+                } else {
+                    (generate_totp(&stdin_val, None, 6, 30), None)
+                }
+            } else if let Some(sec) = secret {
+                eprintln!(
+                    "Warning: Passing secret via --secret CLI argument is insecure and visible in /proc. Pass via STDIN instead."
+                );
                 (generate_totp(&sec, None, 6, 30), None)
             } else if let Some(q) = query {
                 let is_uri = q.starts_with("otpauth://") || q.starts_with("otpauth-migration://");
                 if is_uri {
+                    eprintln!(
+                        "Warning: Passing otpauth URI containing secrets in CLI arguments is insecure and visible in /proc. Pass via STDIN instead."
+                    );
                     (generate_totp(&q, None, 6, 30), None)
                 } else {
                     omawarden::daemon::ensure_daemon_running();
@@ -1717,6 +1781,55 @@ mod tests {
         match cli_explicit.command {
             Commands::Daemon { auto_lock } => assert_eq!(auto_lock, Some(45)),
             _ => panic!("Expected Commands::Daemon"),
+        }
+    }
+
+    #[test]
+    fn test_cli_totp_stdin_and_secret_arg_parsing() {
+        let cli_stdin = Cli::try_parse_from(["omawarden", "totp", "--stdin"]).unwrap();
+        match cli_stdin.command {
+            Commands::Totp {
+                stdin,
+                secret,
+                query,
+                ..
+            } => {
+                assert!(stdin);
+                assert_eq!(secret, None);
+                assert_eq!(query, None);
+            }
+            _ => panic!("Expected Commands::Totp"),
+        }
+
+        let cli_secret =
+            Cli::try_parse_from(["omawarden", "totp", "--secret", "JBSWY3DPEHPK3PXP"]).unwrap();
+        match cli_secret.command {
+            Commands::Totp {
+                stdin,
+                secret,
+                query,
+                ..
+            } => {
+                assert!(!stdin);
+                assert_eq!(secret.as_deref(), Some("JBSWY3DPEHPK3PXP"));
+                assert_eq!(query, None);
+            }
+            _ => panic!("Expected Commands::Totp"),
+        }
+
+        let cli_query = Cli::try_parse_from(["omawarden", "totp", "my-github-item"]).unwrap();
+        match cli_query.command {
+            Commands::Totp {
+                stdin,
+                secret,
+                query,
+                ..
+            } => {
+                assert!(!stdin);
+                assert_eq!(secret, None);
+                assert_eq!(query.as_deref(), Some("my-github-item"));
+            }
+            _ => panic!("Expected Commands::Totp"),
         }
     }
 }

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -3,12 +3,18 @@ set -e
 
 REPO="${1:-icyleaf/omarchy-bitwarden}"
 
+# Validate repository format to prevent script and URL injection
+if [[ ! "$REPO" =~ ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ ]]; then
+  echo '{"ok":false,"error":"Invalid repository format"}'
+  exit 1
+fi
+
 # 1. Try using python3 for full JSON fetching and safe parsing (releases API)
 if command -v python3 >/dev/null 2>&1; then
-  python3 - <<EOF
+  python3 - "$REPO" << 'EOF'
 import json, sys, urllib.request
 
-repo = "${REPO}"
+repo = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else "icyleaf/omarchy-bitwarden"
 headers = {"User-Agent": "OmarchyBitwarden"}
 req = urllib.request.Request(f"https://api.github.com/repos/{repo}/releases?per_page=10", headers=headers)
 try:

--- a/scripts/download-engine.sh
+++ b/scripts/download-engine.sh
@@ -5,6 +5,12 @@ TARGET_DIR="${1:-$HOME/.config/omarchy/plugins/icyleaf.bitwarden/bin}"
 REPO="${2:-icyleaf/omarchy-bitwarden}"
 TAG="${3:-${OMAWARDEN_TAG:-}}"
 
+# Validate repository format to prevent path or URL injection
+if [[ ! "$REPO" =~ ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ ]]; then
+  echo "{\"ok\":false,\"error\":\"Invalid repository format: $REPO\"}"
+  exit 1
+fi
+
 ARCH=$(uname -m)
 case "$ARCH" in
   x86_64) TRIPLE="x86_64-unknown-linux-gnu" ;;


### PR DESCRIPTION
## Summary of Changes

This PR addresses Candidate 4 from the global security architecture review:

1. **CLI Secret Hygiene (`omawarden totp`)**:
   - Added `--stdin` flag to `omawarden totp` to read TOTP secret, `otpauth://` URI, or query JSON payload directly from standard input instead of command-line arguments.
   - Deprecated the `--secret` argument and added warnings printed to `stderr` when secrets or `otpauth://` URIs are passed via `argv` (which are exposed in `/proc/$pid/cmdline` to other users/processes on multi-user systems).
   - Added unit test `test_cli_totp_stdin_and_secret_arg_parsing` verifying clap parsing of `--stdin`, `--secret`, and query arguments.

2. **Script Argument Validation & Python Heredoc Hardening**:
   - `scripts/check-update.sh`: Validates `REPO` with `^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$` to reject invalid repository formats and potential command/URL injections. Passes `"$REPO"` as an argument to `python3 - "$REPO" << 'EOF'` with a single-quoted heredoc to eliminate shell parameter expansion/injection in the embedded Python script.
   - `scripts/download-engine.sh`: Added format validation for `REPO` against `^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$` to prevent directory traversal or URL parameter injection.

## Verification
- `cargo fmt --check` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed (0 warnings).
- `XDG_RUNTIME_DIR=/tmp cargo test` passed (all 112 lib tests + 6 bin tests).