### PR TITLE
sec(daemon): require valid session for activity touch and auto-lock manipulation

### DIFF
--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -198,16 +198,16 @@ These rules were distilled from real-world vulnerabilities and architectural pit
   - Allowing indefinite vault unlock without an absolute maximum session lifetime limit.
 - ✅ **Required Pattern**:
   - **Cryptographic Ephemeral Session Token**: Upon `unlock`, the daemon generates a cryptographically random, high-entropy 256-bit ephemeral session token (`session_token`) using `rand_core::OsRng` encoded in URL-safe base64.
-  - **Privileged Action Protection**: All privileged operations (`list`, `search`, `get_item`, `get_ssh_key`, `get_attachment_key`, `ssh_key_create`, `sync`, `totp` with query, and `stop` when unlocked) strictly require a valid `session_token`.
+  - **Privileged Action Protection**: All privileged operations (`list`, `search`, `get_item`, `get_ssh_key`, `get_attachment_key`, `ssh_key_create`, `sync`, `totp` with query, and `stop` or `set_auto_lock` when unlocked) strictly require a valid `session_token`.
   - **Constant-Time Verification**: Session token validation MUST use constant-time byte comparison (`subtle::ConstantTimeEq`).
-  - **No Keep-Alive Leakage**: Unauthenticated requests (or requests failing token verification) are rejected immediately and MUST NOT touch activity; they cannot bypass idle auto-lock.
+  - **No Keep-Alive Leakage**: Unauthenticated requests (or requests failing token verification) are rejected immediately and MUST NOT touch activity (even if `touch: true` is passed); they cannot bypass idle auto-lock.
   - **Absolute Maximum Lifetime Watchdog**: Implement a hard ceiling (`max_session_lifetime`, default 12 hours) from `unlocked_at`. The daemon locks the vault when this limit elapses, regardless of continuous user activity.
   - **Safe Environment Passing**: Pass the session token to child processes via process environment (`QProcessEnvironment` in QML / `OMAWARDEN_SESSION` in CLI), NEVER via command-line arguments (which are readable via `/proc/<pid>/cmdline`).
   - **Immediate Zeroization**: The session token resides in `Zeroizing<String>` memory and is scrubbed immediately upon `lock`, `stop`, or timeout.
 - 🧪 **Mandatory Verification**:
   Unit tests must assert that:
-  1. Privileged actions (`list`, `search`, `get_item`, `get_ssh_key`, `get_attachment_key`, `sync`, `totp` with query, `stop`) without a session token or with an invalid token return `Unauthorized`.
-  2. Unauthenticated requests do NOT touch activity.
+  1. Privileged actions (`list`, `search`, `get_item`, `get_ssh_key`, `get_attachment_key`, `sync`, `totp` with query, `stop`, `set_auto_lock`) without a session token or with an invalid token return `Unauthorized`.
+  2. Unauthenticated requests do NOT touch activity (including `ping`/`status` with explicit `touch: true`).
   3. `lock()` clears the session token and invalidates subsequent privileged calls.
   4. `check_auto_lock()` triggers when `max_session_lifetime` is exceeded even if `last_activity` is recent.
 

--- a/omawarden/src/daemon.rs
+++ b/omawarden/src/daemon.rs
@@ -617,6 +617,9 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
+    let is_unlocked = state.vault_mgr.is_unlocked();
+    let has_valid_session = state.is_session_valid(candidate_token);
+
     let is_privileged = matches!(
         action,
         "list"
@@ -628,10 +631,10 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
             | "sync"
     ) || (action == "totp"
         && (req.get("query").is_some() || req.get("id").is_some()))
