### PR TITLE
sec(api): enforce HTTPS for remote endpoints and restrict HTTP to loopback

### DIFF
--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -83,14 +83,17 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ---
 
-### Rule 4: Strict URL Origin Validation (RFC 6454)
+### Rule 4: Strict URL Origin Validation (RFC 6454) & Mandatory HTTPS on Remote Servers
 
-**Principle**: Never use substring or prefix matching (`starts_with`) when checking whether a target URL is authorized to receive bearer tokens or authenticated API calls.
+**Principle**: Never use substring or prefix matching (`starts_with`) when checking whether a target URL is authorized to receive bearer tokens or authenticated API calls. Furthermore, plaintext HTTP is strictly restricted to local loopback origins (`localhost`, `127.0.0.0/8`, `::1`). Any remote server or identity endpoint MUST enforce HTTPS to prevent cleartext transmission of master password hashes, 2FA codes, API secrets, and bearer tokens.
 
 - ❌ **Anti-Pattern**:
   ```rust
   // VULNERABLE: allows https://vault.bitwarden.com.evil.com to steal tokens!
   if target_url.starts_with(&server_url) { ... }
+
+  // VULNERABLE: transmitting master password hash and bearer tokens over plaintext HTTP to remote host!
+  server_url = "http://vaultwarden.mycorp.com";
   ```
 - ✅ **Required Pattern**:
   Parse both URLs with a standard-compliant URL parser (`url::Url`) and verify exact matching on scheme, host, and port:
