### PR TITLE
feat(ui): allow disabling the automatic update check

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -49,9 +49,12 @@ Item {
     auto_lock_minutes: 15,
     clipboard_clear_seconds: 30,
     email: "",
-    remember_email: true
+    remember_email: true,
+    check_updates: true
   })
   property bool rememberEmailChecked: true
+  property bool checkUpdatesEnabled: false
+  property bool pendingUpdateCheck: false
   property bool show2FAField: false
 
   property var cliHealth: ({
@@ -316,6 +319,7 @@ Item {
   }
 
   function checkUpdates(isManual) {
+    if (!isManual && !root.checkUpdatesEnabled) { root.pendingUpdateCheck = true; return }
     if (root.isCheckingUpdate) return
     root.isCheckingUpdate = true
     if (isManual) {
@@ -1365,6 +1369,7 @@ Item {
     if (settings.auto_lock_minutes !== undefined) cmd.push("--auto-lock", String(settings.auto_lock_minutes))
     if (settings.clipboard_clear_seconds !== undefined) cmd.push("--clipboard-clear", String(settings.clipboard_clear_seconds))
     if (settings.log_level !== undefined) cmd.push("--log-level", settings.log_level)
+    if (settings.check_updates !== undefined) cmd.push("--check-updates", String(settings.check_updates))
 
     configSetProc.command = cmd
     configSetProc.running = true
@@ -2177,6 +2182,11 @@ Item {
           if (data.remember_email !== undefined) {
             root.rememberEmailChecked = (data.remember_email !== false)
           }
+          root.checkUpdatesEnabled = (data.check_updates !== false)
+          if (root.checkUpdatesEnabled && root.pendingUpdateCheck) {
+            root.pendingUpdateCheck = false
+            root.checkUpdates(false)
+          }
         } catch (e) {
           root.logError("omarchy:ui", "Failed to parse config: " + e)
         }
@@ -2198,6 +2208,7 @@ Item {
         try {
           var data = JSON.parse(text)
           root.config = data
+          root.checkUpdatesEnabled = (data.check_updates !== false)
           root.statusMessage = "Configuration saved successfully."
           root.refreshHealth()
           root.refreshAuthStatus()

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -272,6 +272,7 @@ Item {
   }
 
   function refreshConfig() {
+    root.checkUpdatesEnabled = false
     configGetProc.command = [root.helperPath, "config", "get"]
     configGetProc.running = true
   }

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -24,6 +24,9 @@ Item {
   property color borderColor: Qt.rgba(1, 1, 1, 0.1)
   property color mutedForeground: Qt.darker(foreground, 1.8)
   property string fontFamily: ""
+  property bool checkUpdatesChecked: true
+
+  onConfigChanged: if (config && config.check_updates !== undefined) checkUpdatesChecked = (config.check_updates !== false)
 
   Timer {
     id: latestTimer
@@ -47,6 +50,18 @@ Item {
   property string activeTab: "general" // "general" | "logs"
   property string logFilter: "all" // "all" | "error" | "warn"
   property string selectedLogLevel: (config && config.log_level) ? config.log_level.toLowerCase() : "error"
+
+  function buildPayload() {
+    return {
+      server_url: sUrlInput.text.trim() || "https://vault.bitwarden.com",
+      identity_url: idUrlInput.text.trim(),
+      download_dir: dlDirInput.text.trim() || "~/Downloads",
+      auto_lock_minutes: parseInt(lockMinInput.text.trim()) || 15,
+      clipboard_clear_seconds: parseInt(clipSecInput.text.trim()) || 30,
+      log_level: settingsRoot.selectedLogLevel,
+      check_updates: settingsRoot.checkUpdatesChecked
+    }
+  }
 
   signal saveRequested(var newSettings)
   signal closeRequested()
@@ -583,6 +598,35 @@ Item {
               }
             }
           }
+
+          // Automatic Update Check Toggle
+          ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 3
+            RowLayout {
+              spacing: 6
+              Rectangle {
+                width: 14; height: 14; radius: 3; color: settingsRoot.checkUpdatesChecked ? settingsRoot.accent : Qt.rgba(0, 0, 0, 0.2); border.color: settingsRoot.borderColor; border.width: 1
+                Text {
+                  anchors.centerIn: parent
+                  visible: settingsRoot.checkUpdatesChecked
+                  text: "\uf00c"
+                  font.family: settingsRoot.fontFamily
+                  color: "#ffffff"
+                  font.pixelSize: 9
+                }
+                MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: settingsRoot.checkUpdatesChecked = !settingsRoot.checkUpdatesChecked }
+              }
+              Text { text: "Check for updates"; color: settingsRoot.foreground; font.pixelSize: 11 }
+            }
+            Text {
+              Layout.fillWidth: true
+              text: "Contacts github.com on startup. Turn off if omawarden is managed by a package manager."
+              color: settingsRoot.mutedForeground
+              font.pixelSize: 10
+              wrapMode: Text.WordWrap
+            }
+          }
         }
 
         // Action Buttons Row
@@ -634,17 +678,7 @@ Item {
             MouseArea {
               anchors.fill: parent
               cursorShape: Qt.PointingHandCursor
-              onClicked: {
-                var payload = {
-                  server_url: sUrlInput.text.trim() || "https://vault.bitwarden.com",
-                  identity_url: idUrlInput.text.trim(),
-                  download_dir: dlDirInput.text.trim() || "~/Downloads",
-                  auto_lock_minutes: parseInt(lockMinInput.text.trim()) || 15,
-                  clipboard_clear_seconds: parseInt(clipSecInput.text.trim()) || 30,
-                  log_level: settingsRoot.selectedLogLevel
-                }
-                settingsRoot.saveRequested(payload)
-              }
+              onClicked: settingsRoot.saveRequested(settingsRoot.buildPayload())
             }
           }
         }

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -9,6 +9,7 @@ pub const DEFAULT_AUTO_LOCK_MINUTES: i64 = 15;
 pub const DEFAULT_CLIPBOARD_CLEAR_SECONDS: i64 = 30;
 pub const DEFAULT_EMAIL: &str = "";
 pub const DEFAULT_REMEMBER_EMAIL: bool = true;
+pub const DEFAULT_CHECK_UPDATES: bool = true;
 pub const DEFAULT_LOG_LEVEL: &str = "error";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -27,6 +28,8 @@ pub struct Config {
     pub email: String,
     #[serde(default = "default_remember_email")]
     pub remember_email: bool,
+    #[serde(default = "default_check_updates")]
+    pub check_updates: bool,
     #[serde(default = "default_log_level")]
     pub log_level: String,
 }
@@ -49,6 +52,9 @@ fn default_email() -> String {
 fn default_remember_email() -> bool {
     DEFAULT_REMEMBER_EMAIL
 }
+fn default_check_updates() -> bool {
+    DEFAULT_CHECK_UPDATES
+}
 fn default_log_level() -> String {
     DEFAULT_LOG_LEVEL.to_string()
 }
@@ -63,6 +69,7 @@ impl Default for Config {
             clipboard_clear_seconds: default_clipboard_clear_seconds(),
             email: default_email(),
             remember_email: default_remember_email(),
+            check_updates: default_check_updates(),
             log_level: default_log_level(),
         }
     }
@@ -189,6 +196,9 @@ impl ConfigManager {
         if let Some(v) = options.remember_email {
             cfg.remember_email = v;
         }
+        if let Some(v) = options.check_updates {
+            cfg.check_updates = v;
+        }
         if let Some(v) = options.log_level {
             cfg.log_level = v.to_lowercase();
         }
@@ -207,6 +217,7 @@ pub struct ConfigUpdateOptions {
     pub clipboard_clear_seconds: Option<i64>,
     pub email: Option<String>,
     pub remember_email: Option<bool>,
+    pub check_updates: Option<bool>,
     pub log_level: Option<String>,
 }
 
@@ -509,5 +520,38 @@ esac
             keyring_mgr.get_token("access_token"),
             Some("valid-token".to_string())
         );
+    }
+
+    #[test]
+    fn test_check_updates_default_and_update() {
+        assert!(Config::default().check_updates);
+
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        let mock_script = create_mock_secret_tool(dir.path());
+
+        let config_mgr = ConfigManager::new(Some(&config_path));
+        let storage_mgr = crate::storage::StorageManager::new(dir.path().join("data.json"));
+        let keyring_mgr = crate::keyring::KeyringManager::new(&mock_script);
+
+        let (updated_cfg, _server_changed) = config_mgr
+            .update_config(
+                ConfigUpdateOptions {
+                    check_updates: Some(false),
+                    ..Default::default()
+                },
+                &storage_mgr,
+                &keyring_mgr,
+            )
+            .unwrap();
+        assert!(!updated_cfg.check_updates);
+
+        // Round-trips through config.json
+        assert!(!ConfigManager::new(Some(&config_path)).load().check_updates);
+
+        // Existing configs written before this key existed keep the default
+        let legacy_path = dir.path().join("legacy.json");
+        fs::write(&legacy_path, r#"{"email": "legacy@test.com"}"#).unwrap();
+        assert!(ConfigManager::new(Some(&legacy_path)).load().check_updates);
     }
 }

--- a/omawarden/src/main.rs
+++ b/omawarden/src/main.rs
@@ -153,6 +153,8 @@ enum ConfigAction {
         #[arg(long)]
         remember_email: Option<String>,
         #[arg(long)]
+        check_updates: Option<String>,
+        #[arg(long)]
         log_level: Option<String>,
     },
 }
@@ -411,6 +413,7 @@ fn main() -> ExitCode {
                         }
                         "email" => println!("{}", cfg.email),
                         "remember_email" => println!("{}", cfg.remember_email),
+                        "check_updates" => println!("{}", cfg.check_updates),
                         "log_level" => println!("{}", cfg.log_level),
                         _ => {
                             eprintln!("Unknown configuration key: {}", k);
@@ -430,6 +433,7 @@ fn main() -> ExitCode {
                 clipboard_clear,
                 email,
                 remember_email,
+                check_updates,
                 log_level,
             } => {
                 let storage_mgr = match cli.config.as_deref() {
@@ -450,6 +454,10 @@ fn main() -> ExitCode {
                     let lower = v.trim().to_lowercase();
                     matches!(lower.as_str(), "true" | "1" | "yes")
                 });
+                let parsed_check_updates = check_updates.map(|v| {
+                    let lower = v.trim().to_lowercase();
+                    matches!(lower.as_str(), "true" | "1" | "yes")
+                });
 
                 let options = ConfigUpdateOptions {
                     server_url,
@@ -459,6 +467,7 @@ fn main() -> ExitCode {
                     clipboard_clear_seconds: clipboard_clear,
                     email,
                     remember_email: parsed_remember_email,
+                    check_updates: parsed_check_updates,
                     log_level,
                 };
 
@@ -1841,6 +1850,36 @@ mod tests {
         match cli_explicit.command {
             Commands::Daemon { auto_lock } => assert_eq!(auto_lock, Some(45)),
             _ => panic!("Expected Commands::Daemon"),
+        }
+    }
+
+    #[test]
+    fn test_cli_check_updates_arg_parsing() {
+        let cli_default = Cli::try_parse_from(["omawarden", "config", "set"]).unwrap();
+        match cli_default.command {
+            Commands::Config {
+                action: ConfigAction::Set { check_updates, .. },
+            } => assert_eq!(check_updates, None),
+            _ => panic!("Expected Commands::Config with ConfigAction::Set"),
+        }
+
+        let cli_false =
+            Cli::try_parse_from(["omawarden", "config", "set", "--check-updates", "false"])
+                .unwrap();
+        match cli_false.command {
+            Commands::Config {
+                action: ConfigAction::Set { check_updates, .. },
+            } => assert_eq!(check_updates.as_deref(), Some("false")),
+            _ => panic!("Expected Commands::Config with ConfigAction::Set"),
+        }
+
+        let cli_true =
+            Cli::try_parse_from(["omawarden", "config", "set", "--check-updates", "true"]).unwrap();
+        match cli_true.command {
+            Commands::Config {
+                action: ConfigAction::Set { check_updates, .. },
+            } => assert_eq!(check_updates.as_deref(), Some("true")),
+            _ => panic!("Expected Commands::Config with ConfigAction::Set"),
         }
     }
 

--- a/tests/tst_settings_update_toggle.qml
+++ b/tests/tst_settings_update_toggle.qml
@@ -1,0 +1,44 @@
+import QtQuick
+import QtQuick.Controls
+import "../components"
+
+Item {
+  id: testRunner
+
+  property int failures: 0
+  function check(cond, msg) {
+    if (!cond) { failures++; console.error("FAIL: " + msg) }
+    else console.log("PASS: " + msg)
+  }
+
+  SettingsModal { id: sm }
+
+  Component.onCompleted: {
+    // 1. Config load -> checkbox state
+    sm.config = ({ server_url: "https://vault.bitwarden.com", log_level: "error", check_updates: false })
+    check(sm.checkUpdatesChecked === false, "config check_updates:false disables the checkbox")
+
+    sm.config = ({ server_url: "https://vault.bitwarden.com", log_level: "error", check_updates: true })
+    check(sm.checkUpdatesChecked === true, "config check_updates:true enables the checkbox")
+
+    // 2. Upgrade path: an older engine that omits the key leaves it on
+    sm.config = ({ server_url: "https://vault.bitwarden.com", log_level: "error" })
+    check(sm.checkUpdatesChecked === true, "config without check_updates leaves the checkbox on")
+
+    // 3. Checkbox state -> save payload
+    sm.checkUpdatesChecked = false
+    check(sm.buildPayload().check_updates === false, "unchecked box builds check_updates:false")
+
+    sm.checkUpdatesChecked = true
+    check(sm.buildPayload().check_updates === true, "checked box builds check_updates:true")
+
+    // 4. Regression guard: the six pre-existing keys survived the extraction
+    var payload = sm.buildPayload()
+    var required = ["server_url", "identity_url", "download_dir", "auto_lock_minutes", "clipboard_clear_seconds", "log_level"]
+    for (var i = 0; i < required.length; i++) {
+      check(payload[required[i]] !== undefined, "buildPayload still emits " + required[i])
+    }
+
+    Qt.exit(failures === 0 ? 0 : 1)
+  }
+}


### PR DESCRIPTION
Closes #136

## Summary

Adds a `check_updates` setting (default `true`) so the automatic GitHub update check can be
turned off.

`checkUpdates(false)` runs at `Component.onCompleted` and again in `open()`, executing
`scripts/check-update.sh` against `releases.atom` with an `api.github.com` fallback. There
was no config key governing it, so a user who would rather manage `omawarden` another way —
an AUR package, a pinned local build, an airgapped or metered machine — had no way to stop
the plugin contacting GitHub on every shell start and every overlay open.

Scope note: this does **not** touch the downloader. All three `downloadCli()` call sites are
UI-initiated, so a binary is only ever fetched when the user clicks. Only the automatic
check is gated; manual checks from Settings stay ungated.

## Changes

- **`omawarden`** — new `check_updates` key (default `true`), plumbed through the existing
  `config get|set` path exactly like `remember_email`. New CLI flag `--check-updates`.
- **QML** — automatic checks are gated; manual ones are not.
- **Settings** — a "Check for updates" checkbox.

## The ordering trap, and why the guard looks the way it does

Both automatic call sites run in the **same synchronous block** as `refreshConfig()`:

```
Component.onCompleted: { refreshConfig(); ...; checkUpdates(false) }
open():                { refreshHealth(); refreshConfig(); ...; checkUpdates(false) }
```

`configGetProc` is asynchronous, so config has not arrived when those fire. A plain
`if (enabled)` guard defaulting to `true` still emits one request per shell start;
defaulting to `false` suppresses checking permanently. Either way the setting is visibly
broken.

So the permission starts unknown, an automatic check that arrives too early sets a pending
latch and returns, and the config handler runs the deferred check once the value is known.

`refreshConfig()` also resets the permission before every read. Without that, a stale
`true` from an earlier successful read passes the gate during the synchronous
`checkUpdates(false)` that follows it — so a value persisted as `false` (via the CLI, while
the shell keeps running) would still get a request on the next overlay open. That same reset
covers the parse-error path: a failed read then correctly leaves automatic checks off.

## Verification

Behaviour verified live, in a running Omarchy session, using `inotifywait` on
`scripts/check-update.sh` — bash opens that file when the check runs, so this observes
whether a request actually happened rather than inferring it:

| Scenario | Result |
| --- | --- |
| `check_updates=true`, open overlay | check ran |
| `check_updates=false`, open overlay | no check |
| enabled, then `false` persisted externally, then reopen | no check |
| **same, with the `refreshConfig()` reset removed** | **check ran — leak reproduced** |

The last row is the point: it shows the reset line is load-bearing, and that the test is
sensitive rather than silent for some unrelated reason.

Headless:

- `cargo test` — 125 lib + 7 bin, 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- all `tests/tst_*.qml` exit 0 under `QT_QPA_PLATFORM=offscreen qml6`
- CLI round-trip: `config get` emits `"check_updates": true` by default and `false` after
  `config set --check-updates false`; a `config.json` written before this key existed reads
  back `true`

## Known limitations, stated rather than glossed

- The root-side gate lives in `OmarchyBitwarden.qml`, which imports `Quickshell` and `qs.*`
  and cannot be instantiated by `qml6`, so it is covered by static checks plus the live
  testing above, not by an executable test. The grep checks would catch a deleted guard but
  not a semantic regression such as moving it below the point where the process starts.
- The new QML test covers the Settings checkbox and payload mapping only. Deleting the root
  guard, or dropping `--check-updates` from `saveSettings`, would leave it green.
- I deliberately did not extract the guard into a testable `.js` module. It guards one HTTP
  request; that indirection did not seem proportionate. Happy to add it if you disagree.

## Note

Independent of #135 (website icon opt-out) — different branch off `develop`, no shared
files beyond `OmarchyBitwarden.qml` and `SettingsModal.qml`, and the two can merge in either
order. Happy to change the default, drop the Settings toggle, or split this up.