-        || (action == "stop" && state.vault_mgr.is_unlocked());
+        || ((action == "stop" || action == "set_auto_lock") && is_unlocked);
 
     if is_privileged {
-        if !state.vault_mgr.is_unlocked() {
+        if !is_unlocked {
             let _ = writeln!(
                 stream,
                 "{}",
@@ -640,7 +643,7 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
             return Ok(());
         }
 
-        if !state.is_session_valid(candidate_token) {
+        if !has_valid_session {
             crate::log_warn!(
                 "omawarden:daemon",
                 "Unauthorized access attempt for action '{}' without valid session token",
@@ -659,7 +662,12 @@ fn handle_client(mut stream: UnixStream, state: Arc<DaemonState>) -> std::io::Re
     }
 
     if should_touch_activity(action, &req) {
-        state.touch_activity();
+        // Enforce Rule 9: When the vault is unlocked, touching activity strictly requires
+        // a valid session token. Unauthenticated requests (e.g. ping/status with touch: true)
+        // are forbidden from resetting idle timeout to prevent keep-alive bypasses.
+        if !is_unlocked || has_valid_session {
+            state.touch_activity();
+        }
     }
 
     let response = match action {
@@ -1062,6 +1070,31 @@ mod tests {
         assert_eq!(unauth_res.get("ok").and_then(|v| v.as_bool()), Some(false));
         assert_eq!(*state.last_activity.lock().unwrap(), past);
 
+        // 5a. Unauthenticated "ping" with explicit touch: true must NOT touch activity on unlocked vault
+        let ping_touch_res = send_req(json!({ "action": "ping", "touch": true }));
+        assert_eq!(
+            ping_touch_res.get("pong").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(*state.last_activity.lock().unwrap(), past);
+
+        // 5b. Unauthenticated "status" with explicit touch: true must NOT touch activity on unlocked vault
+        let status_touch_res = send_req(json!({ "action": "status", "touch": true }));
+        assert!(status_touch_res.get("status").is_some());
+        assert_eq!(*state.last_activity.lock().unwrap(), past);
+
+        // 5c. Authenticated "ping" with explicit touch: true DOES touch activity
+        let ping_auth_touch_res =
+            send_req(json!({ "action": "ping", "touch": true, "session_token": token }));
+        assert_eq!(
+            ping_auth_touch_res.get("pong").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert!(*state.last_activity.lock().unwrap() > past);
+
+        // Reset past activity for subsequent test
+        *state.last_activity.lock().unwrap() = past;
+
         // 6. Active action (e.g. "search" with valid token) should touch activity
         let auth_res =
             send_req(json!({ "action": "search", "query": "test", "session_token": token }));
@@ -1304,6 +1337,7 @@ mod tests {
             json!({ "action": "sync" }),
             json!({ "action": "totp", "query": "test" }),
             json!({ "action": "stop" }),
+            json!({ "action": "set_auto_lock", "auto_lock_seconds": 30 }),
         ];
 
         for mut req in privileged_actions {


### PR DESCRIPTION
## Summary of Changes

### Problem
1. In `handle_client`, `state.touch_activity()` was called unconditionally if `should_touch_activity(action, &req)` returned true. Because `req.get("touch").as_bool()` overrode the action classification, any unauthenticated process could send `{"action": "ping", "touch": true}` to the daemon socket and touch activity without possessing a valid `session_token`, indefinitely keeping the vault unlocked and bypassing idle auto-lock.
2. The `set_auto_lock` action was not protected as a privileged operation. An unauthenticated local process could alter the auto-lock timeout (e.g. `{"action": "set_auto_lock", "auto_lock_seconds": 0}`) on an already-unlocked vault.

### Solution
- Added `set_auto_lock` to `is_privileged` when the vault is unlocked (similar to `stop`), requiring a valid `session_token`.
- Restricted activity touch on an unlocked vault: only requests with a valid `session_token` are permitted to touch activity, eliminating unauthenticated keep-alive bypasses even if `touch: true` is explicitly supplied.
- Updated security handbook Rule 9 (`docs/agents/security.md`) to reflect these invariants.
- Added comprehensive unit tests in `omawarden/src/daemon.rs` asserting that unauthenticated `ping` or `status` with `touch: true` does NOT touch activity, authenticated `ping` with `touch: true` does touch activity, and `set_auto_lock` on an unlocked vault fails without a valid session token.

### Verification
- `cargo fmt --check` passed
- `cargo clippy --all-targets --all-features -- -D warnings` passed
- `XDG_RUNTIME_DIR=/tmp cargo test` passed (144 unit tests)
- `python3 tests/test_downloader.py` passed (9 integration tests)