### PR TITLE
sec(daemon): prevent socket hijacking and enforce mutual peercred verification

### DIFF
--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -117,16 +117,18 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ### Rule 6: Local IPC Socket Authentication (`SO_PEERCRED`) & Memory Hygiene
 
-**Principle**: Local Unix domain sockets connect processes under the operating system; they do not automatically guarantee that only the owner process is communicating.
+**Principle**: Local Unix domain sockets connect processes under the operating system; they do not automatically guarantee that only the owner process is communicating or listening.
 
 - ❌ **Anti-Pattern**:
-  Trusting any connection that reaches the socket file simply because the socket file mode is `0600` (e.g. in containerized, shared runtime, or misconfigured permission scenarios).
+  - Trusting any connection that reaches the socket file simply because the socket file mode is `0600` (e.g. in containerized, shared runtime, or misconfigured permission scenarios).
+  - Clients blindly connecting to `/tmp/omawarden-{uid}.sock` or `XDG_RUNTIME_DIR` sockets without verifying that the socket and its parent directory are owned by current UID, free of symlinks, and that the listening server UID matches caller UID before transmitting plaintext credentials (such as master password on unlock).
 - ✅ **Required Pattern**:
-  - **Socket Peer Verification**: On connection accept, query the peer process credentials using `getsockopt(fd, SOL_SOCKET, SO_PEERCRED, ...)` on Linux and ensure `ucred.uid == libc::getuid()`. Reject foreign UIDs immediately before reading any input.
+  - **Mutual Peer Verification**: Both server AND client perform peer credential verification. On connection accept, the server queries caller process credentials using `getsockopt(fd, SOL_SOCKET, SO_PEERCRED, ...)` on Linux and ensures `ucred.uid == libc::getuid()`. Similarly, the client verifies the server process credentials immediately upon `connect()` before transmitting any request payload.
+  - **Path & Directory Hardening**: Socket paths and parent runtime directories are validated with `symlink_metadata()` to reject symlinks and foreign ownership. Fallback runtime directories in `/tmp` must be created atomically as dedicated `0700` directories (`/tmp/omawarden-runtime-{uid}/`).
   - **Cryptographic Memory Hygiene**: Master keys, derived cryptographic keys, and master passwords in memory MUST implement `zeroize::Zeroize` and be scrubbed on lock.
   - **Threat Boundary Clarity**: Document clearly that processes running as the *same OS user* share access under the same UID; defense against same-user memory scraping requires OS sandboxing.
 - 🧪 **Mandatory Verification**:
-  Unit test must assert that `verify_peer_credentials` succeeds for valid socket pairs and rejects mismatched client connections.
+  Unit test must assert that `verify_peer_credentials` succeeds for valid socket pairs, rejects foreign/mismatched connections, and `validate_socket_path` rejects symlinks and foreign socket files.
 
 ---
 
@@ -157,7 +159,7 @@ Before submitting any code changes touching authentication, crypto, networking, 
 - [ ] Keyring failures fail-closed (no fallback to plaintext files).
 - [ ] All file writes with sensitive data enforce 0600 permissions atomically.
 - [ ] All URLs sending Auth headers use exact RFC 6454 same-origin checks.
-- [ ] Socket handlers verify peer UID (SO_PEERCRED) on connection.
+- [ ] Sockets enforce mutual peer UID (SO_PEERCRED) verification and validate paths/symlinks.
 - [ ] Master keys and cryptographic keys use page-aligned physical memory locks (LockedKey32 / mlock).
 - [ ] Process anti-dump protection (PR_SET_DUMPABLE = 0) is active.
 - [ ] Installers / downloaders enforce fail-closed checksum checks.

--- a/omawarden/src/daemon.rs
+++ b/omawarden/src/daemon.rs
@@ -2,9 +2,9 @@ use serde_json::{json, Value};
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -15,13 +15,91 @@ use crate::vault::VaultManager;
 
 use std::os::unix::process::CommandExt;
 
