### PR TITLE
sec(core): fix attachment path traversal and runtime mlock page size

### DIFF
--- a/omawarden/src/attachment.rs
+++ b/omawarden/src/attachment.rs
@@ -81,6 +81,19 @@ pub fn send_notification_with_actions(title: &str, body: &str, file_path: &Path)
     });
 }
 
+/// Validates that a server-provided identifier is safe to use as a single
+/// path component. Rejects traversal sequences and separators so a malicious
+/// or compromised server cannot steer preview writes or cleanup deletes
+/// (`remove_dir_all`) outside the attachments directory.
+pub fn is_safe_path_component(s: &str) -> bool {
+    !s.is_empty()
+        && s != "."
+        && s != ".."
+        && !s.contains('/')
+        && !s.contains('\\')
+        && !s.contains('\0')
+}
+
 pub fn get_preview_dir(item_id: Option<&str>) -> PathBuf {
     let base = if let Ok(runtime_dir) = env::var("XDG_RUNTIME_DIR") {
         PathBuf::from(runtime_dir)
@@ -94,10 +107,9 @@ pub fn get_preview_dir(item_id: Option<&str>) -> PathBuf {
         PathBuf::from(format!("/tmp/omarchy-bitwarden-{}/attachments", uid))
     };
 
-    if let Some(id) = item_id {
-        base.join(id)
-    } else {
-        base
+    match item_id {
+        Some(id) if is_safe_path_component(id) => base.join(id),
+        _ => base,
     }
 }
 
@@ -105,6 +117,16 @@ pub fn clear_preview_attachments(item_id: Option<&str>) {
     #[cfg(test)]
     if item_id.is_none() {
         return;
+    }
+
+    if let Some(id) = item_id {
+        if !is_safe_path_component(id) {
+            crate::log_warn!(
+                "omawarden:attachment",
+                "Refusing preview cleanup for unsafe item id"
+            );
+            return;
+        }
     }
 
     let dir = get_preview_dir(item_id);
@@ -138,6 +160,20 @@ pub fn get_attachment(
         return AttachmentResponse {
             ok: false,
             error: Some("Item ID and Attachment ID are required.".to_string()),
+            path: None,
+            filename: None,
+            action: None,
+            is_image: None,
+            is_text: None,
+            text_content: None,
+            size: None,
+        };
+    }
+
+    if !is_safe_path_component(item_id) || !is_safe_path_component(attachment_id) {
+        return AttachmentResponse {
+            ok: false,
+            error: Some("Item ID or Attachment ID contains invalid path characters.".to_string()),
             path: None,
             filename: None,
             action: None,
@@ -1205,6 +1241,50 @@ mod tests {
         clear_preview_attachments(Some("test_item_clear"));
         assert!(!preview_file.exists());
         assert!(!preview_dir.exists());
+    }
+
+    #[test]
+    fn test_unsafe_path_components_rejected() {
+        assert!(is_safe_path_component(
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        ));
+        assert!(!is_safe_path_component(""));
+        assert!(!is_safe_path_component("."));
+        assert!(!is_safe_path_component(".."));
+        assert!(!is_safe_path_component("../../home/user"));
+        assert!(!is_safe_path_component("/home/user/Documents"));
+        assert!(!is_safe_path_component("a\\b"));
+        assert!(!is_safe_path_component("a\0b"));
+
+        // A traversal item id must never escape the attachments base directory
+        let base = get_preview_dir(None);
+        assert_eq!(get_preview_dir(Some("/etc")), base);
+        assert_eq!(get_preview_dir(Some("../../escape")), base);
+
+        // Traversal ids are refused by get_attachment before any path is built
+        let res = get_attachment(
+            "../../escape",
+            "att1",
+            "file.txt",
+            None,
+            false,
+            false,
+            Some("tok"),
+            None,
+            false,
+        );
+        assert!(!res.ok);
+        assert_eq!(
+            res.error.unwrap(),
+            "Item ID or Attachment ID contains invalid path characters."
+        );
+
+        // Cleanup with a traversal id must be a no-op instead of remove_dir_all
+        let victim = tempfile::tempdir().unwrap();
+        let marker = victim.path().join("marker.txt");
+        fs::write(&marker, b"keep").unwrap();
+        clear_preview_attachments(Some(victim.path().to_str().unwrap()));
+        assert!(marker.exists());
     }
 
     #[test]

--- a/omawarden/src/locked.rs
+++ b/omawarden/src/locked.rs
@@ -3,17 +3,33 @@ use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
-pub const PAGE_SIZE: usize = 4096;
+/// OS page size resolved at runtime. Hardcoding 4096 is wrong on 16K/64K-page
+/// kernels (common on aarch64): allocations from different keys could share
+/// one real page, and `munlock` on a dropped key would unlock its neighbors.
+pub fn page_size() -> usize {
+    static PAGE_SIZE: OnceLock<usize> = OnceLock::new();
+    *PAGE_SIZE.get_or_init(|| {
+        #[cfg(unix)]
+        {
+            let ret = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+            if ret > 0 {
+                return ret as usize;
+            }
+        }
+        4096
+    })
+}
 
 static MLOCK_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Page-aligned, mlocked memory container for sensitive cryptographic secrets.
 ///
 /// Ensures:
-/// 1. Page-aligned allocation (4096 bytes) to eliminate mlock/munlock cross-key race conditions.
+/// 1. Page-aligned allocation (one OS page) to eliminate mlock/munlock cross-key race conditions.
 /// 2. Physical RAM locking via `libc::mlock` to prevent swapping to disk.
 /// 3. Secure zeroization (`Zeroize`) of the entire allocated page prior to deallocation.
 /// 4. Disables debug printing of raw secret bytes.
@@ -31,24 +47,25 @@ pub type LockedKey64 = LockedMemory<64>;
 
 impl<const N: usize> LockedMemory<N> {
     pub fn new_zeroed() -> Self {
+        let page = page_size();
         assert!(
-            N <= PAGE_SIZE,
-            "LockedMemory payload must fit in PAGE_SIZE ({PAGE_SIZE} bytes)"
+            N <= page,
+            "LockedMemory payload must fit in one OS page ({page} bytes)"
         );
-        let layout = Layout::from_size_align(PAGE_SIZE, PAGE_SIZE)
-            .expect("Invalid page layout for LockedMemory");
+        let layout =
+            Layout::from_size_align(page, page).expect("Invalid page layout for LockedMemory");
         let raw_ptr = unsafe { alloc(layout) };
         let ptr = NonNull::new(raw_ptr).expect("Memory allocation failed for LockedMemory");
 
         // Zero out the freshly allocated page
         unsafe {
-            std::slice::from_raw_parts_mut(ptr.as_ptr(), PAGE_SIZE).zeroize();
+            std::slice::from_raw_parts_mut(ptr.as_ptr(), page).zeroize();
         }
 
         let mut is_locked = false;
         #[cfg(unix)]
         {
-            let ret = unsafe { libc::mlock(ptr.as_ptr() as *const libc::c_void, PAGE_SIZE) };
+            let ret = unsafe { libc::mlock(ptr.as_ptr() as *const libc::c_void, page) };
             if ret == 0 {
                 is_locked = true;
             } else if !MLOCK_WARNED.swap(true, Ordering::Relaxed) {
@@ -208,10 +225,11 @@ mod tests {
     fn test_locked_memory_allocation_and_alignment() {
         let key = LockedKey32::new_zeroed();
         let addr = key.ptr.as_ptr() as usize;
+        let page = page_size();
         assert_eq!(
-            addr % PAGE_SIZE,
+            addr % page,
             0,
-            "Memory buffer must be page-aligned to {PAGE_SIZE} bytes"
+            "Memory buffer must be page-aligned to {page} bytes"
         );
         assert_eq!(key.as_slice(), &[0u8; 32]);
     }


### PR DESCRIPTION
## Summary of Changes

Two remaining fixes from an audit of the `develop` branch. Originally this PR also carried a client-side socket ownership check, but #128 (merged after the audit base) already implements that more thoroughly — the branch is now rebased onto latest `develop` (002a2fd) with that commit dropped. Great to see #128/#129/#131/#133 land; they independently addressed several other findings from the same audit.

### 1. `sec(attachment)`: path traversal via server-provided cipher ids

`get_preview_dir(Some(item_id))` joins the server-controlled cipher id directly into the preview path. `PathBuf::join` replaces the base entirely for absolute paths, and `../` escapes it. Since `clear_preview_attachments` then calls `fs::remove_dir_all` on that path (triggered from the QML side when a preview is closed, and on daemon lock), a malicious or compromised Vaultwarden/Bitwarden server could return a cipher id like `/home/user/Documents` and have the plugin recursively delete it. The same join also steers where decrypted attachment bytes get written.

Fix: validate `item_id` and `attachment_id` as single safe path components (no separators, no `.`/`..`, no NUL) at the `get_attachment` entry point, and make `get_preview_dir` / `clear_preview_attachments` refuse unsafe ids as defense in depth. Bitwarden cipher/attachment ids are UUIDs, so this rejects nothing legitimate.

### 2. `sec(locked)`: mlock page size was hardcoded to 4096

aarch64 kernels commonly run 16K (Apple Silicon VMs, Asahi) or 64K pages, and this project ships an `aarch64-unknown-linux-gnu` release. With 4096-byte alignment, multiple `LockedMemory` keys can land in one real OS page, and `munlock` on the first dropped key silently unlocks the page still holding its neighbors — defeating the swap protection added in #127. Fix: resolve the page size once via `sysconf(_SC_PAGESIZE)` and allocate one full OS page per key.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `XDG_RUNTIME_DIR=/tmp cargo test`: 131/131 pass (includes a new traversal regression test covering rejected ids, non-escaping `get_preview_dir`, and cleanup no-op)

## Remaining audit notes (not addressed here)

Attachment downloads still buffer the entire HTTP response into memory before any size check (`Response::bytes()`), so a malicious server can exhaust memory; and `rsa 0.9.10` carries RUSTSEC-2023-0071 (Marvin timing attack, no fixed release upstream yet — local-only decryption path here, so limited practical impact). Happy to open issues for these if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
