### PR TITLE
sec(download): implement GitHub Artifact Attestation and dual-tier verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
       - refactor/*
     paths:
       - "omawarden/**"
+      - "scripts/**"
+      - "tests/**"
       - ".github/workflows/ci.yml"
   pull_request:
     branches:
@@ -20,6 +22,8 @@ on:
       - develop
     paths:
       - "omawarden/**"
+      - "scripts/**"
+      - "tests/**"
       - ".github/workflows/ci.yml"
 
 jobs:
@@ -56,3 +60,6 @@ jobs:
 
       - name: Run test suite
         run: cargo test --all-targets
+
+      - name: Run downloader integration tests
+        run: python3 ../tests/test_downloader.py

--- a/.github/workflows/release-omawarden.yml
+++ b/.github/workflows/release-omawarden.yml
@@ -14,6 +14,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-release:
@@ -87,6 +89,11 @@ jobs:
 
           echo "archive_path=dist/${ARCHIVE_NAME}.tar.gz" >> $GITHUB_OUTPUT
           echo "sha256_path=dist/${ARCHIVE_NAME}.tar.gz.sha256" >> $GITHUB_OUTPUT
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'dist/*.tar.gz'
 
       - name: Upload artifact to job
         uses: actions/upload-artifact@v7

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -64,6 +64,7 @@ Item {
     error: "Checking CLI status..."
   })
   property bool isDownloadingCli: false
+  property bool engineAttestationVerified: false
   property string latestVersion: ""
   property bool isCheckingUpdate: false
   property string updateCheckStatus: ""
@@ -1387,6 +1388,7 @@ Item {
     report += "- **Configured Log Level**: " + lLevel + "\n"
     report += "- **Vault Status**: " + vStatus + "\n"
     report += "- **Engine Ready**: " + (root.cliHealth && root.cliHealth.installed ? "Yes" : "No") + "\n"
+    report += "- **Engine Attestation**: " + (root.engineAttestationVerified ? "Verified (GitHub Artifact Attestation)" : "Unverified / SHA-256 Only") + "\n"
     report += "- **Keyring Available**: " + (root.cliHealth && root.cliHealth.keyring_available ? "Yes" : "No") + "\n"
     report += "- **Clipboard Available**: " + (root.cliHealth && root.cliHealth.clipboard_available ? "Yes" : "No") + "\n\n"
     report += "#### Recent Logs (" + (root.logBuffer ? root.logBuffer.length : 0) + " entries):\n\n```text\n"
@@ -2284,7 +2286,12 @@ Item {
           var cleanText = (text || "").trim()
           var data = JSON.parse(cleanText)
           if (data && data.ok) {
-            root.statusMessage = "omawarden engine updated successfully."
+            root.engineAttestationVerified = Boolean(data.attestation_verified)
+            if (data.attestation_verified) {
+              root.statusMessage = "omawarden engine updated successfully (✓ GitHub Attestation verified)."
+            } else {
+              root.statusMessage = "omawarden engine updated successfully (SHA-256 verified)."
+            }
             root.errorMessage = ""
             root.refreshHealth()
             root.refreshConfig()

--- a/docs/adr/0011-github-artifact-attestation-and-dual-tier-verification.md
+++ b/docs/adr/0011-github-artifact-attestation-and-dual-tier-verification.md
@@ -1,0 +1,71 @@
+# ADR 0011: GitHub Artifact Attestation and Dual-Tier Release Verification
+
+## Status
+Accepted
+
+## Context
+
+The `omarchy-bitwarden` desktop plugin downloads pre-compiled native engine binaries (`omawarden`) from GitHub Releases via `scripts/download-engine.sh`.
+
+Previously, download verification relied solely on comparing the downloaded archive against a `.sha256` checksum file published alongside the archive in the same GitHub Release. While this protects against incomplete downloads, proxy caching errors, and network corruption, it has a significant architectural limitation in the supply chain threat model:
+
+1. **Vulnerability to Release Asset Tampering**:
+   Because the `.sha256` checksum file is co-located with the release archive, any attacker who gains write access to the GitHub repository or release assets can simultaneously overwrite both the binary archive and the checksum file. A client verifying only `sha256sum` would compute a valid hash matching the attacker's forged file and execute untrusted code.
+
+2. **Absence of Cryptographic Provenance Verification**:
+   Users and the desktop UI had no mechanism to prove that an archive actually originated from a clean, automated build in GitHub Actions from the official source repository, as opposed to a third-party upload.
+
+3. **Key Management Trade-Offs**:
+   While traditional signing methods (Minisign / GPG) provide cryptographic guarantees, managing static signing private keys across an automated GitHub Actions release pipeline presents security challenges (key exposure in repository secrets) and requires distributing/maintaining trusted public keys across client environments.
+
+---
+
+## Decision
+
+We adopt a **Dual-Tier Release Verification Architecture** leveraging GitHub Artifact Attestations (Sigstore OIDC) combined with universal SHA-256 checksums:
+
+### 1. Build Provenance Attestations (GitHub Actions Release Workflow)
+- In `.github/workflows/release-omawarden.yml`, we configure `id-token: write` and `attestations: write` permissions.
+- After producing the release archives (`dist/*.tar.gz`), the workflow invokes `actions/attest-build-provenance@v2`.
+- GitHub's Sigstore integration signs cryptographic assertions binding each archive's SHA-256 digest to the repository, workflow, commit SHA, and OIDC identity. The attestation is recorded immutably in the public transparency log (Rekor).
+- No long-lived cryptographic private keys are stored in CI secrets.
+
+### 2. Dual-Tier Verification in Downloader Bootstrap (`scripts/download-engine.sh`)
+- **Tier 1 (Universal Checksum Verification)**:
+  - Continues to download and verify `.sha256` using local `sha256sum` / `shasum`.
+  - Ensures universal compatibility and fail-closed corruption detection even on systems lacking the GitHub CLI.
+- **Tier 2 (Provenance Attestation Verification)**:
+  - If the GitHub CLI (`gh`) is available, the script executes `gh attestation verify "$TMP_DIR/omawarden.tar.gz" --repo "$REPO"`.
+  - If verified, `attestation_verified: true` is reported.
+  - If unverified in default mode, the script falls back gracefully to Tier 1 integrity and reports `attestation_verified: false`.
+  - In strict mode (`REQUIRE_ATTESTATION=1`), missing `gh` or failed provenance verification triggers an immediate fail-closed abort with a clear security alert.
+
+### 3. Structured Verification Reporting & Frontend Transparency
+- The downloader script returns structured JSON containing verification metadata:
+  ```json
+  {
+    "ok": true,
+    "version": "0.6.1",
+    "path": "/path/to/omawarden",
+    "verified": true,
+    "sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "attestation_verified": true
+  }
+  ```
+- In `OmarchyBitwarden.qml`:
+  - `root.engineAttestationVerified` stores the provenance verification outcome in memory.
+  - User-facing status messages reflect the verification tier (`✓ GitHub Attestation verified` vs `SHA-256 verified`).
+  - The System Diagnostics report displays the engine attestation trust state.
+
+---
+
+## Consequences
+
+### Positive
+- **Supply-Chain Hardening**: Release archives can be mathematically proven to have been compiled by GitHub Actions from the authentic `icyleaf/omarchy-bitwarden` repository.
+- **Zero Key Management Overhead**: Uses short-lived OIDC certificates from GitHub's Sigstore CA, eliminating the risk of compromised or leaked static private keys.
+- **Graceful Compatibility**: Existing environments without `gh` continue to work with Tier 1 SHA-256 integrity verification, while environments with `gh` gain automated provenance verification.
+- **Package Manager Friendly**: Standard `.sha256` files remain available for AUR / package managers.
+
+### Trade-offs
+- Verification of Tier 2 provenance depends on the GitHub CLI (`gh`) and access to the Sigstore API.

--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -41,23 +41,28 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ---
 
-### Rule 2: Fail-Closed Integrity & Cryptographic Checksum Verification
+### Rule 2: Fail-Closed Integrity & Dual-Tier Provenance Verification (SHA-256 + Artifact Attestations)
 
-**Principle**: All installers, downloaders, and update bootstrap scripts (`scripts/download-engine.sh`, `check-update.sh`) MUST cryptographically verify release artifacts before extracting or executing them.
+**Principle**: All installers, downloaders, and update bootstrap scripts (`scripts/download-engine.sh`, `check-update.sh`) MUST cryptographically verify release artifacts before extracting or executing them, combining universal SHA-256 integrity with cryptographic build provenance attestations.
 
 - ❌ **Anti-Pattern**:
   - Skipping verification if a checksum file fails to download (404/network error) or is empty.
   - Parsing HTML error pages as checksum strings.
   - Reporting synthetic success (`verified: true`) when no actual verification was performed.
+  - Relying exclusively on an unauthenticated `.sha256` file without provenance verification against release tampering or compromised release assets.
 - ✅ **Required Pattern**:
-  - Checksum downloads are **mandatory and fail-closed**: if the checksum cannot be fetched, contains non-hex text, or does not match the archive's SHA-256 hash, the script MUST immediately delete the download and exit with a non-zero code.
-  - Report `verified: true` ONLY after `sha256sum -c` (or equivalent cryptographic validation) succeeds.
-  - Support pinned version arguments to bypass dynamic feed resolution during automated testing or reproducible builds.
+  - **Tier 1 (Universal Integrity Checksum)**: Checksum downloads are **mandatory and fail-closed**: if the checksum cannot be fetched, contains non-hex text, or does not match the archive's SHA-256 hash, the script MUST immediately delete the download and exit with a non-zero code.
+  - **Tier 2 (Cryptographic Build Provenance Attestation)**: Release pipelines automatically sign and attest build provenance using GitHub Artifact Attestations (`actions/attest-build-provenance` via Sigstore OIDC). When `gh` CLI is available, the downloader runs `gh attestation verify` to prove the binary originated from an official `icyleaf/omarchy-bitwarden` workflow run.
+  - **Structured Verification Reporting**: The downloader reports `verified: true`, `sha256`, and `attestation_verified: bool` in its structured JSON output for UI transparency.
+  - **Strict Policy Mode**: When `REQUIRE_ATTESTATION=1` is set, attestation verification is mandatory; missing `gh` or failed provenance verification aborts installation immediately.
 - 🧪 **Mandatory Verification**:
-  Maintain automated tests covering:
+  Maintain automated integration tests covering:
   1. Checksum mismatch aborts without extraction.
   2. 404 / missing checksum aborts without extraction.
   3. Malformed/HTML checksum aborts without extraction.
+  4. Attestation success reports `attestation_verified: true`.
+  5. Attestation failure gracefully falls back in default mode and fails closed when `REQUIRE_ATTESTATION=1`.
+  6. Missing `gh` fails closed when `REQUIRE_ATTESTATION=1`.
 
 ---
 

--- a/scripts/download-engine.sh
+++ b/scripts/download-engine.sh
@@ -142,7 +142,23 @@ fi
 
 VERIFIED=true
 
-# 4. Extract and install (fail-closed: only if VERIFIED is true)
+# 4. GitHub Artifact Attestation verification (Tier 2 provenance verification)
+ATTESTATION_VERIFIED=false
+if command -v gh >/dev/null 2>&1; then
+  if gh attestation verify "$TMP_DIR/omawarden.tar.gz" --repo "$REPO" >/dev/null 2>&1; then
+    ATTESTATION_VERIFIED=true
+  else
+    if [ "${REQUIRE_ATTESTATION:-0}" = "1" ]; then
+      echo "{\"ok\":false,\"error\":\"Security Alert: GitHub Artifact Attestation verification failed for $REPO\"}"
+      exit 1
+    fi
+  fi
+elif [ "${REQUIRE_ATTESTATION:-0}" = "1" ]; then
+  echo "{\"ok\":false,\"error\":\"Security Alert: GitHub CLI (gh) required for strict attestation verification but not found\"}"
+  exit 1
+fi
+
+# 5. Extract and install (fail-closed: only if VERIFIED is true)
 if [ "$VERIFIED" != "true" ]; then
   echo "{\"ok\":false,\"error\":\"Installation blocked: archive failed integrity verification\"}"
   exit 1
@@ -173,4 +189,4 @@ chmod 0755 "$TARGET_DIR/omawarden"
 rm -rf "$EXTRACT_DIR"
 
 INSTALLED_VER=$("$TARGET_DIR/omawarden" --version 2>/dev/null || echo "ok")
-echo "{\"ok\":true,\"version\":\"$INSTALLED_VER\",\"path\":\"$TARGET_DIR/omawarden\",\"verified\":true}"
+echo "{\"ok\":true,\"version\":\"$INSTALLED_VER\",\"path\":\"$TARGET_DIR/omawarden\",\"verified\":true,\"sha256\":\"$ACTUAL_SHA\",\"attestation_verified\":$ATTESTATION_VERIFIED}"

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -193,5 +193,93 @@ class TestDownloadEngine(unittest.TestCase):
         self.assertIn('"ok":true', proc.stdout)
         self.assertIn('"verified":true', proc.stdout)
 
+    def test_attestation_verification_success_reports_true(self):
+        """When gh attestation verify succeeds, output must include attestation_verified: true."""
+        MockGitHubHandler.routes[self.sha_url] = (
+            200,
+            "text/plain",
+            f"{self.valid_sha256}  {ARCHIVE_NAME}\n".encode("utf-8")
+        )
+        mock_bin_dir = tempfile.mkdtemp()
+        mock_gh = os.path.join(mock_bin_dir, "gh")
+        with open(mock_gh, "w") as f:
+            f.write("#!/bin/sh\nexit 0\n")
+        os.chmod(mock_gh, 0o755)
+
+        try:
+            extra_path = f"{mock_bin_dir}:{os.environ.get('PATH', '')}"
+            proc = self.run_downloader(env_extra={"PATH": extra_path})
+            self.assertEqual(proc.returncode, 0, f"Downloader failed: {proc.stdout}")
+            self.assertIn('"attestation_verified":true', proc.stdout)
+        finally:
+            shutil.rmtree(mock_bin_dir, ignore_errors=True)
+
+    def test_attestation_verification_failure_fallback_in_default_mode(self):
+        """When gh attestation fails but strict mode is disabled, download succeeds with attestation_verified: false."""
+        MockGitHubHandler.routes[self.sha_url] = (
+            200,
+            "text/plain",
+            f"{self.valid_sha256}  {ARCHIVE_NAME}\n".encode("utf-8")
+        )
+        mock_bin_dir = tempfile.mkdtemp()
+        mock_gh = os.path.join(mock_bin_dir, "gh")
+        with open(mock_gh, "w") as f:
+            f.write("#!/bin/sh\nexit 1\n")
+        os.chmod(mock_gh, 0o755)
+
+        try:
+            extra_path = f"{mock_bin_dir}:{os.environ.get('PATH', '')}"
+            proc = self.run_downloader(env_extra={"PATH": extra_path})
+            self.assertEqual(proc.returncode, 0, f"Downloader failed: {proc.stdout}")
+            self.assertIn('"attestation_verified":false', proc.stdout)
+        finally:
+            shutil.rmtree(mock_bin_dir, ignore_errors=True)
+
+    def test_attestation_verification_failure_fails_closed_in_strict_mode(self):
+        """When gh attestation fails and REQUIRE_ATTESTATION=1, download must fail closed."""
+        MockGitHubHandler.routes[self.sha_url] = (
+            200,
+            "text/plain",
+            f"{self.valid_sha256}  {ARCHIVE_NAME}\n".encode("utf-8")
+        )
+        mock_bin_dir = tempfile.mkdtemp()
+        mock_gh = os.path.join(mock_bin_dir, "gh")
+        with open(mock_gh, "w") as f:
+            f.write("#!/bin/sh\nexit 1\n")
+        os.chmod(mock_gh, 0o755)
+
+        try:
+            extra_path = f"{mock_bin_dir}:{os.environ.get('PATH', '')}"
+            proc = self.run_downloader(env_extra={"PATH": extra_path, "REQUIRE_ATTESTATION": "1"})
+            self.assertNotEqual(proc.returncode, 0, "Downloader must fail non-zero in strict mode")
+            self.assertIn('"ok":false', proc.stdout)
+            self.assertIn("GitHub Artifact Attestation verification failed", proc.stdout)
+            installed_bin = os.path.join(self.target_dir, "omawarden")
+            self.assertFalse(os.path.exists(installed_bin), "Binary must NOT be installed on attestation failure")
+        finally:
+            shutil.rmtree(mock_bin_dir, ignore_errors=True)
+
+    def test_attestation_missing_gh_fails_closed_in_strict_mode(self):
+        """When gh is missing and REQUIRE_ATTESTATION=1, download must fail closed."""
+        MockGitHubHandler.routes[self.sha_url] = (
+            200,
+            "text/plain",
+            f"{self.valid_sha256}  {ARCHIVE_NAME}\n".encode("utf-8")
+        )
+        # Create a restricted PATH without gh
+        clean_bin_dir = tempfile.mkdtemp()
+        for cmd in ["bash", "sh", "uname", "which", "tar", "gzip", "sha256sum", "mktemp", "mkdir", "chmod", "cp", "mv", "rm", "find", "cat", "awk", "tr", "grep", "cut", "head", "curl", "sleep"]:
+            cmd_path = shutil.which(cmd)
+            if cmd_path:
+                os.symlink(cmd_path, os.path.join(clean_bin_dir, cmd))
+
+        try:
+            proc = self.run_downloader(env_extra={"PATH": clean_bin_dir, "REQUIRE_ATTESTATION": "1"})
+            self.assertNotEqual(proc.returncode, 0, "Downloader must fail non-zero when gh is missing in strict mode")
+            self.assertIn('"ok":false', proc.stdout)
+            self.assertIn("GitHub CLI (gh) required for strict attestation verification", proc.stdout)
+        finally:
+            shutil.rmtree(clean_bin_dir, ignore_errors=True)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #132

## Summary of Changes

1. **GitHub Actions Build Provenance Attestation**:
   - Added `id-token: write` and `attestations: write` permissions to `.github/workflows/release-omawarden.yml`.
   - Added `actions/attest-build-provenance@v2` to cryptographically sign and register provenance for all `dist/*.tar.gz` archives in Sigstore transparency log.

2. **Dual-Tier Downloader Verification**:
   - Updated `scripts/download-engine.sh` to maintain Tier 1 SHA-256 verification and add Tier 2 provenance attestation verification via `gh attestation verify`.
   - Added `REQUIRE_ATTESTATION=1` strict mode support to fail closed if provenance attestation cannot be verified or if `gh` is missing.
   - Extended JSON response contract with `attestation_verified` boolean field.

3. **Frontend Integration & Transparency**:
   - Added `engineAttestationVerified` state property in `OmarchyBitwarden.qml`.
   - Updated `downloadCliProc` to capture and report attestation status in status messages.
   - Added Engine Attestation verification status to the System Diagnostics report.

4. **ADR & Security Handbook**:
   - Updated Rule 2 in `docs/agents/security.md`.
   - Authored [ADR 0011](docs/adr/0011-github-artifact-attestation-and-dual-tier-verification.md).

5. **Integration Tests**:
   - Added automated tests in `tests/test_downloader.py` for attestation success, non-strict fallback, strict failure, and missing `gh` in strict mode.