### PR TITLE
sec(crypto): implement physical memory locking (mlock) and anti-dump protection

### DIFF
--- a/docs/adr/0009-physical-memory-locking-and-memory-protection.md
+++ b/docs/adr/0009-physical-memory-locking-and-memory-protection.md
@@ -1,0 +1,103 @@
+# ADR 0009: Physical Memory Locking (mlock) and Anti-Dumping Protection for Cryptographic Secrets
+
+## Status
+Proposed
+
+## Context
+
+In password management engines like `omawarden`, cryptographic keys—specifically the derived Master Key, User Symmetric Encryption/MAC Keys (`SymmetricCryptoKey`), and Master Password hashes—are resident in process memory while the vault is unlocked.
+
+Currently, `omawarden` utilizes the `zeroize` crate to overwrite memory buffers with zeroes upon deallocation (`Drop`). While effective against residual memory leakage upon clean deallocation, this mechanism does not protect against two critical OS-level threat vectors:
+
+1. **Linux Kernel Swap Paging to Disk**:
+   Under memory pressure, the Linux kernel virtual memory subsystem periodically flushes anonymous heap pages to disk swap partitions or swap files (`/swapfile`). Sensitive cryptographic keys held in ordinary heap memory (`Vec<u8>`, `[u8; 32]`) may be silently persisted onto persistent disk sectors in unencrypted plaintext, leaving residual keys extractable via physical disk forensics or after system reboot.
+
+2. **Process Memory Dumping & Inspection**:
+   - **Crash Coredumps**: If the daemon or CLI terminates abnormally (e.g. panic or fatal signal), `systemd-coredump` or the kernel core dumper writes the full virtual address space of the process to `/var/lib/systemd/coredump/` or the current directory, exposing master keys in plaintext.
+   - **PTRACE / Debugger Attachment**: Other processes running under the same user ID (e.g. compromised browser extensions, unvetted user scripts) can attach via `ptrace(PTRACE_ATTACH, ...)` or read `/proc/$pid/mem` to extract decrypted keys from a running daemon.
+
+Prior art in the Linux ecosystem (notably `rbw`, the unofficial Bitwarden CLI) implements memory locking via `mlock` and disables process tracing via `prctl(PR_SET_DUMPABLE, 0)`. However, naive implementation of `mlock` on small heap buffers suffers from page-sharing race hazards: because Linux `mlock`/`munlock` operates on 4KB memory page boundaries, unlocking one key buffer can prematurely unlock another key buffer allocated by `malloc` on the same page.
+
+---
+
+## Decision
+
+We will implement a dedicated physical memory locking architecture and anti-dumping protections in `omawarden`:
+
+### 1. Page-Aligned Secure Memory Container (`omawarden/src/locked.rs`)
+
+We introduce a dedicated `LockedMemory<const N: usize>` (and ergonomic aliases `LockedKey32 = LockedMemory<32>`, `LockedKey64 = LockedMemory<64>`) with the following invariants:
+
+- **Isolated Page Allocation**:
+  Memory is allocated using `std::alloc::alloc` with `Layout::from_size_align(PAGE_SIZE, PAGE_SIZE)` (where `PAGE_SIZE = 4096` on x86_64/aarch64 Linux). Each sensitive key resides in its own isolated memory page, eliminating any possibility of page-sharing race conditions during `munlock`.
+- **Physical Memory Lock (`mlock`)**:
+  Upon allocation, invoke `libc::mlock(ptr as *const libc::c_void, PAGE_SIZE)` to lock the physical page into RAM and prevent kernel swap out to disk.
+- **Graceful Fallback on Resource Limits**:
+  If `mlock` returns `EPERM` or `ENOMEM` (e.g., inside restricted container environments or when `RLIMIT_MEMLOCK` is zero), log a one-time diagnostic warning and fall back gracefully to unlocked page memory without crashing. Memory sanitization (`zeroize`) remains fully active.
+- **Guaranteed Cleanup on Drop**:
+  On `Drop`, the container:
+  1. Overwrites the active buffer and the entire 4KB page with zeroes using `zeroize::Zeroize`.
+  2. Calls `libc::munlock(ptr as *const libc::c_void, PAGE_SIZE)`.
+  3. Deallocates the page via `std::alloc::dealloc`.
+
+```rust
+pub struct LockedMemory<const N: usize> {
+    ptr: std::ptr::NonNull<u8>,
+    layout: std::alloc::Layout,
+    is_locked: bool,
+}
+```
+
+### 2. Cryptographic Key Hardening (`omawarden/src/crypto.rs`)
+
+Refactor `SymmetricCryptoKey` and key derivation functions to be backed by `LockedKey32`:
+
+- `SymmetricCryptoKey`:
+  ```rust
+  #[derive(Clone)]
+  pub struct SymmetricCryptoKey {
+      pub enc_key: LockedKey32,
+      pub mac_key: Option<LockedKey32>,
+  }
+  ```
+- `derive_master_key`: Returns `Result<LockedKey32, CryptoError>`, guaranteeing that the raw derived master key is locked into RAM immediately upon creation.
+
+### 3. State & Vault Management Protection (`vault.rs`, `daemon.rs`)
+
+- In `VaultManager`:
+  `pub user_key: RwLock<Option<SymmetricCryptoKey>>` holds the locked keys. While the vault is unlocked, all encryption/decryption operations reference locked memory pages that cannot be paged to swap.
+- Upon `vault_mgr.lock()`:
+  Setting `user_key = None` triggers immediate `Drop`, which zeroes out the memory page, calls `munlock`, and frees the page.
+
+### 4. Process Anti-Tracing and Coredump Suppression
+
+In `omawarden daemon` initialization and CLI startup:
+- On Linux, invoke:
+  ```rust
+  #[cfg(target_os = "linux")]
+  pub fn disable_dumpable() -> Result<(), std::io::Error> {
+      let ret = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0) };
+      if ret == 0 {
+          Ok(())
+      } else {
+          Err(std::io::Error::last_os_error())
+      }
+  }
+  ```
+  This single call:
+  - Disables `ptrace` attachment from non-root same-UID processes.
+  - Disables Linux kernel and `systemd-coredump` core dumps upon process crash.
+  - Prevents `/proc/$pid/mem` snooping.
+
+---
+
+## Consequences
+
+### Positive
+- **Immunity to Swap Leakage**: Master keys and user decryption keys are pinned to physical RAM and will never be flushed to swap files or partitions.
+- **Zero Page Collisions**: Dedicated page alignment (`align: 4096`) guarantees that dropping one key will never prematurely unlock adjacent keys.
+- **Anti-Forensics & Anti-Dump**: `PR_SET_DUMPABLE = 0` eliminates core dump leakage and blocks user-space memory scrapers.
+- **Fail-Safe Portability**: Gracefully degrades in resource-constrained environments (containers/CI) where `mlock` is restricted, without breaking functionality.
+
+### Trade-offs & Mitigations
+- **Memory Footprint**: Each locked key occupies one 4KB page. In a typical running instance (1 master key, 1 user key with enc/mac, 1-2 organization keys), total locked memory is 16–24 KB, well below standard Linux `ulimit -l` limits (typically 8,192 KB).