-pub fn get_socket_path() -> PathBuf {
+/// Resolves the secure runtime directory for daemon sockets and IPC.
+///
+/// Precedence:
+/// 1. `XDG_RUNTIME_DIR`: Verified to exist, owned by current UID, and not a symlink.
+/// 2. Fallback: Creates an isolated `/tmp/omawarden-runtime-{uid}/` directory with mode `0700`.
+pub fn get_runtime_dir() -> PathBuf {
+    let current_uid = unsafe { libc::getuid() };
+
     if let Ok(runtime_dir) = env::var("XDG_RUNTIME_DIR") {
-        PathBuf::from(runtime_dir).join("omawarden.sock")
-    } else {
-        let uid = unsafe { libc::getuid() };
-        PathBuf::from(format!("/tmp/omawarden-{}.sock", uid))
+        let p = PathBuf::from(runtime_dir);
+        if let Ok(meta) = fs::symlink_metadata(&p) {
+            if !meta.file_type().is_symlink() && meta.uid() == current_uid {
+                return p;
+            }
+        }
     }
+
+    let fallback = env::temp_dir().join(format!("omawarden-runtime-{}", current_uid));
+    let _ = crate::fs_util::create_secure_dir_all(&fallback, 0o700);
+    fallback
+}
+
+pub fn get_socket_path() -> PathBuf {
+    get_runtime_dir().join("omawarden.sock")
+}
+
+/// Validates that a socket file (and its parent directory) is owned by the current UID
+/// and is not a symlink to prevent cross-user socket hijacking or TOCTOU attacks.
+pub fn validate_socket_path(path: &Path) -> std::io::Result<()> {
+    let current_uid = unsafe { libc::getuid() };
+
+    if let Ok(meta) = fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "Socket path '{}' is a symlink (potential hijacking attempt)",
+                    path.display()
+                ),
+            ));
+        }
+
+        if meta.uid() != current_uid {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "Socket path '{}' is owned by foreign UID {} (expected current UID {})",
+                    path.display(),
+                    meta.uid(),
+                    current_uid
+                ),
+            ));
+        }
+    }
+
+    if let Some(parent) = path.parent() {
+        if let Ok(parent_meta) = fs::symlink_metadata(parent) {
+            if parent_meta.file_type().is_symlink() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!(
+                        "Socket parent directory '{}' is a symlink (potential hijacking attempt)",
+                        parent.display()
+                    ),
+                ));
+            }
+
+            if parent_meta.uid() != current_uid
+                && parent != Path::new("/tmp")
+                && parent != Path::new("/var/tmp")
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!(
+                        "Socket parent directory '{}' is owned by foreign UID {} (expected current UID {})",
+                        parent.display(),
+                        parent_meta.uid(),
+                        current_uid
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub fn ensure_daemon_running() {
@@ -75,7 +153,28 @@ pub fn send_daemon_request(req: &Value) -> Option<Value> {
         return None;
     }
 
-    let mut stream = UnixStream::connect(socket_path).ok()?;
+    if let Err(e) = validate_socket_path(&socket_path) {
+        crate::log_error!(
+            "omawarden:daemon",
+            "Refusing to connect to socket {}: {}",
+            socket_path.display(),
+            e
+        );
+        return None;
+    }
+
+    let mut stream = UnixStream::connect(&socket_path).ok()?;
+
+    // Mutual SO_PEERCRED verification: client verifies that server process UID matches current UID
+    if let Err(e) = verify_peer_credentials(&stream) {
+        crate::log_error!(
+            "omawarden:daemon",
+            "Refusing to send request: server peer UID verification failed: {}",
+            e
+        );
+        return None;
+    }
+
     let payload = format!("{}\n", req);
     stream.write_all(payload.as_bytes()).ok()?;
     stream.flush().ok()?;
@@ -193,7 +292,12 @@ pub fn should_touch_activity(action: &str, req: &Value) -> bool {
 pub fn run_daemon_server(state: Arc<DaemonState>) -> std::io::Result<()> {
     let socket_path = get_socket_path();
     if socket_path.exists() {
+        validate_socket_path(&socket_path)?;
         let _ = fs::remove_file(&socket_path);
+    }
+
+    if let Some(parent) = socket_path.parent() {
+        crate::fs_util::create_secure_dir_all(parent, 0o700)?;
     }
 
     let listener = UnixListener::bind(&socket_path)?;
@@ -910,5 +1014,56 @@ mod tests {
         let _ = is_screen_locker_running();
         let _ = is_logind_locked_or_sleeping();
         let _ = is_system_or_screen_locked();
+    }
+
+    #[test]
+    fn test_validate_socket_path_valid_and_symlink_rejection() {
+        let dir = tempdir().unwrap();
+        let real_socket = dir.path().join("real.sock");
+        fs::write(&real_socket, b"").unwrap();
+
+        // Valid socket file owned by current user
+        assert!(validate_socket_path(&real_socket).is_ok());
+
+        // Symlink pointing to the real socket must be rejected
+        let symlink_socket = dir.path().join("symlink.sock");
+        std::os::unix::fs::symlink(&real_socket, &symlink_socket).unwrap();
+        let err = validate_socket_path(&symlink_socket);
+        assert!(err.is_err());
+        assert_eq!(
+            err.unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn test_validate_socket_path_parent_symlink_rejection() {
+        let dir = tempdir().unwrap();
+        let real_dir = dir.path().join("real_runtime");
+        fs::create_dir_all(&real_dir).unwrap();
+
+        let symlink_dir = dir.path().join("symlink_runtime");
+        std::os::unix::fs::symlink(&real_dir, &symlink_dir).unwrap();
+
+        let socket_in_symlink_parent = symlink_dir.join("omawarden.sock");
+        let err = validate_socket_path(&socket_in_symlink_parent);
+        assert!(err.is_err());
+        assert_eq!(
+            err.unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn test_get_runtime_dir_permissions_and_ownership() {
+        let runtime_dir = get_runtime_dir();
+        assert!(runtime_dir.exists());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let meta = fs::metadata(&runtime_dir).unwrap();
+            assert_eq!(meta.uid(), unsafe { libc::getuid() });
+        }
     }
 }


### PR DESCRIPTION
## Summary of Changes

This PR resolves **Issue 2** (Socket hijacking and client peer credential verification) identified in the security audit:

1. **Isolated Runtime Directory Resolution (`get_runtime_dir`)**:
   - Replaces vulnerable loose socket fallback `/tmp/omawarden-{uid}.sock` in shared `/tmp`.
   - Validates `XDG_RUNTIME_DIR` to ensure it is not a symlink and is strictly owned by the current UID.
   - Falls back to an isolated per-user directory (`/tmp/omawarden-runtime-{uid}/`) created atomically with `0700` permissions.

2. **Socket Path & Symlink Traversal Protection (`validate_socket_path`)**:
   - Checks socket path and its parent directory using `symlink_metadata()`.
   - Rejects symlinked socket files and symlinked parent directories to prevent hijacking or arbitrary file redirection.
   - Enforces UID ownership checks on both socket and parent directory.

3. **Mutual `SO_PEERCRED` Peer Credential Verification**:
   - In `send_daemon_request`, the client now performs `verify_peer_credentials(&stream)` immediately upon connecting to the daemon socket before writing any payload.
   - If the listening process UID does not match the client UID, the connection is immediately aborted, preventing plaintext master password transmission to rogue processes.

4. **Security Handbook Documentation**:
   - Updated Rule 6 in `docs/agents/security.md` and PR checklist to enforce mutual socket authentication and path/symlink validation.

5. **Unit Tests Added**:
   - `test_validate_socket_path_valid_and_symlink_rejection`
   - `test_validate_socket_path_parent_symlink_rejection`
   - `test_get_runtime_dir_permissions_and_ownership`

## Verification
- `cargo fmt --check`: Passed
- `cargo clippy --all-targets --all-features -- -D warnings`: Passed (0 warnings)
- `XDG_RUNTIME_DIR=/tmp cargo test`: All 121 library tests + 6 CLI tests passed