### PR TITLE
sec(ui): add opt-out for remote website icon fetching

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -7,6 +7,7 @@ import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
 import "./components"
+import "./components/iconpolicy.js" as IconPolicy
 
 Item {
   id: root
@@ -49,9 +50,11 @@ Item {
     auto_lock_minutes: 15,
     clipboard_clear_seconds: 30,
     email: "",
-    remember_email: true
+    remember_email: true,
+    show_website_icons: true
   })
   property bool rememberEmailChecked: true
+  property bool showWebsiteIcons: false
   property bool show2FAField: false
 
   property var cliHealth: ({
@@ -1860,6 +1863,7 @@ Item {
             // Left Column: Items List
             VaultItemList {
               id: vaultItemList
+              showWebsiteIcons: root.showWebsiteIcons
               Layout.fillHeight: true
               Layout.preferredWidth: 320
               Layout.minimumWidth: 260
@@ -1896,6 +1900,7 @@ Item {
               // Item Inspector View
               ItemInspector {
                 anchors.fill: parent
+                showWebsiteIcons: root.showWebsiteIcons
                 visible: root.selectedItem !== null
                 item: root.selectedItem
                 currentTotp: root.currentTotp
@@ -2177,6 +2182,7 @@ Item {
           if (data.remember_email !== undefined) {
             root.rememberEmailChecked = (data.remember_email !== false)
           }
+          root.showWebsiteIcons = IconPolicy.resolve(true, data.show_website_icons)
         } catch (e) {
           root.logError("omarchy:ui", "Failed to parse config: " + e)
         }

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -55,6 +55,7 @@ Item {
   })
   property bool rememberEmailChecked: true
   property bool showWebsiteIcons: false
+  property int configSeq: 0
   property bool show2FAField: false
 
   property var cliHealth: ({
@@ -273,6 +274,8 @@ Item {
 
   function refreshConfig() {
     root.showWebsiteIcons = false
+    root.configSeq++
+    configGetProc.seq = root.configSeq
     configGetProc.command = [root.helperPath, "config", "get"]
     configGetProc.running = true
   }
@@ -1359,6 +1362,7 @@ Item {
   }
 
   function saveSettings(settings) {
+    root.configSeq++
     root.isBusy = true
     root.logInfo("omarchy:settings", "Saving configuration (log_level: " + (settings.log_level || "error") + ")...")
     root.statusMessage = "Saving configuration..."
@@ -2174,10 +2178,12 @@ Item {
   }
   Process {
     id: configGetProc
+    property int seq: 0
     command: []
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
+        if (configGetProc.seq !== root.configSeq) return
         try {
           var data = JSON.parse(text)
           root.config = data

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -274,6 +274,7 @@ Item {
 
   function refreshConfig() {
     root.showWebsiteIcons = false
+    if (configGetProc.running) return
     root.configSeq++
     configGetProc.seq = root.configSeq
     configGetProc.command = [root.helperPath, "config", "get"]

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -1368,6 +1368,7 @@ Item {
     if (settings.auto_lock_minutes !== undefined) cmd.push("--auto-lock", String(settings.auto_lock_minutes))
     if (settings.clipboard_clear_seconds !== undefined) cmd.push("--clipboard-clear", String(settings.clipboard_clear_seconds))
     if (settings.log_level !== undefined) cmd.push("--log-level", settings.log_level)
+    if (settings.show_website_icons !== undefined) cmd.push("--show-website-icons", String(settings.show_website_icons))
 
     configSetProc.command = cmd
     configSetProc.running = true
@@ -2204,6 +2205,7 @@ Item {
         try {
           var data = JSON.parse(text)
           root.config = data
+          root.showWebsiteIcons = IconPolicy.resolve(true, data.show_website_icons)
           root.statusMessage = "Configuration saved successfully."
           root.refreshHealth()
           root.refreshAuthStatus()

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -272,6 +272,7 @@ Item {
   }
 
   function refreshConfig() {
+    root.showWebsiteIcons = false
     configGetProc.command = [root.helperPath, "config", "get"]
     configGetProc.running = true
   }
@@ -2185,6 +2186,7 @@ Item {
           }
           root.showWebsiteIcons = IconPolicy.resolve(true, data.show_website_icons)
         } catch (e) {
+          root.showWebsiteIcons = false
           root.logError("omarchy:ui", "Failed to parse config: " + e)
         }
       }
@@ -2210,6 +2212,7 @@ Item {
           root.refreshHealth()
           root.refreshAuthStatus()
         } catch (e) {
+          root.showWebsiteIcons = false
           root.statusMessage = "Failed to update config."
           root.logError("omarchy:ui", "Failed to parse updated config: " + e)
         }

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -18,6 +18,7 @@ ScrollView {
   property color accent: "#3b82f6"
   property color borderColor: Qt.rgba(1, 1, 1, 0.1)
   property string fontFamily: ""
+  property bool showWebsiteIcons: false
   readonly property int keyPixelSize: 10
   readonly property int valuePixelSize: 12
 
@@ -104,6 +105,7 @@ ScrollView {
   }
 
   function getFaviconUrl(item) {
+    if (!showWebsiteIcons) return ""
     if (!item) return ""
     if (item.type_name !== "login" && item.category !== "login") return ""
     if (!item.login || !item.login.uris || item.login.uris.length === 0) return ""

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -47,6 +47,21 @@ Item {
   property string activeTab: "general" // "general" | "logs"
   property string logFilter: "all" // "all" | "error" | "warn"
   property string selectedLogLevel: (config && config.log_level) ? config.log_level.toLowerCase() : "error"
+  property bool showWebsiteIconsChecked: true
+
+  onConfigChanged: if (config && config.show_website_icons !== undefined) showWebsiteIconsChecked = (config.show_website_icons !== false)
+
+  function buildPayload() {
+    return {
+      server_url: sUrlInput.text.trim() || "https://vault.bitwarden.com",
+      identity_url: idUrlInput.text.trim(),
+      download_dir: dlDirInput.text.trim() || "~/Downloads",
+      auto_lock_minutes: parseInt(lockMinInput.text.trim()) || 15,
+      clipboard_clear_seconds: parseInt(clipSecInput.text.trim()) || 30,
+      log_level: settingsRoot.selectedLogLevel,
+      show_website_icons: settingsRoot.showWebsiteIconsChecked
+    }
+  }
 
   signal saveRequested(var newSettings)
   signal closeRequested()
@@ -545,6 +560,35 @@ Item {
             }
           }
 
+          // Show Website Icons Checkbox
+          ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 3
+            RowLayout {
+              spacing: 6
+              Rectangle {
+                width: 14; height: 14; radius: 3; color: settingsRoot.showWebsiteIconsChecked ? settingsRoot.accent : Qt.rgba(0, 0, 0, 0.2); border.color: settingsRoot.borderColor; border.width: 1
+                Text {
+                  anchors.centerIn: parent
+                  visible: settingsRoot.showWebsiteIconsChecked
+                  text: "\uf00c"
+                  font.family: settingsRoot.fontFamily
+                  color: "#ffffff"
+                  font.pixelSize: 9
+                }
+                MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: settingsRoot.showWebsiteIconsChecked = !settingsRoot.showWebsiteIconsChecked }
+              }
+              Text { text: "Show website icons"; color: settingsRoot.foreground; font.pixelSize: 11 }
+            }
+            Text {
+              text: "Fetches icons from icons.bitwarden.net, revealing your saved sites to Bitwarden."
+              color: settingsRoot.mutedForeground
+              font.pixelSize: 10
+              Layout.fillWidth: true
+              wrapMode: Text.WordWrap
+            }
+          }
+
           // Log Level Selection
           ColumnLayout {
             Layout.fillWidth: true
@@ -634,17 +678,7 @@ Item {
             MouseArea {
               anchors.fill: parent
               cursorShape: Qt.PointingHandCursor
-              onClicked: {
-                var payload = {
-                  server_url: sUrlInput.text.trim() || "https://vault.bitwarden.com",
-                  identity_url: idUrlInput.text.trim(),
-                  download_dir: dlDirInput.text.trim() || "~/Downloads",
-                  auto_lock_minutes: parseInt(lockMinInput.text.trim()) || 15,
-                  clipboard_clear_seconds: parseInt(clipSecInput.text.trim()) || 30,
-                  log_level: settingsRoot.selectedLogLevel
-                }
-                settingsRoot.saveRequested(payload)
-              }
+              onClicked: settingsRoot.saveRequested(settingsRoot.buildPayload())
             }
           }
         }

--- a/components/VaultItemList.qml
+++ b/components/VaultItemList.qml
@@ -15,6 +15,7 @@ Item {
   property color selectedBackground: Qt.rgba(0.23, 0.51, 0.96, 0.25)
   property color borderColor: Qt.rgba(1, 1, 1, 0.1)
   property string fontFamily: ""
+  property bool showWebsiteIcons: false
 
   signal itemSelected(int index)
   signal itemTriggered(int index)
@@ -50,6 +51,7 @@ Item {
   }
 
   function getFaviconUrl(item) {
+    if (!showWebsiteIcons) return ""
     if (!item) return ""
     if (item.type_name !== "login" && item.category !== "login") return ""
     if (!item.login || !item.login.uris || item.login.uris.length === 0) return ""

--- a/components/iconpolicy.js
+++ b/components/iconpolicy.js
@@ -1,0 +1,5 @@
+.pragma library
+function resolve(configLoaded, configValue) {
+  if (!configLoaded) return false
+  return configValue !== false
+}

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_CLIPBOARD_CLEAR_SECONDS: i64 = 30;
 pub const DEFAULT_EMAIL: &str = "";
 pub const DEFAULT_REMEMBER_EMAIL: bool = true;
 pub const DEFAULT_LOG_LEVEL: &str = "error";
+pub const DEFAULT_SHOW_WEBSITE_ICONS: bool = true;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
@@ -29,6 +30,8 @@ pub struct Config {
     pub remember_email: bool,
     #[serde(default = "default_log_level")]
     pub log_level: String,
+    #[serde(default = "default_show_website_icons")]
+    pub show_website_icons: bool,
 }
 
 fn default_server_url() -> String {
@@ -52,6 +55,9 @@ fn default_remember_email() -> bool {
 fn default_log_level() -> String {
     DEFAULT_LOG_LEVEL.to_string()
 }
+fn default_show_website_icons() -> bool {
+    DEFAULT_SHOW_WEBSITE_ICONS
+}
 
 impl Default for Config {
     fn default() -> Self {
@@ -64,6 +70,7 @@ impl Default for Config {
             email: default_email(),
             remember_email: default_remember_email(),
             log_level: default_log_level(),
+            show_website_icons: default_show_website_icons(),
         }
     }
 }
@@ -192,6 +199,9 @@ impl ConfigManager {
         if let Some(v) = options.log_level {
             cfg.log_level = v.to_lowercase();
         }
+        if let Some(v) = options.show_website_icons {
+            cfg.show_website_icons = v;
+        }
 
         self.save(&cfg)?;
         Ok((cfg, server_changed))
@@ -208,6 +218,7 @@ pub struct ConfigUpdateOptions {
     pub email: Option<String>,
     pub remember_email: Option<bool>,
     pub log_level: Option<String>,
+    pub show_website_icons: Option<bool>,
 }
 
 #[cfg(test)]
@@ -509,5 +520,41 @@ esac
             keyring_mgr.get_token("access_token"),
             Some("valid-token".to_string())
         );
+    }
+
+    #[test]
+    fn test_show_website_icons_default_and_update() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        let storage_path = dir.path().join("data.json");
+        let mock_script = create_mock_secret_tool(dir.path());
+
+        assert!(Config::default().show_website_icons);
+
+        let config_mgr = ConfigManager::new(Some(&config_path));
+        let storage_mgr = crate::storage::StorageManager::new(storage_path);
+        let keyring_mgr = crate::keyring::KeyringManager::new(&mock_script);
+
+        let (updated_cfg, _) = config_mgr
+            .update_config(
+                ConfigUpdateOptions {
+                    show_website_icons: Some(false),
+                    ..Default::default()
+                },
+                &storage_mgr,
+                &keyring_mgr,
+            )
+            .unwrap();
+        assert!(!updated_cfg.show_website_icons);
+
+        // Persisted to disk
+        let reloaded = ConfigManager::new(Some(&config_path)).load();
+        assert!(!reloaded.show_website_icons);
+
+        // Upgrade path: config written before the key existed must default to true
+        let legacy_path = dir.path().join("legacy.json");
+        fs::write(&legacy_path, r#"{"email": "legacy@test.com"}"#).unwrap();
+        let legacy = ConfigManager::new(Some(&legacy_path)).load();
+        assert!(legacy.show_website_icons);
     }
 }

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -154,6 +154,8 @@ enum ConfigAction {
         remember_email: Option<String>,
         #[arg(long)]
         log_level: Option<String>,
+        #[arg(long)]
+        show_website_icons: Option<String>,
     },
 }
 
@@ -412,6 +414,7 @@ fn main() -> ExitCode {
                         "email" => println!("{}", cfg.email),
                         "remember_email" => println!("{}", cfg.remember_email),
                         "log_level" => println!("{}", cfg.log_level),
+                        "show_website_icons" => println!("{}", cfg.show_website_icons),
                         _ => {
                             eprintln!("Unknown configuration key: {}", k);
                             return ExitCode::FAILURE;
@@ -431,6 +434,7 @@ fn main() -> ExitCode {
                 email,
                 remember_email,
                 log_level,
+                show_website_icons,
             } => {
                 let storage_mgr = match cli.config.as_deref() {
                     Some(cp) => {
@@ -451,6 +455,11 @@ fn main() -> ExitCode {
                     matches!(lower.as_str(), "true" | "1" | "yes")
                 });
 
+                let parsed_show_website_icons = show_website_icons.map(|v| {
+                    let lower = v.trim().to_lowercase();
+                    matches!(lower.as_str(), "true" | "1" | "yes")
+                });
+
                 let options = ConfigUpdateOptions {
                     server_url,
                     identity_url,
@@ -460,6 +469,7 @@ fn main() -> ExitCode {
                     email,
                     remember_email: parsed_remember_email,
                     log_level,
+                    show_website_icons: parsed_show_website_icons,
                 };
 
                 let (updated_cfg, _server_changed) =

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -1855,6 +1855,52 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_show_website_icons_arg_parsing() {
+        // Without the flag, show_website_icons should be None so config keeps its value
+        let cli_default = Cli::try_parse_from(["omawarden", "config", "set"]).unwrap();
+        match cli_default.command {
+            Commands::Config {
+                action:
+                    ConfigAction::Set {
+                        show_website_icons, ..
+                    },
+            } => assert_eq!(show_website_icons, None),
+            _ => panic!("Expected Commands::Config with ConfigAction::Set"),
+        }
+
+        let cli_false = Cli::try_parse_from([
+            "omawarden",
+            "config",
+            "set",
+            "--show-website-icons",
+            "false",
+        ])
+        .unwrap();
+        match cli_false.command {
+            Commands::Config {
+                action:
+                    ConfigAction::Set {
+                        show_website_icons, ..
+                    },
+            } => assert_eq!(show_website_icons, Some("false".to_string())),
+            _ => panic!("Expected Commands::Config with ConfigAction::Set"),
+        }
+
+        let cli_true =
+            Cli::try_parse_from(["omawarden", "config", "set", "--show-website-icons", "true"])
+                .unwrap();
+        match cli_true.command {
+            Commands::Config {
+                action:
+                    ConfigAction::Set {
+                        show_website_icons, ..
+                    },
+            } => assert_eq!(show_website_icons, Some("true".to_string())),
+            _ => panic!("Expected Commands::Config with ConfigAction::Set"),
+        }
+    }
+
+    #[test]
     fn test_cli_totp_stdin_and_secret_arg_parsing() {
         let cli_stdin = Cli::try_parse_from(["omawarden", "totp", "--stdin"]).unwrap();
         match cli_stdin.command {

--- a/tests/tst_favicon_privacy.qml
+++ b/tests/tst_favicon_privacy.qml
@@ -1,0 +1,68 @@
+import QtQuick
+import QtQuick.Controls
+import "../components"
+import "../components/iconpolicy.js" as IconPolicy
+
+Item {
+  property int failures: 0
+  function check(cond, msg) { if (!cond) { failures++; console.error("FAIL: " + msg) } }
+
+  VaultItemList { id: list }
+  ItemInspector { id: insp }
+
+  property var loginItem: ({
+    name: "GitHub",
+    type_name: "login",
+    login: { username: "octocat", uris: [{ uri: "https://github.com" }] },
+    sub_title: "octocat"
+  })
+  property var appSchemeItem: ({
+    name: "Example App",
+    type_name: "login",
+    login: { username: "user", uris: [{ uri: "androidapp://com.example" }] },
+    sub_title: "user"
+  })
+  property var nonLoginItem: ({
+    name: "Secret Recipe",
+    type_name: "note",
+    sub_title: "Secure Note"
+  })
+
+  Component.onCompleted: {
+    // A. Policy truth table — fail closed until config has actually loaded
+    check(IconPolicy.resolve(false, true) === false, "resolve(false, true) is false")
+    check(IconPolicy.resolve(false, undefined) === false, "resolve(false, undefined) is false")
+    check(IconPolicy.resolve(false, false) === false, "resolve(false, false) is false")
+    check(IconPolicy.resolve(true, false) === false, "resolve(true, false) is false")
+    check(IconPolicy.resolve(true, true) === true, "resolve(true, true) is true")
+    check(IconPolicy.resolve(true, undefined) === true, "resolve(true, undefined) is true")
+
+    var comps = [{ n: "VaultItemList", c: list }, { n: "ItemInspector", c: insp }]
+    var i
+
+    // B. Components fail closed by default
+    for (i = 0; i < comps.length; i++) {
+      check(comps[i].c.showWebsiteIcons === false, comps[i].n + ": showWebsiteIcons defaults to false")
+      check(comps[i].c.getFaviconUrl(loginItem) === "", comps[i].n + ": no favicon URL by default")
+    }
+
+    // C. Enabled path
+    for (i = 0; i < comps.length; i++) {
+      comps[i].c.showWebsiteIcons = true
+      check(comps[i].c.getFaviconUrl(loginItem) === "https://icons.bitwarden.net/github.com/icon.png",
+            comps[i].n + ": enabled login item returns bitwarden icon URL")
+      check(comps[i].c.getFaviconUrl(appSchemeItem) === "", comps[i].n + ": enabled app-scheme item returns empty")
+      check(comps[i].c.getFaviconUrl(nonLoginItem) === "", comps[i].n + ": enabled non-login item returns empty")
+    }
+
+    // D. Disabled path
+    for (i = 0; i < comps.length; i++) {
+      comps[i].c.showWebsiteIcons = false
+      check(comps[i].c.getFaviconUrl(loginItem) === "", comps[i].n + ": disabled login item returns empty")
+      check(comps[i].c.getFaviconUrl(appSchemeItem) === "", comps[i].n + ": disabled app-scheme item returns empty")
+      check(comps[i].c.getFaviconUrl(nonLoginItem) === "", comps[i].n + ": disabled non-login item returns empty")
+    }
+
+    Qt.exit(failures === 0 ? 0 : 1)
+  }
+}

--- a/tests/tst_settings_icon_toggle.qml
+++ b/tests/tst_settings_icon_toggle.qml
@@ -1,0 +1,41 @@
+import QtQuick
+import QtQuick.Controls
+import "../components"
+
+Item {
+  property int failures: 0
+  function check(cond, msg) { if (!cond) { failures++; console.error("FAIL: " + msg) } }
+
+  SettingsModal { id: sm }
+
+  Component.onCompleted: {
+    // A. Config load drives the checkbox
+    sm.config = ({ server_url: "https://vault.bitwarden.com", log_level: "error", show_website_icons: false })
+    check(sm.showWebsiteIconsChecked === false, "config show_website_icons:false unchecks the box")
+
+    sm.config = ({ server_url: "https://vault.bitwarden.com", log_level: "error", show_website_icons: true })
+    check(sm.showWebsiteIconsChecked === true, "config show_website_icons:true checks the box")
+
+    // Existing-user upgrade path: key absent leaves the last known value alone (default true)
+    sm.showWebsiteIconsChecked = true
+    sm.config = ({ server_url: "https://vault.bitwarden.com", log_level: "error" })
+    check(sm.showWebsiteIconsChecked === true, "config without the key leaves it true")
+
+    // B. Payload carries the checkbox state
+    sm.showWebsiteIconsChecked = false
+    check(sm.buildPayload().show_website_icons === false, "payload show_website_icons is false when unchecked")
+
+    sm.showWebsiteIconsChecked = true
+    check(sm.buildPayload().show_website_icons === true, "payload show_website_icons is true when checked")
+
+    // C. Regression guard on the extraction — all six pre-existing keys survive
+    var payload = sm.buildPayload()
+    var keys = ["server_url", "identity_url", "download_dir", "auto_lock_minutes",
+                "clipboard_clear_seconds", "log_level"]
+    for (var i = 0; i < keys.length; i++) {
+      check(payload[keys[i]] !== undefined, "payload still contains " + keys[i])
+    }
+
+    Qt.exit(failures === 0 ? 0 : 1)
+  }
+}


### PR DESCRIPTION
Closes #134

## Summary

Adds a `show_website_icons` setting (default `true`) so users can stop the plugin
disclosing their saved domains to `icons.bitwarden.net`.

`getFaviconUrl()` previously built a remote URL unconditionally for every login item with
a URI, so rendering the vault list emitted one request per distinct domain — and the
domain is in the request path, so anyone observing that service learns which sites the
user holds credentials for. Bitwarden's own clients expose this as a setting; this plugin
had no equivalent.

## Changes

- **`omawarden`** — new `show_website_icons` config key (default `true`), plumbed through
  the existing `config get|set` path exactly like `remember_email`. New CLI flag
  `--show-website-icons`.
- **QML** — both `getFaviconUrl()` implementations return `""` when disabled. The existing
  glyph fallback already treats an empty URL as "no remote icon", so nothing about
  rendering changed.
- **Settings** — a "Show website icons" checkbox, reusing the existing checkbox primitive
  from `AuthView.qml` rather than pulling in `QtQuick.Controls.CheckBox`.

## Fail-closed, not just defaulted

The permission starts `false` and turns on only after a config response is parsed.

This matters more than it might look. `Component.onCompleted` fires `refreshConfig()`
without awaiting it, and an unlocked `auth status` starts `vault list`, so rows can render
— and `Image.source` can call `getFaviconUrl()` — before `configGetProc` returns. A flag
that merely defaulted to `true` would still leak for users who had already opted out.

For the same reason the gate is closed at the start of every `refreshConfig()` and in both
config handlers' `catch` blocks: a failed or unparseable response is not a known state, so
it must not leave a previously-enabled gate enabled while the persisted value may now be
`false`. This follows Rules 1 and 2 in `docs/agents/security.md`.

Two stale-read paths are also closed, both of which could reopen the gate against a
persisted `false`. `configGetProc` and `configSetProc` are independent `Process` objects
with no ordering, so a read dispatched before a write can be delivered after it:

- A monotonic `configSeq` stamps each read; `saveSettings()` advances it, so a read that
  predates a write is rejected rather than applied.
- `refreshConfig()` will not restamp an already-running read. Without this, clicking
  Refresh in Settings mid-save (that control has no busy guard) would renumber the
  in-flight read and let its stale payload pass the check.

Both are narrow races, but the whole point of the setting is a privacy guarantee, so they
are fixed rather than documented.

The policy is extracted to `components/iconpolicy.js` (six lines) so this state machine is
testable — `OmarchyBitwarden.qml` itself imports `Quickshell` and `qs.*` and cannot be
instantiated headlessly.

## Tests

Two new test files, plus a CLI arg-parsing test following the existing
`test_cli_daemon_auto_lock_arg_parsing` pattern.

The new QML tests deliberately do **not** use the `assert()` helper the existing
`tests/tst_*.qml` files share. That helper calls `Qt.quit()` (exit 0) before it throws,
and QML console output is not visible under `qml6`, so a failing assertion currently exits
0 silently — the five existing QML tests cannot fail. Happy to file that separately if
useful. The new tests count failures and end with
`Qt.exit(failures === 0 ? 0 : 1)`, and were checked by mutating the implementation
(neutering each guard, flipping each fail-closed default, inverting the policy) to confirm
each mutation produces exit 1.

## Known limitations, stated rather than glossed

- `OmarchyBitwarden.qml` cannot be loaded by `qml6` (Quickshell + `qs.*` modules), so
  everything in that file — the root's own `showWebsiteIcons: false` default, the two
  root→child bindings, and the stale-read guards — is covered by static checks, not an
  executable test. Flipping that root default would leak at startup and no test would
  catch it. This is the weakest part of the change and I'd rather say so than imply
  coverage I don't have.
- Every test calls `getFaviconUrl()` directly; none exercises the real `favUrl` property
  binding. I verified separately that QML bindings do track property reads inside called
  functions, so the live toggle works — but a future change making the guard read a
  non-property would break live re-evaluation with the tests still green.
- The new Rust test covers argument parsing only. Dropping the field from the
  `ConfigUpdateOptions` construction would still pass it; that path is covered by a manual
  CLI round-trip, not an automated test.
- The two stale-read fixes and the pre-config startup window are timing-dependent, so
  they are reasoned about and statically checked rather than observed firing. I could not
  provoke either race by hand.

## Verification

Verified in a live Omarchy session (plugin installed and enabled under Quickshell, not
just headless): the overlay opens with no QML errors, and unticking **Show website icons**
in Settings and saving makes the list icons disappear immediately, without reopening the
overlay.

That last check matters more than it sounds. It exercises the whole chain end to end —
checkbox -> `buildPayload()` -> `config set` -> the `configSetProc` handler recomputing the
gate -> the root->child bindings -> `favUrl` re-evaluating. Every one of those links is in
`OmarchyBitwarden.qml` or its bindings, which no headless test can reach; before this they
were covered only by static checks.

Headless verification:

- `cargo test` — 125 lib + 7 bin, 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- all seven `tests/tst_*.qml` exit 0 under `QT_QPA_PLATFORM=offscreen qml6`
- CLI round-trip: `config get` emits `"show_website_icons": true` by default and `false`
  after `config set --show-website-icons false`

Happy to change the default to `false`, drop the Settings toggle, or split this up if
you'd rather take it in pieces.