--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -18,6 +18,7 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 │ 4. RFC 6454 Same-Origin      │ Exact scheme+host+port match; NO prefix match│
 │ 5. Atomic 0600 Permissions   │ Restrictive mode set at creation time        │
 │ 6. IPC SO_PEERCRED Auth      │ Verify caller UID on all socket requests     │
+│ 7. Memory Locking (mlock)    │ Page-aligned physical RAM lock & no coredump │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -129,6 +130,24 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ---
 
+### Rule 7: Physical Memory Locking (`mlock`) and Anti-Dump Protection (`prctl`)
+
+**Principle**: Master keys and derived cryptographic keys resident in memory while the vault is unlocked MUST be locked to physical RAM to prevent Linux kernel swap paging to disk, and protected against user-space memory dumping and crash coredumps.
+
+- ❌ **Anti-Pattern**:
+  - Allocating master keys and `SymmetricCryptoKey` in raw un-locked heap buffers without page-aligned `mlock`.
+  - Allowing `systemd-coredump` or `ptrace` to dump process memory containing active decrypted keys.
+  - Naive `mlock` on arbitrary heap memory where unlocking one key inadvertently unlocks other adjacent keys sharing the same 4KB page.
+- ✅ **Required Pattern**:
+  - Allocate sensitive cryptographic keys (`LockedKey32`, `LockedKey64`) in dedicated, 4096-byte page-aligned memory (`Layout::from_size_align(4096, 4096)`).
+  - Pin memory pages to physical RAM using `libc::mlock` upon allocation, and gracefully degrade with diagnostic logging if resource limits (`RLIMIT_MEMLOCK`) prevent locking.
+  - Overwrite entire 4KB page with zeroes (`zeroize`) and call `libc::munlock` upon `Drop`.
+  - Invoke `libc::prctl(libc::PR_SET_DUMPABLE, 0)` at process startup on Linux to disable ptrace attachment and suppress crash coredumps.
+- 🧪 **Mandatory Verification**:
+  Unit test must assert that `LockedKey32` allocations are 4096-byte page-aligned, independent copies occupy distinct memory addresses, and `disable_dumpable` returns `Ok`.
+
+---
+
 ## Agent Checklist Before Opening a PR
 
 Before submitting any code changes touching authentication, crypto, networking, IPC, or storage:
