### PR TITLE
sec(daemon): implement ephemeral session token authorization and max lifetime watchdog

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -83,6 +83,7 @@ Item {
     user_email: "",
     has_session: false
   })
+  property string sessionToken: ""
 
   // Vault Items & Search State
   property var rawVaultItems: []
@@ -192,6 +193,7 @@ Item {
 
     root.activeAttachmentPreview = null
     root.loadingAttachmentId = ""
+    root.sessionToken = ""
 
     if (authViewComponent && typeof authViewComponent.clearInputs === "function") {
       authViewComponent.clearInputs()
@@ -2107,6 +2109,7 @@ Item {
     property string actionType: "create"
     property string actionName: ""
     command: []
+    environment: root.sessionToken ? ({ "OMAWARDEN_SESSION": root.sessionToken }) : ({})
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
@@ -2420,6 +2423,7 @@ Item {
         try {
           var data = JSON.parse(text)
           if (data.ok) {
+            root.sessionToken = (data && (data.session_token || data.session)) || ""
             root.statusMessage = "Vault unlocked successfully."
             root.searchQuery = ""
             if (authViewComponent) authViewComponent.clearInputs()
@@ -2470,6 +2474,9 @@ Item {
         try {
           var data = JSON.parse(text)
           if (data.ok) {
+            if (data.session_token || data.session) {
+              root.sessionToken = data.session_token || data.session || ""
+            }
             var statusVal = data.status || "unlocked"
             if (statusVal === "locked") {
               root.statusMessage = "API Key authenticated. Please enter Master Password to unlock."
@@ -2588,6 +2595,7 @@ Item {
   Process {
     id: vaultSyncProc
     command: []
+    environment: root.sessionToken ? ({ "OMAWARDEN_SESSION": root.sessionToken }) : ({})
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
@@ -2643,6 +2651,7 @@ Item {
   Process {
     id: vaultListProc
     command: []
+    environment: root.sessionToken ? ({ "OMAWARDEN_SESSION": root.sessionToken }) : ({})
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
@@ -2701,6 +2710,7 @@ Item {
     id: clipCopyProc
     property string secret: ""
     stdinEnabled: true
+    environment: root.sessionToken ? ({ "OMAWARDEN_SESSION": root.sessionToken }) : ({})
     onStarted: {
       if (secret) {
         write(secret + "\n")
@@ -2718,6 +2728,7 @@ Item {
     id: totpGenProc
     property string secret: ""
     stdinEnabled: true
+    environment: root.sessionToken ? ({ "OMAWARDEN_SESSION": root.sessionToken }) : ({})
     onStarted: {
       if (secret) {
         write(secret + "\n")
@@ -2763,6 +2774,7 @@ Item {
     property string activeAttachmentId: ""
     property string activeItemId: ""
     command: []
+    environment: root.sessionToken ? ({ "OMAWARDEN_SESSION": root.sessionToken }) : ({})
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {

--- a/docs/adr/0010-daemon-session-token-and-access-control.md
+++ b/docs/adr/0010-daemon-session-token-and-access-control.md
@@ -1,0 +1,83 @@
+# ADR 0010: Daemon Ephemeral Session Token and Access Control Architecture
+
+## Status
+Accepted
+
+## Context
+
+In `omarchy-bitwarden`, the background daemon (`omawarden daemon`) maintains decrypted vault items in physical memory (`LockedKey32` / `LockedKey64`) to provide sub-millisecond response times for search, auto-fill, clipboard copying, and TOTP generation across desktop workflows.
+
+Communication between the UI (Quickshell frontend) or CLI and the daemon occurs over a local Unix domain socket (`/run/user/<uid>/omawarden.sock`). While mutual `SO_PEERCRED` verification (enforced in ADR 0003 and Security Rule 6) successfully isolates cross-user access on multi-user systems, it creates an unrestricted "same-user zero-auth vault API":
+
+1. **Unrestricted Same-UID Decrypted Vault Extraction**:
+   Any process executing under the same UID (for example, compromised user scripts, third-party desktop tools, unvetted electron applications, or malicious curl/bash snippets) could connect to `/run/user/<uid>/omawarden.sock` and issue `{"action": "list"}` or `{"action": "search"}` to dump all decrypted credentials, TOTP secrets, credit cards, secure notes, and SSH private keys without authenticating.
+
+2. **Auto-Lock Evasion via Unauthenticated Keep-Alives**:
+   A rogue local background loop could periodically send unauthenticated `ping` or `status` requests to the socket to prevent idle auto-lock indefinitely.
+
+3. **Denial of Service via Unauthenticated Daemon Termination**:
+   Any local process under the same UID could issue `{"action": "stop"}` while the vault was unlocked, killing the user's password manager process without authorization.
+
+4. **Missing Upper Ceiling on Unlock Duration**:
+   While idle inactivity timeouts locked the vault after periods of disuse, there was no absolute upper ceiling (`max_session_lifetime`). A workstation with continuous activity could remain perpetually unlocked for days or weeks.
+
+---
+
+## Decision
+
+We introduce an **Ephemeral Session Token Authorization** and **Max Session Lifetime Watchdog** model for the `omawarden` daemon:
+
+### 1. High-Entropy Ephemeral Session Token
+- Upon successful `unlock` (via master password or quick PIN), the daemon generates a cryptographically random, 256-bit (32 bytes) token using OS entropy (`rand_core::OsRng`) encoded as URL-safe base64 without padding.
+- The session token is wrapped in `Zeroizing<String>` in physical memory and associated with the daemon state.
+- Upon `lock` (manual lock, idle timeout, screen lock, sleep, or max lifetime expiration) or daemon exit, the session token is scrubbed with zeroes and reset to `None`.
+
+### 2. Privileged Action Enforcement
+- Privileged operations strictly require a valid `session_token` in the request payload (`session_token` or `session` field):
+  - `list` (vault item export/dump)
+  - `search` (vault item search)
+  - `get_item` (decrypted item retrieval)
+  - `get_ssh_key` (SSH private/public key retrieval)
+  - `get_attachment_key` (decryption key for encrypted attachments)
+  - `ssh_key_create` (vault item modification)
+  - `sync` (vault synchronization)
+  - `totp` with item query (`query` or `id`)
+  - `stop` when the vault is unlocked
+- Non-privileged actions (which do not require token) include:
+  - `ping` (health check)
+  - `status` (lock status and version check)
+  - `unlock` (authentication handshake)
+  - `lock` (defensive action; any local process can defensively lock the vault)
+  - `totp` with raw secret (stateless cryptographic utility)
+  - `copy` (clipboard utility)
+  - `set_auto_lock` (timeout configuration)
+
+### 3. Constant-Time Verification & Fail-Closed Policy
+- Token comparison is performed in constant time using `subtle::ConstantTimeEq` to eliminate timing side-channels.
+- Requests failing session verification are rejected immediately with `{"ok": false, "error": "Unauthorized: valid session token required"}`.
+- Unauthenticated or rejected requests **NEVER touch activity**, guaranteeing that rogue polling cannot prevent idle auto-locking.
+
+### 4. Absolute Maximum Session Lifetime (`max_session_lifetime`)
+- Alongside the idle inactivity timeout, the daemon tracks `unlocked_at: Instant`.
+- An absolute maximum session lifetime (default 12 hours) is enforced in `check_auto_lock()`.
+- When elapsed, the daemon locks the vault and purges all decrypted keys and session tokens, even if continuous user activity has kept the idle timer fresh.
+
+### 5. Secure Token Propagation (Zero Process Argv Leaks)
+- In the Quickshell UI (`OmarchyBitwarden.qml`), the session token received from the `unlock` response is retained in the root component state.
+- When launching child `Process` blocks (`vaultSyncProc`, `vaultListProc`, `clipCopyProc`, `totpGenProc`, `attachmentProc`, `sshKeyActionProc`), the token is injected into the child process environment via `environment: ({ "OMAWARDEN_SESSION": root.sessionToken })`.
+- This ensures tokens are strictly in-memory and **never passed via CLI command-line arguments**, preventing leakage to `/proc/<pid>/cmdline`.
+- In `omawarden` CLI, commands read `OMAWARDEN_SESSION` or `BW_SESSION` from the environment or via `--session <token>` and automatically inject it into daemon requests.
+
+---
+
+## Consequences
+
+### Positive
+- **Complete Same-UID Isolation**: Rogue or unvetted scripts running as the same user can no longer dump decrypted vault items or steal credentials from the daemon.
+- **Auto-Lock Invariant Guaranteed**: Unauthenticated requests cannot refresh the idle watchdog.
+- **Hard Ceiling on Unlocked State**: 12-hour max lifetime enforces periodic re-authentication even on unattended systems with simulated mouse/keyboard activity.
+- **Zero Disk or Argv Leakage**: Ephemeral tokens stay in process RAM and are zeroized upon lock.
+
+### Trade-offs & Operational Impact
+- External shell scripts interacting with the daemon must capture `OMAWARDEN_SESSION` upon `omawarden auth unlock` or provide it via `--session`.
+- The CLI outputs a shell export snippet (`export OMAWARDEN_SESSION="..."`) when `omawarden auth unlock` is run in an interactive terminal.

--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -6,7 +6,7 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ---
 
-## The 8 Mandatory Security Principles
+## The 9 Mandatory Security Principles
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -20,6 +20,7 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 │ 6. IPC SO_PEERCRED Auth      │ Verify caller UID on all socket requests     │
 │ 7. Memory Locking (mlock)    │ Page-aligned physical RAM lock & no coredump │
 │ 8. Authenticated Encryption  │ Encrypt-then-MAC mandatory; no unauth cipher │
+│ 9. Ephemeral Session Token   │ Same-user socket authorization & max watchdog│
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -172,6 +173,32 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ---
 
+### Rule 9: Ephemeral Session Token Authorization & Max Lifetime Watchdog for Local IPC Daemon
+
+**Principle**: `SO_PEERCRED` establishes caller user identity (preventing cross-user attacks on multi-user systems), but does NOT protect against unauthorized processes running under the *same UID* from connecting to `/run/user/<uid>/omawarden.sock` and dumping decrypted secrets or executing privileged commands without user consent.
+
+- ❌ **Anti-Pattern**:
+  - Exposing an unrestricted "same-user zero-auth vault API" where any process running as the current UID can execute `{"action": "list"}` or `{"action": "search"}` to dump all decrypted passwords, TOTP seeds, cards, notes, and SSH keys.
+  - Allowing unauthenticated connections (e.g. rogue scripts polling `ping` or `status`) to touch daemon activity, preventing idle auto-lock indefinitely.
+  - Allowing unauthenticated processes to terminate the unlocked daemon via `{"action": "stop"}`.
+  - Allowing indefinite vault unlock without an absolute maximum session lifetime limit.
+- ✅ **Required Pattern**:
+  - **Cryptographic Ephemeral Session Token**: Upon `unlock`, the daemon generates a cryptographically random, high-entropy 256-bit ephemeral session token (`session_token`) using `rand_core::OsRng` encoded in URL-safe base64.
+  - **Privileged Action Protection**: All privileged operations (`list`, `search`, `get_item`, `get_ssh_key`, `get_attachment_key`, `ssh_key_create`, `sync`, `totp` with query, and `stop` when unlocked) strictly require a valid `session_token`.
+  - **Constant-Time Verification**: Session token validation MUST use constant-time byte comparison (`subtle::ConstantTimeEq`).
+  - **No Keep-Alive Leakage**: Unauthenticated requests (or requests failing token verification) are rejected immediately and MUST NOT touch activity; they cannot bypass idle auto-lock.
+  - **Absolute Maximum Lifetime Watchdog**: Implement a hard ceiling (`max_session_lifetime`, default 12 hours) from `unlocked_at`. The daemon locks the vault when this limit elapses, regardless of continuous user activity.
+  - **Safe Environment Passing**: Pass the session token to child processes via process environment (`QProcessEnvironment` in QML / `OMAWARDEN_SESSION` in CLI), NEVER via command-line arguments (which are readable via `/proc/<pid>/cmdline`).
+  - **Immediate Zeroization**: The session token resides in `Zeroizing<String>` memory and is scrubbed immediately upon `lock`, `stop`, or timeout.
+- 🧪 **Mandatory Verification**:
+  Unit tests must assert that:
+  1. Privileged actions (`list`, `search`, `get_item`, `get_ssh_key`, `get_attachment_key`, `sync`, `totp` with query, `stop`) without a session token or with an invalid token return `Unauthorized`.
+  2. Unauthenticated requests do NOT touch activity.
+  3. `lock()` clears the session token and invalidates subsequent privileged calls.
+  4. `check_auto_lock()` triggers when `max_session_lifetime` is exceeded even if `last_activity` is recent.
+
+---
+
 ## Agent Checklist Before Opening a PR
 
 Before submitting any code changes touching authentication, crypto, networking, IPC, or storage:
@@ -182,11 +209,12 @@ Before submitting any code changes touching authentication, crypto, networking, 
 - [ ] All file writes with sensitive data enforce 0600 permissions atomically.
 - [ ] All URLs sending Auth headers use exact RFC 6454 same-origin checks.
 - [ ] Sockets enforce mutual peer UID (SO_PEERCRED) verification and validate paths/symlinks.
+- [ ] Daemon privileged actions require ephemeral session token verified in constant time.
 - [ ] Master keys and cryptographic keys use page-aligned physical memory locks (LockedKey32 / mlock).
 - [ ] Symmetric decryption strictly requires and verifies HMAC-SHA256 (no unauthenticated fallback).
 - [ ] Process anti-dump protection (PR_SET_DUMPABLE = 0) is active.
 - [ ] Installers / downloaders enforce fail-closed checksum checks.
-- [ ] Vault locks cleanly upon screen-lock, sleep, or idle timeout.
+- [ ] Vault locks cleanly upon screen-lock, sleep, idle timeout, or max session lifetime.
 - [ ] Sensitive memory structures implement Zeroize.
 - [ ] cargo fmt --check, cargo clippy -- -D warnings, and full cargo test pass.
 ```

--- a/omawarden/Cargo.toml
+++ b/omawarden/Cargo.toml
@@ -6,7 +6,7 @@ description = "High-performance and low memory Bitwarden CLI (Designed for Omarc
 authors = ["icyleaf"]
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.10"

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -741,17 +741,28 @@ impl AuthManager {
 
                 // Auto-unlock daemon with decrypted items in memory
                 crate::daemon::ensure_daemon_running();
-                let _ = crate::daemon::send_daemon_request(&serde_json::json!({
+                let daemon_resp = crate::daemon::send_daemon_request(&serde_json::json!({
                     "action": "unlock",
                     "password": password
                 }));
+
+                let daemon_token = daemon_resp
+                    .as_ref()
+                    .and_then(|v| v.get("session_token"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                let effective_session = daemon_token.or(session_val);
+                if let Some(ref tok) = effective_session {
+                    std::env::set_var("OMAWARDEN_SESSION", tok);
+                }
 
                 crate::log_info!("omawarden:auth", "Vault unlocked successfully.");
 
                 AuthResult {
                     ok: true,
                     status: Some("unlocked".to_string()),
-                    session: session_val,
+                    session: effective_session,
                     ..Default::default()
                 }
             }

--- a/omawarden/src/daemon.rs
+++ b/omawarden/src/daemon.rs
@@ -9,6 +9,11 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rand_core::{OsRng, RngCore};
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
 use crate::crypto::{Engine, BASE64};
 use crate::storage::StorageManager;
 use crate::vault::VaultManager;
@@ -175,7 +180,23 @@ pub fn send_daemon_request(req: &Value) -> Option<Value> {
         return None;
     }
 
-    let payload = format!("{}\n", req);
+    // Automatically propagate active session token from environment if not explicitly specified
+    let mut payload_value = req.clone();
+    if payload_value.get("session_token").is_none() && payload_value.get("session").is_none() {
+        if let Ok(token) = env::var("OMAWARDEN_SESSION").or_else(|_| env::var("BW_SESSION")) {
+            let token = token.trim();
+            if !token.is_empty() {
+                if let Some(map) = payload_value.as_object_mut() {
+                    map.insert(
+                        "session_token".to_string(),
+                        Value::String(token.to_string()),
+                    );
+                }
+            }
+        }
+    }
+
+    let payload = format!("{}\n", payload_value);
     stream.write_all(payload.as_bytes()).ok()?;
     stream.flush().ok()?;
 
@@ -190,6 +211,9 @@ pub struct DaemonState {
     pub vault_mgr: Arc<VaultManager>,
     pub last_activity: Mutex<Instant>,
     pub auto_lock_duration: Mutex<Duration>,
+    pub session_token: Mutex<Option<Zeroizing<String>>>,
+    pub unlocked_at: Mutex<Option<Instant>>,
+    pub max_session_lifetime: Mutex<Duration>,
 }
 
 impl DaemonState {
@@ -199,6 +223,9 @@ impl DaemonState {
             vault_mgr,
             last_activity: Mutex::new(Instant::now()),
             auto_lock_duration: Mutex::new(Duration::from_secs(auto_lock_minutes * 60)),
+            session_token: Mutex::new(None),
+            unlocked_at: Mutex::new(None),
+            max_session_lifetime: Mutex::new(Duration::from_secs(12 * 3600)),
         }
     }
 
@@ -212,18 +239,71 @@ impl DaemonState {
         self.set_auto_lock_duration(Duration::from_secs(minutes * 60));
     }
 
+    pub fn is_session_valid(&self, candidate_token: &str) -> bool {
+        if candidate_token.is_empty() || !self.vault_mgr.is_unlocked() {
+            return false;
+        }
+        if let Ok(guard) = self.session_token.lock() {
+            if let Some(expected) = guard.as_ref() {
+                let exp_bytes = expected.as_bytes();
+                let cand_bytes = candidate_token.as_bytes();
+                return exp_bytes.ct_eq(cand_bytes).unwrap_u8() == 1;
+            }
+        }
+        false
+    }
+
     pub fn check_auto_lock(&self) -> bool {
         if self.vault_mgr.is_unlocked() {
-            if let Ok(dur) = self.auto_lock_duration.lock() {
-                if !dur.is_zero() {
-                    if let Ok(last) = self.last_activity.lock() {
-                        if last.elapsed() > *dur {
-                            self.lock();
-                            crate::attachment::clear_preview_attachments(None);
-                            return true;
+            // 1. Check absolute maximum session lifetime (e.g. 12 hours)
+            let max_lifetime_expired = {
+                if let Ok(ua_guard) = self.unlocked_at.lock() {
+                    if let Some(unlocked_time) = *ua_guard {
+                        if let Ok(max_dur) = self.max_session_lifetime.lock() {
+                            !max_dur.is_zero() && unlocked_time.elapsed() > *max_dur
+                        } else {
+                            false
                         }
+                    } else {
+                        false
                     }
+                } else {
+                    false
                 }
+            };
+
+            if max_lifetime_expired {
+                crate::log_info!(
+                    "omawarden:daemon",
+                    "Maximum session lifetime reached; locking vault"
+                );
+                self.lock();
+                crate::attachment::clear_preview_attachments(None);
+                return true;
+            }
+
+            // 2. Check idle inactivity timeout
+            let idle_expired = {
+                if let Ok(dur) = self.auto_lock_duration.lock() {
+                    if !dur.is_zero() {
+                        if let Ok(last) = self.last_activity.lock() {
+                            last.elapsed() > *dur
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            };
+
+            if idle_expired {
+                crate::log_info!("omawarden:daemon", "Idle timeout elapsed; locking vault");
+                self.lock();
+                crate::attachment::clear_preview_attachments(None);
+                return true;
             }
         }
         false
@@ -252,15 +332,29 @@ impl DaemonState {
     }
 
     pub fn lock(&self) {
+        if let Ok(mut tok) = self.session_token.lock() {
+            *tok = None;
+        }
+        if let Ok(mut ua) = self.unlocked_at.lock() {
+            *ua = None;
+        }
         self.vault_mgr.lock();
     }
 
-    pub fn unlock(&self, password: &str) -> Result<usize, String> {
-        let res = self.vault_mgr.unlock(password);
-        if res.is_ok() {
-            self.touch_activity();
+    pub fn unlock(&self, password: &str) -> Result<(usize, String), String> {
+        let count = self.vault_mgr.unlock(password)?;
+        let mut token_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut token_bytes);
+        let token = URL_SAFE_NO_PAD.encode(token_bytes);
+
+        if let Ok(mut tok_guard) = self.session_token.lock() {
+            *tok_guard = Some(Zeroizing::new(token.clone()));
         }
-        res
+        if let Ok(mut ua_guard) = self.unlocked_at.lock() {
+            *ua_guard = Some(Instant::now());
+        }
+        self.touch_activity();
+        Ok((count, token))
     }
 
     pub fn sync(&self) -> Result<usize, String> {
@@ -514,6 +608,53 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
     };
 
     let action = req.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    let candidate_token = req
+        .get("session_token")
+        .or_else(|| req.get("session"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let is_privileged = matches!(
+        action,
+        "list"
+            | "search"
+            | "get_item"
+            | "get_ssh_key"
+            | "get_attachment_key"
+            | "ssh_key_create"
+            | "sync"
+    ) || (action == "totp"
+        && (req.get("query").is_some() || req.get("id").is_some()))
+        || (action == "stop" && state.vault_mgr.is_unlocked());
+
+    if is_privileged {
+        if !state.vault_mgr.is_unlocked() {
+            let _ = writeln!(
+                stream,
+                "{}",
+                json!({ "ok": false, "error": "Vault is locked. Please unlock the vault first." })
+            );
+            return Ok(());
+        }
+
+        if !state.is_session_valid(candidate_token) {
+            crate::log_warn!(
+                "omawarden:daemon",
+                "Unauthorized access attempt for action '{}' without valid session token",
+                action
+            );
+            let _ = writeln!(
+                stream,
+                "{}",
+                json!({
+                    "ok": false,
+                    "error": "Unauthorized: valid session token required"
+                })
+            );
+            return Ok(());
+        }
+    }
+
     if should_touch_activity(action, &req) {
         state.touch_activity();
     }
@@ -526,15 +667,33 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
             "commit": env!("GIT_HASH"),
         }),
         "stop" => {
+            state.lock();
+            crate::attachment::clear_preview_attachments(None);
             let _ = writeln!(stream, "{}", json!({ "ok": true }));
             let _ = stream.flush();
             std::process::exit(0);
         }
-        "status" => state.vault_mgr.get_status(),
+        "status" => {
+            let mut st = state.vault_mgr.get_status();
+            let has_session = state
+                .session_token
+                .lock()
+                .map(|g| g.is_some())
+                .unwrap_or(false);
+            if let Some(map) = st.as_object_mut() {
+                map.insert("has_session".to_string(), Value::Bool(has_session));
+            }
+            st
+        }
         "unlock" => {
             let pwd = req.get("password").and_then(|v| v.as_str()).unwrap_or("");
             match state.unlock(pwd) {
-                Ok(count) => json!({ "ok": true, "status": "unlocked", "items_count": count }),
+                Ok((count, token)) => json!({
+                    "ok": true,
+                    "status": "unlocked",
+                    "items_count": count,
+                    "session_token": token
+                }),
                 Err(e) => json!({ "ok": false, "status": "locked", "error": e }),
             }
         }
@@ -849,6 +1008,10 @@ mod tests {
         let storage_mgr = StorageManager::new(path);
         let state = Arc::new(DaemonState::new(storage_mgr, 15));
 
+        let token = "test-valid-session-token-123";
+        *state.vault_mgr.is_unlocked.write().unwrap() = true;
+        *state.session_token.lock().unwrap() = Some(Zeroizing::new(token.to_string()));
+
         // Set initial activity to a known point in the past
         let past = Instant::now() - Duration::from_secs(10);
         *state.last_activity.lock().unwrap() = past;
@@ -880,16 +1043,26 @@ mod tests {
         let _ = send_req(json!({ "action": "status" }));
         assert_eq!(*state.last_activity.lock().unwrap(), past);
 
-        // 3. "totp" should not touch activity
+        // 3. "totp" with raw secret should not touch activity
         let _ = send_req(json!({ "action": "totp", "secret": "JBSWY3DPEHPK3PXP" }));
         assert_eq!(*state.last_activity.lock().unwrap(), past);
 
         // 4. "get_item" with explicit touch: false should not touch activity
-        let _ = send_req(json!({ "action": "get_item", "query": "none", "touch": false }));
+        let _ = send_req(
+            json!({ "action": "get_item", "query": "none", "touch": false, "session_token": token }),
+        );
         assert_eq!(*state.last_activity.lock().unwrap(), past);
 
-        // 5. Active action (e.g. "search") should touch activity
-        let _ = send_req(json!({ "action": "search", "query": "test" }));
+        // 5. Unauthenticated privileged action ("search" without valid token) must NOT touch activity
+        let unauth_res =
+            send_req(json!({ "action": "search", "query": "test", "session_token": "wrong" }));
+        assert_eq!(unauth_res.get("ok").and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(*state.last_activity.lock().unwrap(), past);
+
+        // 6. Active action (e.g. "search" with valid token) should touch activity
+        let auth_res =
+            send_req(json!({ "action": "search", "query": "test", "session_token": token }));
+        assert!(auth_res.is_array());
         assert!(*state.last_activity.lock().unwrap() > past);
     }
 
@@ -1065,5 +1238,141 @@ mod tests {
             let meta = fs::metadata(&runtime_dir).unwrap();
             assert_eq!(meta.uid(), unsafe { libc::getuid() });
         }
+    }
+
+    #[test]
+    fn test_session_token_validation_and_lock_clearing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("daemon_data.json");
+        let storage_mgr = StorageManager::new(path);
+        let state = DaemonState::new(storage_mgr, 15);
+
+        assert!(!state.is_session_valid("any-token"));
+        assert!(!state.is_session_valid(""));
+
+        let token = "my-secret-session-token-456";
+        *state.vault_mgr.is_unlocked.write().unwrap() = true;
+        *state.session_token.lock().unwrap() = Some(Zeroizing::new(token.to_string()));
+
+        assert!(state.is_session_valid(token));
+        assert!(!state.is_session_valid("wrong-token"));
+        assert!(!state.is_session_valid(""));
+
+        // Lock clears token
+        state.lock();
+        assert!(!state.is_session_valid(token));
+        assert!(state.session_token.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_privileged_actions_require_valid_session_token() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("daemon_data.json");
+        let storage_mgr = StorageManager::new(path);
+        let state = Arc::new(DaemonState::new(storage_mgr, 15));
+
+        let valid_token = "valid-token-xyz-789";
+        *state.vault_mgr.is_unlocked.write().unwrap() = true;
+        *state.session_token.lock().unwrap() = Some(Zeroizing::new(valid_token.to_string()));
+
+        let send_req = |req: Value| -> Value {
+            let (mut client, server) = UnixStream::pair().unwrap();
+            let st = state.clone();
+            let handle = std::thread::spawn(move || {
+                let _ = handle_client(server, st);
+            });
+            let payload = format!("{}\n", req);
+            client.write_all(payload.as_bytes()).unwrap();
+            client.flush().unwrap();
+
+            let mut reader = BufReader::new(client);
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            handle.join().unwrap();
+            serde_json::from_str(&line).unwrap()
+        };
+
+        let privileged_actions = vec![
+            json!({ "action": "list" }),
+            json!({ "action": "search", "query": "test" }),
+            json!({ "action": "get_item", "query": "test" }),
+            json!({ "action": "get_ssh_key", "query": "test" }),
+            json!({ "action": "get_attachment_key", "item_id": "i", "attachment_id": "a" }),
+            json!({ "action": "sync" }),
+            json!({ "action": "totp", "query": "test" }),
+            json!({ "action": "stop" }),
+        ];
+
+        for mut req in privileged_actions {
+            let act = req.get("action").unwrap().as_str().unwrap().to_string();
+
+            // 1. Without session token -> Unauthorized
+            let res = send_req(req.clone());
+            assert_eq!(
+                res.get("ok").and_then(|v| v.as_bool()),
+                Some(false),
+                "Action '{}' should fail without session token",
+                act
+            );
+            assert!(
+                res.get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .contains("Unauthorized"),
+                "Action '{}' error should mention Unauthorized",
+                act
+            );
+
+            // 2. With invalid session token -> Unauthorized
+            if let Some(map) = req.as_object_mut() {
+                map.insert("session_token".to_string(), json!("invalid-token"));
+            }
+            let res = send_req(req.clone());
+            assert_eq!(
+                res.get("ok").and_then(|v| v.as_bool()),
+                Some(false),
+                "Action '{}' should fail with invalid session token",
+                act
+            );
+
+            // 3. With valid session token -> Authorized (not rejected by session check)
+            if let Some(map) = req.as_object_mut() {
+                map.insert("session_token".to_string(), json!(valid_token));
+            }
+            // For stop and sync, skip actually executing it here since stop exits the process
+            // and sync triggers server network calls which can lock the unconfigured mock vault.
+            if act != "stop" && act != "sync" {
+                let res = send_req(req);
+                let err_str = res.get("error").and_then(|v| v.as_str()).unwrap_or("");
+                assert!(
+                    !err_str.contains("Unauthorized"),
+                    "Action '{}' should not be rejected as Unauthorized with valid token",
+                    act
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_max_session_lifetime_auto_lock() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("daemon_data.json");
+        let storage_mgr = StorageManager::new(path);
+        let state = DaemonState::new(storage_mgr, 15);
+
+        // Vault unlocked 2 hours ago with max lifetime of 1 hour
+        *state.vault_mgr.is_unlocked.write().unwrap() = true;
+        *state.session_token.lock().unwrap() = Some(Zeroizing::new("token123".to_string()));
+        *state.unlocked_at.lock().unwrap() = Some(Instant::now() - Duration::from_secs(7200));
+        *state.max_session_lifetime.lock().unwrap() = Duration::from_secs(3600);
+
+        // Keep last_activity brand new (just now) so idle timeout would NOT trigger
+        *state.last_activity.lock().unwrap() = Instant::now();
+
+        // check_auto_lock must trigger because max_session_lifetime has elapsed!
+        assert!(state.check_auto_lock());
+        assert!(!state.vault_mgr.is_unlocked());
+        assert!(state.session_token.lock().unwrap().is_none());
+        assert!(state.unlocked_at.lock().unwrap().is_none());
     }
 }

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -30,6 +30,14 @@ struct Cli {
     #[arg(long, value_name = "CONFIG_PATH", help = "Path to config.json")]
     config: Option<PathBuf>,
 
+    #[arg(
+        long,
+        global = true,
+        env = "OMAWARDEN_SESSION",
+        help = "Session token for daemon operations (also reads OMAWARDEN_SESSION or BW_SESSION)"
+    )]
+    session: Option<String>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -362,6 +370,9 @@ fn main() -> ExitCode {
     let _ = omawarden::locked::disable_dumpable();
 
     let cli = Cli::parse();
+    if let Some(ref session) = cli.session {
+        std::env::set_var("OMAWARDEN_SESSION", session);
+    }
     let config_mgr = ConfigManager::new(cli.config.as_deref());
     let mut cfg = config_mgr.load();
 
@@ -603,16 +614,26 @@ fn main() -> ExitCode {
                     };
                     omawarden::daemon::ensure_daemon_running();
                     let res = auth_mgr.unlock(&pwd);
-                    println!("{}", serde_json::to_string_pretty(&res).unwrap());
                     if res.ok {
+                        if let Some(ref tok) = res.session {
+                            std::env::set_var("OMAWARDEN_SESSION", tok);
+                            if io::stdout().is_terminal() {
+                                eprintln!("\nVault unlocked successfully.");
+                                eprintln!("To set your session in this shell, run:");
+                                eprintln!("  export OMAWARDEN_SESSION=\"{}\"", tok);
+                            }
+                        }
+                        println!("{}", serde_json::to_string_pretty(&res).unwrap());
                         ExitCode::SUCCESS
                     } else {
+                        println!("{}", serde_json::to_string_pretty(&res).unwrap());
                         ExitCode::FAILURE
                     }
                 }
                 AuthAction::Lock => {
                     let _ = send_daemon_request(&json!({ "action": "lock" }));
                     let res = auth_mgr.lock();
+                    std::env::remove_var("OMAWARDEN_SESSION");
                     println!("{}", serde_json::to_string_pretty(&res).unwrap());
                     ExitCode::SUCCESS
                 }
@@ -710,6 +731,23 @@ fn main() -> ExitCode {
                         );
                         return ExitCode::FAILURE;
                     }
+                    if is_unlocked && !vault_mgr.is_unlocked() {
+                        if let Some(daemon_resp) = send_daemon_request(&json!({ "action": "list" }))
+                        {
+                            if daemon_resp.get("ok") == Some(&Value::Bool(false)) {
+                                println!("{}", serde_json::to_string_pretty(&daemon_resp).unwrap());
+                                return ExitCode::FAILURE;
+                            }
+                            if let Ok(items) = serde_json::from_value::<
+                                Vec<omawarden::vault::VaultItem>,
+                            >(daemon_resp)
+                            {
+                                let filtered = vault_mgr.search(&items, "", category.as_deref());
+                                println!("{}", serde_json::to_string_pretty(&filtered).unwrap());
+                                return ExitCode::SUCCESS;
+                            }
+                        }
+                    }
                     let items = vault_mgr.get_items();
                     let filtered = vault_mgr.search(&items, "", category.as_deref());
                     println!("{}", serde_json::to_string_pretty(&filtered).unwrap());
@@ -733,6 +771,25 @@ fn main() -> ExitCode {
                             .unwrap()
                         );
                         return ExitCode::FAILURE;
+                    }
+                    if is_unlocked && !vault_mgr.is_unlocked() {
+                        if let Some(daemon_resp) = send_daemon_request(&json!({
+                            "action": "search",
+                            "query": query,
+                            "category": category
+                        })) {
+                            if daemon_resp.get("ok") == Some(&Value::Bool(false)) {
+                                println!("{}", serde_json::to_string_pretty(&daemon_resp).unwrap());
+                                return ExitCode::FAILURE;
+                            }
+                            if let Ok(items) = serde_json::from_value::<
+                                Vec<omawarden::vault::VaultItem>,
+                            >(daemon_resp)
+                            {
+                                println!("{}", serde_json::to_string_pretty(&items).unwrap());
+                                return ExitCode::SUCCESS;
+                            }
+                        }
                     }
                     let results = vault_mgr.search_items(&query, category.as_deref());
                     println!("{}", serde_json::to_string_pretty(&results).unwrap());


### PR DESCRIPTION
## Summary of Changes

Addresses Security Vulnerability 1 (Unrestricted Same-User Daemon IPC API & Auto-Lock Evasion):

1. **High-Entropy Ephemeral Session Token**:
   - Daemon generates a 256-bit cryptographically secure ephemeral token via `OsRng` encoded in URL-safe base64 upon vault unlock.
   - Session token is stored in `Zeroizing<String>` and zeroized immediately upon vault lock or stop.

2. **Privileged Action Authorization & Constant-Time Verification**:
   - Privileged operations (`list`, `search`, `get_item`, `get_ssh_key`, `get_attachment_key`, `ssh_key_create`, `sync`, `totp` with query, `stop` when unlocked) require a valid session token.
   - Verification uses constant-time byte comparison (`subtle::ConstantTimeEq`).
   - Unauthenticated or unauthorized requests return `{"ok": false, "error": "Unauthorized: valid session token required"}` and **do not touch activity**, preventing unauthenticated polling from bypassing idle auto-lock.

3. **Absolute Maximum Session Lifetime Watchdog**:
   - Implemented `max_session_lifetime` (default 12 hours) from `unlocked_at`.
   - The daemon automatically locks when max lifetime elapses, even with continuous user activity.

4. **Secure In-Memory Token Propagation**:
   - `OmarchyBitwarden.qml` captures the token on unlock and propagates `OMAWARDEN_SESSION` to child `Process` blocks via `environment` (`QProcessEnvironment`), completely avoiding command-line argument leakage to `/proc/<pid>/cmdline`.
   - `omawarden` CLI supports `--session <token>` and auto-injects `OMAWARDEN_SESSION` / `BW_SESSION` into daemon IPC payloads.

5. **Documentation & ADR**:
   - Added **Rule 9** to `docs/agents/security.md`.
   - Authored [ADR 0010](docs/adr/0010-daemon-session-token-and-access-control.md).

## Verification
- `cargo fmt --check` passed cleanly.
- `cargo clippy --all-targets --all-features -- -D warnings` passed with 0 warnings.
- `XDG_RUNTIME_DIR=/tmp cargo test` passed with 130/130 tests passing (including 16 daemon tests covering session token validation, unauthenticated rejection, activity touch isolation, and max session lifetime).