@@ -101,8 +104,14 @@ These rules were distilled from real-world vulnerabilities and architectural pit
       u1.scheme() == u2.scheme() && u1.host() == u2.host() && u1.port_or_known_default() == u2.port_or_known_default()
   }
   ```
+  Validate server and identity URLs on configuration and resolution. Reject remote plaintext HTTP at configuration time (`validate_url_scheme_security`) and automatically upgrade to HTTPS during endpoint resolution (`EnvironmentUrls::resolve`) if an unencrypted remote URL is encountered:
+  ```rust
+  if parsed.scheme() == "http" && !is_loopback_host(&host) {
+      // Must upgrade to https or fail closed
+  }
+  ```
 - 🧪 **Mandatory Verification**:
-  Unit test must assert rejection on subdomain spoofing (`target.domain.com.attacker.com`), scheme downgrades (`https` vs `http`), and mismatched ports.
+  Unit test must assert rejection on subdomain spoofing (`target.domain.com.attacker.com`), scheme downgrades (`https` vs `http`), mismatched ports, and assert that remote plaintext HTTP is rejected on configuration and upgraded at resolution.
 
 ---
 

--- a/omawarden/src/api.rs
+++ b/omawarden/src/api.rs
@@ -120,10 +120,23 @@ pub struct EnvironmentUrls {
     pub has_explicit_identity: bool,
 }
 
+/// Determines whether a hostname or IP address represents a local loopback origin
+/// (`localhost`, `*.localhost`, `127.0.0.0/8`, `::1`, `[::1]`).
+pub fn is_loopback_host(host: &str) -> bool {
+    let clean = host.trim().trim_start_matches('[').trim_end_matches(']');
+    if clean.eq_ignore_ascii_case("localhost") || clean.to_lowercase().ends_with(".localhost") {
+        return true;
+    }
+    if let Ok(ip) = clean.parse::<std::net::IpAddr>() {
+        return ip.is_loopback();
+    }
+    false
+}
+
 impl EnvironmentUrls {
     pub fn resolve(server_url: &str, explicit_identity_url: Option<&str>) -> Self {
         let trimmed_server = server_url.trim();
-        let normalized_server = if trimmed_server.is_empty() {
+        let mut normalized_server = if trimmed_server.is_empty() {
             "https://vault.bitwarden.com".to_string()
         } else if !trimmed_server.starts_with("http://") && !trimmed_server.starts_with("https://")
         {
@@ -131,6 +144,18 @@ impl EnvironmentUrls {
         } else {
             trimmed_server.to_string()
         };
+
+        if let Ok(parsed) = url::Url::parse(&normalized_server) {
+            let host = parsed.host_str().unwrap_or("").to_lowercase();
+            if parsed.scheme() == "http" && !is_loopback_host(&host) {
+                crate::log_warn!(
+                    "omawarden:api",
+                    "Plaintext HTTP is forbidden for remote server host '{}'. Upgrading to HTTPS to protect credentials in transit.",
+                    host
+                );
+                normalized_server = format!("https://{}", &normalized_server["http://".len()..]);
+            }
+        }
 
         let parsed = url::Url::parse(&normalized_server).ok();
         let host = parsed
@@ -185,6 +210,17 @@ impl EnvironmentUrls {
                 };
                 if let Some(stripped) = norm_explicit.strip_suffix("/connect/token") {
                     norm_explicit = stripped.trim_end_matches('/').to_string();
+                }
+                if let Ok(parsed) = url::Url::parse(&norm_explicit) {
+                    let host = parsed.host_str().unwrap_or("").to_lowercase();
+                    if parsed.scheme() == "http" && !is_loopback_host(&host) {
+                        crate::log_warn!(
+                            "omawarden:api",
+                            "Plaintext HTTP is forbidden for remote identity host '{}'. Upgrading to HTTPS to protect credentials in transit.",
+                            host
+                        );
+                        norm_explicit = format!("https://{}", &norm_explicit["http://".len()..]);
+                    }
                 }
                 identity_url = norm_explicit;
             }
@@ -1968,6 +2004,51 @@ mod tests {
         assert_eq!(urls.base_url, "https://mybitwarden.com");
         assert_eq!(urls.api_url, "https://mybitwarden.com/api");
         assert_eq!(urls.identity_url, "https://mybitwarden.com/identity");
+    }
+
+    #[test]
+    fn test_is_loopback_host() {
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("LOCALHOST"));
+        assert!(is_loopback_host("sub.localhost"));
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("127.0.0.2"));
+        assert!(is_loopback_host("127.255.255.254"));
+        assert!(is_loopback_host("::1"));
+        assert!(is_loopback_host("[::1]"));
+
+        assert!(!is_loopback_host("vaultwarden.example.com"));
+        assert!(!is_loopback_host("192.168.1.1"));
+        assert!(!is_loopback_host("10.0.0.1"));
+        assert!(!is_loopback_host("172.16.0.1"));
+        assert!(!is_loopback_host(""));
+    }
+
+    #[test]
+    fn test_endpoint_resolver_enforces_https_for_remote_http() {
+        // Plaintext HTTP remote server is upgraded to HTTPS
+        let urls = EnvironmentUrls::resolve("http://vaultwarden.example.com", None);
+        assert_eq!(urls.base_url, "https://vaultwarden.example.com");
+        assert_eq!(urls.api_url, "https://vaultwarden.example.com/api");
+        assert_eq!(
+            urls.identity_url,
+            "https://vaultwarden.example.com/identity"
+        );
+
+        // Plaintext HTTP remote identity override is upgraded to HTTPS
+        let urls = EnvironmentUrls::resolve(
+            "https://vaultwarden.example.com",
+            Some("http://identity.example.com"),
+        );
+        assert_eq!(urls.base_url, "https://vaultwarden.example.com");
+        assert_eq!(urls.identity_url, "https://identity.example.com");
+
+        // Loopback HTTP addresses are preserved
+        let urls = EnvironmentUrls::resolve("http://localhost:8080", None);
+        assert_eq!(urls.base_url, "http://localhost:8080");
+
+        let urls = EnvironmentUrls::resolve("http://[::1]:8080", None);
+        assert_eq!(urls.base_url, "http://[::1]:8080");
     }
 
     #[test]

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -127,6 +127,32 @@ impl ConfigManager {
         crate::fs_util::atomic_write_str(&self.config_path, &content, 0o600)
     }
 
+    pub fn validate_url_scheme_security(url_str: &str, field_name: &str) -> std::io::Result<()> {
+        let trimmed = url_str.trim();
+        if trimmed.is_empty() {
+            return Ok(());
+        }
+        let norm = if !trimmed.starts_with("http://") && !trimmed.starts_with("https://") {
+            format!("https://{}", trimmed)
+        } else {
+            trimmed.to_string()
+        };
+
+        if let Ok(parsed) = url::Url::parse(&norm) {
+            let host = parsed.host_str().unwrap_or("");
+            if parsed.scheme() == "http" && !crate::api::is_loopback_host(host) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!(
+                        "Insecure {} '{}': Plaintext HTTP is only permitted for local loopback addresses (localhost, 127.0.0.1, [::1]). Remote servers must use HTTPS.",
+                        field_name, trimmed
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub fn update_config(
         &self,
         options: ConfigUpdateOptions,
@@ -134,6 +160,13 @@ impl ConfigManager {
         keyring_mgr: &crate::keyring::KeyringManager,
     ) -> std::io::Result<(Config, bool)> {
         let mut cfg = self.load();
+
+        if let Some(ref v) = options.server_url {
+            Self::validate_url_scheme_security(v, "server_url")?;
+        }
+        if let Some(ref v) = options.identity_url {
+            Self::validate_url_scheme_security(v, "identity_url")?;
+        }
 
         let old_server_norm = cfg.server_url.trim().trim_end_matches('/');
         let server_changed = if let Some(ref new_url) = options.server_url {
@@ -556,5 +589,83 @@ esac
         fs::write(&legacy_path, r#"{"email": "legacy@test.com"}"#).unwrap();
         let legacy = ConfigManager::new(Some(&legacy_path)).load();
         assert!(legacy.show_website_icons);
+    }
+
+    #[test]
+    fn test_validate_url_scheme_security() {
+        // Valid secure or loopback URLs
+        assert!(ConfigManager::validate_url_scheme_security(
+            "https://vault.bitwarden.com",
+            "server_url"
+        )
+        .is_ok());
+        assert!(ConfigManager::validate_url_scheme_security(
+            "https://vaultwarden.custom.corp",
+            "server_url"
+        )
+        .is_ok());
+        assert!(
+            ConfigManager::validate_url_scheme_security("http://localhost:8080", "server_url")
+                .is_ok()
+        );
+        assert!(
+            ConfigManager::validate_url_scheme_security("http://127.0.0.1:8080", "server_url")
+                .is_ok()
+        );
+        assert!(
+            ConfigManager::validate_url_scheme_security("http://[::1]:8080", "server_url").is_ok()
+        );
+        assert!(ConfigManager::validate_url_scheme_security(
+            "vaultwarden.custom.corp",
+            "server_url"
+        )
+        .is_ok());
+        assert!(ConfigManager::validate_url_scheme_security("", "server_url").is_ok());
+
+        // Insecure plaintext HTTP remote URLs rejected
+        let err = ConfigManager::validate_url_scheme_security(
+            "http://vaultwarden.custom.corp",
+            "server_url",
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err
+            .to_string()
+            .contains("Plaintext HTTP is only permitted for local loopback"));
+
+        let err = ConfigManager::validate_url_scheme_security(
+            "http://192.168.1.100:8080",
+            "identity_url",
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err
+            .to_string()
+            .contains("Plaintext HTTP is only permitted for local loopback"));
+    }
+
+    #[test]
+    fn test_update_config_rejects_insecure_remote_http() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("config.json");
+        let storage_path = dir.path().join("data.json");
+        let mock_script = create_mock_secret_tool(dir.path());
+
+        let config_mgr = ConfigManager::new(Some(&config_path));
+        let storage_mgr = crate::storage::StorageManager::new(storage_path);
+        let keyring_mgr = crate::keyring::KeyringManager::new(&mock_script);
+
+        let res = config_mgr.update_config(
+            ConfigUpdateOptions {
+                server_url: Some("http://vaultwarden.remote.corp".to_string()),
+                ..Default::default()
+            },
+            &storage_mgr,
+            &keyring_mgr,
+        );
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("Remote servers must use HTTPS"));
     }
 }


### PR DESCRIPTION
## Summary of Changes

- **Restrict Plaintext HTTP to Local Loopback**:
  - Added `is_loopback_host(host)` identifying `localhost`, `*.localhost`, `127.0.0.0/8`, and `::1` / `[::1]`.
  - Plaintext HTTP is strictly rejected for remote/non-loopback servers to eliminate cleartext credential exposure (master password hash, 2FA codes, API secrets, and bearer tokens).
- **Configuration-Time Validation**:
  - `ConfigManager::update_config` now runs `validate_url_scheme_security` for both `server_url` and `identity_url`. Configuring insecure remote HTTP fails immediately with a clear diagnostic message.
- **Runtime Resolution Fail-Safe**:
  - `EnvironmentUrls::resolve` automatically upgrades non-loopback HTTP to HTTPS with a warning log, guaranteeing no API requests transmit credentials over unencrypted remote HTTP even if an unvalidated URL enters the engine.
- **Security Handbook Update**:
  - Updated Rule 4 in `docs/agents/security.md` with mandatory HTTPS policy for remote endpoints.
- **Test Coverage**:
  - Added unit tests in `api.rs` and `config.rs` covering loopback origin detection, resolution-time HTTPS upgrades, and configuration-time rejection.