@@ -139,6 +158,8 @@ Before submitting any code changes touching authentication, crypto, networking, 
 - [ ] All file writes with sensitive data enforce 0600 permissions atomically.
 - [ ] All URLs sending Auth headers use exact RFC 6454 same-origin checks.
 - [ ] Socket handlers verify peer UID (SO_PEERCRED) on connection.
+- [ ] Master keys and cryptographic keys use page-aligned physical memory locks (LockedKey32 / mlock).
+- [ ] Process anti-dump protection (PR_SET_DUMPABLE = 0) is active.
 - [ ] Installers / downloaders enforce fail-closed checksum checks.
 - [ ] Vault locks cleanly upon screen-lock, sleep, or idle timeout.
 - [ ] Sensitive memory structures implement Zeroize.

--- a/omawarden/src/crypto.rs
+++ b/omawarden/src/crypto.rs
@@ -10,6 +10,8 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, Zeroizing};
 
+use crate::locked::LockedKey32;
+
 type Aes256CbcDec = cbc::Decryptor<Aes256>;
 type HmacSha256 = Hmac<Sha256>;
 
@@ -62,9 +64,9 @@ pub fn derive_master_key(
     iterations: u32,
     memory_mb: Option<u32>,
     parallelism: Option<u32>,
-) -> Result<Zeroizing<[u8; 32]>, CryptoError> {
+) -> Result<LockedKey32, CryptoError> {
     let email_normalized = email.trim().to_lowercase();
-    let mut master_key = Zeroizing::new([0u8; 32]);
+    let mut master_key = LockedKey32::new_zeroed();
 
     match kdf_type {
         KdfType::Pbkdf2Sha256 => {
@@ -77,7 +79,7 @@ pub fn derive_master_key(
                 password.as_bytes(),
                 email_normalized.as_bytes(),
                 iter,
-                master_key.as_mut(),
+                master_key.as_mut_slice(),
             );
         }
         KdfType::Argon2id => {
@@ -91,7 +93,7 @@ pub fn derive_master_key(
 
             let email_hash = Sha256::digest(email_normalized.as_bytes());
             argon2
-                .hash_password_into(password.as_bytes(), &email_hash, master_key.as_mut())
+                .hash_password_into(password.as_bytes(), &email_hash, master_key.as_mut_slice())
                 .map_err(|_| CryptoError::InvalidKdfParams)?;
         }
     }
@@ -99,28 +101,36 @@ pub fn derive_master_key(
     Ok(master_key)
 }
 
-pub fn derive_master_password_hash(master_key: &[u8; 32], password: &str) -> String {
+pub fn derive_master_password_hash(master_key: &[u8], password: &str) -> String {
     let mut hash = Zeroizing::new([0u8; 32]);
-    pbkdf2::pbkdf2_hmac::<Sha256>(master_key.as_ref(), password.as_bytes(), 1, hash.as_mut());
+    pbkdf2::pbkdf2_hmac::<Sha256>(master_key, password.as_bytes(), 1, hash.as_mut());
     BASE64.encode(hash.as_ref())
 }
 
-#[derive(Debug, Clone, Zeroize)]
-#[zeroize(drop)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SymmetricCryptoKey {
-    pub enc_key: [u8; 32],
-    pub mac_key: Option<[u8; 32]>,
+    pub enc_key: LockedKey32,
+    pub mac_key: Option<LockedKey32>,
+}
+
+impl Zeroize for SymmetricCryptoKey {
+    fn zeroize(&mut self) {
+        self.enc_key.zeroize();
+        if let Some(ref mut mac) = self.mac_key {
+            mac.zeroize();
+        }
+    }
 }
 
 impl SymmetricCryptoKey {
-    pub fn from_master_key(master_key: &[u8; 32]) -> Self {
+    pub fn from_master_key(master_key: &[u8]) -> Self {
         let hkdf = Hkdf::<Sha256>::new(Some(&[]), master_key);
-        let mut enc_key = [0u8; 32];
-        let mut mac_key = [0u8; 32];
+        let mut enc_key = LockedKey32::new_zeroed();
+        let mut mac_key = LockedKey32::new_zeroed();
 
-        hkdf.expand(b"enc", &mut enc_key)
+        hkdf.expand(b"enc", enc_key.as_mut_slice())
             .expect("HKDF expand enc failed");
-        hkdf.expand(b"mac", &mut mac_key)
+        hkdf.expand(b"mac", mac_key.as_mut_slice())
             .expect("HKDF expand mac failed");
 
         Self {
@@ -131,16 +141,19 @@ impl SymmetricCryptoKey {
 
     pub fn decrypt_with_master_key(
         enc: &EncString,
-        master_key: &[u8; 32],
+        master_key: &[u8],
     ) -> Result<Vec<u8>, CryptoError> {
+        if master_key.len() != 32 {
+            return Err(CryptoError::InvalidKeyLength);
+        }
         let mut candidate_keys = Vec::new();
 
         // 1. HKDF from_prk (RFC 5869 Section 2.3 directly on master key)
         if let Ok(hkdf) = Hkdf::<Sha256>::from_prk(master_key) {
-            let mut enc_key = [0u8; 32];
-            let mut mac_key = [0u8; 32];
-            if hkdf.expand(b"enc", &mut enc_key).is_ok()
-                && hkdf.expand(b"mac", &mut mac_key).is_ok()
+            let mut enc_key = LockedKey32::new_zeroed();
+            let mut mac_key = LockedKey32::new_zeroed();
+            if hkdf.expand(b"enc", enc_key.as_mut_slice()).is_ok()
+                && hkdf.expand(b"mac", mac_key.as_mut_slice()).is_ok()
             {
                 candidate_keys.push(SymmetricCryptoKey {
                     enc_key,
@@ -152,10 +165,10 @@ impl SymmetricCryptoKey {
         // 2. HKDF with empty salt (Node.js/WebCrypto extract+expand)
         {
             let hkdf = Hkdf::<Sha256>::new(Some(&[]), master_key);
-            let mut enc_key = [0u8; 32];
-            let mut mac_key = [0u8; 32];
-            if hkdf.expand(b"enc", &mut enc_key).is_ok()
-                && hkdf.expand(b"mac", &mut mac_key).is_ok()
+            let mut enc_key = LockedKey32::new_zeroed();
+            let mut mac_key = LockedKey32::new_zeroed();
+            if hkdf.expand(b"enc", enc_key.as_mut_slice()).is_ok()
+                && hkdf.expand(b"mac", mac_key.as_mut_slice()).is_ok()
             {
                 candidate_keys.push(SymmetricCryptoKey {
                     enc_key,
@@ -166,10 +179,12 @@ impl SymmetricCryptoKey {
 
         // 3. Direct master key as encryption key (only for legacy unauthenticated enc_type == 0)
         if enc.enc_type == 0 {
-            candidate_keys.push(SymmetricCryptoKey {
-                enc_key: *master_key,
-                mac_key: None,
-            });
+            if let Some(enc_k) = LockedKey32::from_slice(master_key) {
+                candidate_keys.push(SymmetricCryptoKey {
+                    enc_key: enc_k,
+                    mac_key: None,
+                });
+            }
         }
 
         let mut last_err =
@@ -186,17 +201,16 @@ impl SymmetricCryptoKey {
 
     pub fn from_raw_bytes(key_bytes: &[u8]) -> Result<Self, CryptoError> {
         if key_bytes.len() == 32 {
-            let mut enc = [0u8; 32];
-            enc.copy_from_slice(key_bytes);
+            let enc = LockedKey32::from_slice(key_bytes).ok_or(CryptoError::InvalidKeyLength)?;
             Ok(Self {
                 enc_key: enc,
                 mac_key: None,
             })
         } else if key_bytes.len() == 64 {
-            let mut enc = [0u8; 32];
-            let mut mac = [0u8; 32];
-            enc.copy_from_slice(&key_bytes[..32]);
-            mac.copy_from_slice(&key_bytes[32..64]);
+            let enc =
+                LockedKey32::from_slice(&key_bytes[..32]).ok_or(CryptoError::InvalidKeyLength)?;
+            let mac =
+                LockedKey32::from_slice(&key_bytes[32..64]).ok_or(CryptoError::InvalidKeyLength)?;
             Ok(Self {
                 enc_key: enc,
                 mac_key: Some(mac),
@@ -732,7 +746,7 @@ mod tests {
         let parsed = EncString::parse(&encrypted).unwrap();
 
         let key_without_mac = SymmetricCryptoKey {
-            enc_key: key.enc_key,
+            enc_key: key.enc_key.clone(),
             mac_key: None,
         };
 
@@ -786,7 +800,7 @@ mod tests {
         assert!(parsed.mac.is_none());
 
         let key = SymmetricCryptoKey {
-            enc_key,
+            enc_key: LockedKey32::from_array(enc_key),
             mac_key: None,
         };
         let decrypted = parsed.decrypt_string(&key).unwrap();
@@ -835,7 +849,7 @@ fn test_decrypt_attachment_blob() {
     let plaintext = b"JFIF JPEG Image Content Data";
 
     // Encrypt AES-256-CBC
-    let cipher = cbc::Encryptor::<aes::Aes256>::new((&key.enc_key).into(), (&iv).into());
+    let cipher = cbc::Encryptor::<aes::Aes256>::new(key.enc_key.as_array().into(), (&iv).into());
     let mut buf = vec![0u8; plaintext.len() + 16];
     buf[..plaintext.len()].copy_from_slice(plaintext);
     let ciphertext = cipher

--- a/omawarden/src/lib.rs
+++ b/omawarden/src/lib.rs
@@ -9,6 +9,7 @@ pub mod fs_util;
 pub mod health;
 pub mod hook;
 pub mod keyring;
+pub mod locked;
 pub mod logging;
 pub mod ssh;
 pub mod storage;

--- a/omawarden/src/locked.rs
+++ b/omawarden/src/locked.rs
@@ -1,0 +1,274 @@
+use std::alloc::{alloc, dealloc, Layout};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, Ordering};
+use subtle::ConstantTimeEq;
+use zeroize::Zeroize;
+
+pub const PAGE_SIZE: usize = 4096;
+
+static MLOCK_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// Page-aligned, mlocked memory container for sensitive cryptographic secrets.
+///
+/// Ensures:
+/// 1. Page-aligned allocation (4096 bytes) to eliminate mlock/munlock cross-key race conditions.
+/// 2. Physical RAM locking via `libc::mlock` to prevent swapping to disk.
+/// 3. Secure zeroization (`Zeroize`) of the entire allocated page prior to deallocation.
+/// 4. Disables debug printing of raw secret bytes.
+pub struct LockedMemory<const N: usize> {
+    ptr: NonNull<u8>,
+    layout: Layout,
+    is_locked: bool,
+}
+
+unsafe impl<const N: usize> Send for LockedMemory<N> {}
+unsafe impl<const N: usize> Sync for LockedMemory<N> {}
+
+pub type LockedKey32 = LockedMemory<32>;
+pub type LockedKey64 = LockedMemory<64>;
+
+impl<const N: usize> LockedMemory<N> {
+    pub fn new_zeroed() -> Self {
+        assert!(
+            N <= PAGE_SIZE,
+            "LockedMemory payload must fit in PAGE_SIZE ({PAGE_SIZE} bytes)"
+        );
+        let layout = Layout::from_size_align(PAGE_SIZE, PAGE_SIZE)
+            .expect("Invalid page layout for LockedMemory");
+        let raw_ptr = unsafe { alloc(layout) };
+        let ptr = NonNull::new(raw_ptr).expect("Memory allocation failed for LockedMemory");
+
+        // Zero out the freshly allocated page
+        unsafe {
+            std::slice::from_raw_parts_mut(ptr.as_ptr(), PAGE_SIZE).zeroize();
+        }
+
+        let mut is_locked = false;
+        #[cfg(unix)]
+        {
+            let ret = unsafe { libc::mlock(ptr.as_ptr() as *const libc::c_void, PAGE_SIZE) };
+            if ret == 0 {
+                is_locked = true;
+            } else if !MLOCK_WARNED.swap(true, Ordering::Relaxed) {
+                let err = std::io::Error::last_os_error();
+                crate::log_warn!(
+                    "omawarden:locked",
+                    "mlock failed ({}); operating in unlocked memory fallback mode",
+                    err
+                );
+            }
+        }
+
+        Self {
+            ptr,
+            layout,
+            is_locked,
+        }
+    }
+
+    pub fn from_array(arr: [u8; N]) -> Self {
+        let mut mem = Self::new_zeroed();
+        mem.as_mut_slice().copy_from_slice(&arr);
+        mem
+    }
+
+    pub fn from_slice(slice: &[u8]) -> Option<Self> {
+        if slice.len() != N {
+            return None;
+        }
+        let mut mem = Self::new_zeroed();
+        mem.as_mut_slice().copy_from_slice(slice);
+        Some(mem)
+    }
+
+    pub fn as_array(&self) -> &[u8; N] {
+        unsafe { &*(self.ptr.as_ptr() as *const [u8; N]) }
+    }
+
+    pub fn as_mut_array(&mut self) -> &mut [u8; N] {
+        unsafe { &mut *(self.ptr.as_ptr() as *mut [u8; N]) }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), N) }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), N) }
+    }
+
+    pub fn is_locked(&self) -> bool {
+        self.is_locked
+    }
+}
+
+impl<const N: usize> Clone for LockedMemory<N> {
+    fn clone(&self) -> Self {
+        let mut new_mem = Self::new_zeroed();
+        new_mem.as_mut_slice().copy_from_slice(self.as_slice());
+        new_mem
+    }
+}
+
+impl<const N: usize> Drop for LockedMemory<N> {
+    fn drop(&mut self) {
+        unsafe {
+            // 1. Zero out the entire 4KB page
+            let slice = std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.layout.size());
+            slice.zeroize();
+
+            // 2. Unlock memory page if mlock was active
+            #[cfg(unix)]
+            if self.is_locked {
+                libc::munlock(self.ptr.as_ptr() as *const libc::c_void, self.layout.size());
+            }
+
+            // 3. Deallocate the page-aligned memory
+            dealloc(self.ptr.as_ptr(), self.layout);
+        }
+    }
+}
+
+impl<const N: usize> Deref for LockedMemory<N> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<const N: usize> DerefMut for LockedMemory<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<const N: usize> AsRef<[u8; N]> for LockedMemory<N> {
+    fn as_ref(&self) -> &[u8; N] {
+        self.as_array()
+    }
+}
+
+impl<const N: usize> AsRef<[u8]> for LockedMemory<N> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl<const N: usize> AsMut<[u8]> for LockedMemory<N> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+}
+
+impl<const N: usize> Zeroize for LockedMemory<N> {
+    fn zeroize(&mut self) {
+        self.as_mut_slice().zeroize();
+    }
+}
+
+impl<const N: usize> PartialEq for LockedMemory<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice().ct_eq(other.as_slice()).into()
+    }
+}
+
+impl<const N: usize> Eq for LockedMemory<N> {}
+
+impl<const N: usize> fmt::Debug for LockedMemory<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[LOCKED_SECRET; {} bytes]", N)
+    }
+}
+
+/// Disables ptrace debugging attachment and core dump generation on Linux.
+#[cfg(target_os = "linux")]
+pub fn disable_dumpable() -> Result<(), std::io::Error> {
+    const PR_SET_DUMPABLE: libc::c_int = 4;
+    let ret = unsafe { libc::prctl(PR_SET_DUMPABLE, 0) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn disable_dumpable() -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_locked_memory_allocation_and_alignment() {
+        let key = LockedKey32::new_zeroed();
+        let addr = key.ptr.as_ptr() as usize;
+        assert_eq!(
+            addr % PAGE_SIZE,
+            0,
+            "Memory buffer must be page-aligned to {PAGE_SIZE} bytes"
+        );
+        assert_eq!(key.as_slice(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn test_locked_memory_read_write_and_deref() {
+        let mut key = LockedKey32::new_zeroed();
+        key[0] = 0x42;
+        key[31] = 0x99;
+        assert_eq!(key[0], 0x42);
+        assert_eq!(key[31], 0x99);
+        assert_eq!(key.len(), 32);
+
+        let from_arr = LockedKey32::from_array(*key.as_array());
+        assert_eq!(key, from_arr);
+    }
+
+    #[test]
+    fn test_locked_memory_clone_isolation() {
+        let mut k1 = LockedKey32::new_zeroed();
+        k1[0] = 0xAA;
+        let mut k2 = k1.clone();
+        assert_eq!(k1, k2);
+
+        // Modifying k2 should not alter k1
+        k2[0] = 0xBB;
+        assert_ne!(k1, k2);
+        assert_ne!(
+            k1.ptr.as_ptr(),
+            k2.ptr.as_ptr(),
+            "Cloned keys must occupy independent memory pages"
+        );
+    }
+
+    #[test]
+    fn test_locked_memory_debug_formatting_does_not_leak_bytes() {
+        let mut key = LockedKey32::new_zeroed();
+        key.as_mut_slice()
+            .copy_from_slice(b"super_secret_master_key_12345678");
+        let debug_str = format!("{:?}", key);
+        assert_eq!(debug_str, "[LOCKED_SECRET; 32 bytes]");
+        assert!(!debug_str.contains("super_secret"));
+    }
+
+    #[test]
+    fn test_locked_memory_from_slice() {
+        let bytes = [7u8; 32];
+        let key = LockedKey32::from_slice(&bytes).unwrap();
+        assert_eq!(key.as_slice(), &bytes);
+
+        assert!(LockedKey32::from_slice(&bytes[..16]).is_none());
+        assert!(LockedKey32::from_slice(&[0u8; 64]).is_none());
+    }
+
+    #[test]
+    fn test_disable_dumpable() {
+        let res = disable_dumpable();
+        assert!(res.is_ok(), "disable_dumpable should succeed on Linux");
+    }
+}

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -358,6 +358,9 @@ fn read_auth_payload() -> (String, Option<String>) {
 }
 
 fn main() -> ExitCode {
+    // Disable process tracing (ptrace) and core dump generation for memory defense
+    let _ = omawarden::locked::disable_dumpable();
+
     let cli = Cli::parse();
     let config_mgr = ConfigManager::new(cli.config.as_deref());
     let mut cfg = config_mgr.load();


### PR DESCRIPTION
## Summary of Changes

This PR implements Gap 2 from the architecture security review, based on [ADR 0009](file:///home/icyleaf/Development/linux/omarchy-bitwarden/docs/adr/0009-physical-memory-locking-and-memory-protection.md):

1. **Page-Aligned Memory Locking (`omawarden/src/locked.rs`)**:
   - Introduces `LockedMemory<const N: usize>` (`LockedKey32` and `LockedKey64`).
   - Uses dedicated 4096-byte page alignment (`Layout::from_size_align(4096, 4096)`) to completely eliminate page-sharing race hazards during `munlock`.
   - Locks memory pages to physical RAM via `libc::mlock` upon allocation, ensuring keys are never swapped to disk by the Linux kernel.
   - Gracefully falls back with diagnostic logging in resource-restricted environments (e.g. unprivileged containers with zero memlock limits) without crashing.
   - On `Drop`, wipes the entire 4KB page with `zeroize::Zeroize`, calls `libc::munlock`, and deallocates memory.
   - Disables debug format leakage (`[LOCKED_SECRET; 32 bytes]`) and enforces constant-time equality check.

2. **Cryptographic Key Hardening (`omawarden/src/crypto.rs`)**:
   - Refactored `SymmetricCryptoKey` to store `enc_key: LockedKey32` and `mac_key: Option<LockedKey32>`.
   - Updated `derive_master_key` to directly allocate and return `LockedKey32`.
   - Updated master key functions to accept `&[u8]`, allowing zero-friction usage of `LockedKey32`, byte arrays, and slices.

3. **Process Anti-Tracing & Core Dump Suppression**:
   - Added `disable_dumpable()` using `libc::prctl(libc::PR_SET_DUMPABLE, 0)` on Linux.
   - Called at the entry point of `omawarden` CLI and `omawarden daemon` to block non-root `ptrace` attachment and suppress core dump files upon crashes.

4. **Documentation & Handbook Update**:
   - Added [ADR 0009](file:///home/icyleaf/Development/linux/omarchy-bitwarden/docs/adr/0009-physical-memory-locking-and-memory-protection.md).
   - Added Rule 7 to `docs/agents/security.md` and updated the PR security checklist.

## Verification
- `cargo fmt --check` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed (0 warnings).
- `XDG_RUNTIME_DIR=/tmp cargo test` passed (all 118 lib tests + 6 bin tests).