### PR TITLE
sec(keyring): isolate access and refresh tokens by server url origin

### DIFF
--- a/docs/agents/security.md
+++ b/docs/agents/security.md
@@ -6,7 +6,7 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ---
 
-## The 9 Mandatory Security Principles
+## The 10 Mandatory Security Principles
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -21,6 +21,7 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 │ 7. Memory Locking (mlock)    │ Page-aligned physical RAM lock & no coredump │
 │ 8. Authenticated Encryption  │ Encrypt-then-MAC mandatory; no unauth cipher │
 │ 9. Ephemeral Session Token   │ Same-user socket authorization & max watchdog│
+│ 10. Keyring Server Isolation │ Access/refresh tokens isolated by server_url │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -213,6 +214,27 @@ These rules were distilled from real-world vulnerabilities and architectural pit
 
 ---
 
+### Rule 10: Server-URL Scoped Keyring Token Isolation
+
+**Principle**: All bearer tokens (access tokens, refresh tokens, and session credentials) stored in the system keyring MUST be explicitly scoped by the normalized Bitwarden server origin (`server_url`). Keyring queries and deletions must never operate globally or un-scoped, preventing cross-server token contamination, privilege confusion, or unintended credential deletion when switching between official cloud and self-hosted instances.
+
+- ❌ **Anti-Pattern**:
+  - Storing access or refresh tokens with only `{ "service": "omarchy-bitwarden", "kind": "access_token" }` without `server_url`.
+  - Switching `server_url` from `https://vault.bitwarden.com` to `https://vault.corp.internal` and inadvertently sending cloud bearer tokens to the internal server (or vice versa).
+  - Calling un-scoped `secret-tool clear` which accidentally clears tokens belonging to a different server instance.
+- ✅ **Required Pattern**:
+  - All token store/lookup/clear calls (`store_token`, `get_token`, `clear_token`, `store_session`, `get_session`, `clear_session`) require `server_url: &str`.
+  - Server URLs are normalized (trimmed whitespace and trailing slashes removed) before keyring storage and retrieval.
+  - `get_token` performs a scoped lookup first; backwards-compatible fallback to legacy un-scoped tokens is permitted only for zero-friction user upgrades.
+  - `clear_token` and `clear_session` strictly target the specified `server_url` attribute to ensure cross-server isolation.
+- 🧪 **Mandatory Verification**:
+  Unit tests must assert that:
+  1. Storing tokens for Server A does not return them when querying Server B.
+  2. Clearing tokens for Server A leaves Server B's tokens intact.
+  3. Empty `server_url` or token inputs fail closed and return `false`/`None`.
+
+---
+
 ## Agent Checklist Before Opening a PR
 
 Before submitting any code changes touching authentication, crypto, networking, IPC, or storage:
@@ -220,6 +242,7 @@ Before submitting any code changes touching authentication, crypto, networking, 
 ```markdown
 - [ ] No tokens, secrets, or master passwords are written to disk or logs.
 - [ ] Keyring failures fail-closed (no fallback to plaintext files).
+- [ ] All Keyring tokens and secrets are strictly scoped to normalized server_url.
 - [ ] All file writes with sensitive data enforce 0600 permissions atomically.
 - [ ] All URLs sending Auth headers use exact RFC 6454 same-origin checks.
 - [ ] Sockets enforce mutual peer UID (SO_PEERCRED) verification and validate paths/symlinks.

--- a/omawarden/src/attachment.rs
+++ b/omawarden/src/attachment.rs
@@ -216,8 +216,8 @@ pub fn get_attachment(
 
     let initial_token = session_token
         .map(|s| s.to_string())
-        .or_else(|| keyring_mgr.get_token(crate::keyring::KIND_ACCESS_TOKEN))
-        .or_else(|| keyring_mgr.get_session())
+        .or_else(|| keyring_mgr.get_token(initial_server_url, crate::keyring::KIND_ACCESS_TOKEN))
+        .or_else(|| keyring_mgr.get_session(initial_server_url))
         .or_else(|| storage.access_token.clone());
 
     let token_val = match initial_token {
@@ -744,12 +744,12 @@ fn attempt_attachment_token_refresh(
 
     // 1. Try refresh_token
     let refresh_token = keyring_mgr
-        .get_token(crate::keyring::KIND_REFRESH_TOKEN)
+        .get_token(server_url, crate::keyring::KIND_REFRESH_TOKEN)
         .or_else(|| storage.refresh_token.clone());
 
     if let Some(ref ref_tok) = refresh_token {
         if let Ok(tok_resp) = api_client.refresh_token_grant(ref_tok) {
-            persist_attachment_tokens(storage_mgr, keyring_mgr, &tok_resp);
+            persist_attachment_tokens(server_url, storage_mgr, keyring_mgr, &tok_resp);
             return Some(tok_resp.access_token);
         }
     }
@@ -758,7 +758,7 @@ fn attempt_attachment_token_refresh(
     if let Some(ref cid) = storage.client_id {
         if let Some(sec) = keyring_mgr.get_api_secret(server_url, cid) {
             if let Ok(tok_resp) = api_client.login_apikey(cid, &sec) {
-                persist_attachment_tokens(storage_mgr, keyring_mgr, &tok_resp);
+                persist_attachment_tokens(server_url, storage_mgr, keyring_mgr, &tok_resp);
                 return Some(tok_resp.access_token);
             }
         }
@@ -768,17 +768,27 @@ fn attempt_attachment_token_refresh(
 }
 
 fn persist_attachment_tokens(
+    server_url: &str,
     storage_mgr: &StorageManager,
     keyring_mgr: &KeyringManager,
     tok_resp: &crate::api::TokenResponse,
 ) {
     let mut fresh_st = storage_mgr.load();
+    let s_url = if !fresh_st.server_url.is_empty() {
+        fresh_st.server_url.as_str()
+    } else {
+        server_url
+    };
     if keyring_mgr.is_available() {
-        let s1 = keyring_mgr.store_token(crate::keyring::KIND_ACCESS_TOKEN, &tok_resp.access_token);
+        let s1 = keyring_mgr.store_token(
+            s_url,
+            crate::keyring::KIND_ACCESS_TOKEN,
+            &tok_resp.access_token,
+        );
         let s2 = if let Some(ref new_ref) = tok_resp.refresh_token {
-            keyring_mgr.store_token(crate::keyring::KIND_REFRESH_TOKEN, new_ref)
+            keyring_mgr.store_token(s_url, crate::keyring::KIND_REFRESH_TOKEN, new_ref)
         } else {
-            keyring_mgr.clear_token(crate::keyring::KIND_REFRESH_TOKEN);
+            keyring_mgr.clear_token(s_url, crate::keyring::KIND_REFRESH_TOKEN);
             true
         };
         if s1 && s2 {

--- a/omawarden/src/auth.rs
+++ b/omawarden/src/auth.rs
@@ -198,11 +198,17 @@ impl AuthManager {
     pub fn get_status(&self, _verify: bool) -> AuthStatus {
         let mut storage = self.storage_mgr.load();
 
+        let s_url = if !storage.server_url.is_empty() {
+            &storage.server_url
+        } else {
+            &self.server_url
+        };
+
         // 1. Resolve active access token from Keyring or Storage fallback
         let active_token = self
             .keyring_mgr
-            .get_token(KIND_ACCESS_TOKEN)
-            .or_else(|| self.keyring_mgr.get_session())
+            .get_token(s_url, KIND_ACCESS_TOKEN)
+            .or_else(|| self.keyring_mgr.get_session(s_url))
             .or_else(|| storage.access_token.clone());
 
         // 2. Migration: If keyring is available and plaintext tokens are in storage, migrate them to Keyring safely
@@ -211,11 +217,13 @@ impl AuthManager {
         {
             let mut access_saved = true;
             if let Some(ref tok) = storage.access_token {
-                access_saved = self.keyring_mgr.store_token(KIND_ACCESS_TOKEN, tok);
+                access_saved = self.keyring_mgr.store_token(s_url, KIND_ACCESS_TOKEN, tok);
             }
             let mut refresh_saved = true;
             if let Some(ref ref_tok) = storage.refresh_token {
-                refresh_saved = self.keyring_mgr.store_token(KIND_REFRESH_TOKEN, ref_tok);
+                refresh_saved = self
+                    .keyring_mgr
+                    .store_token(s_url, KIND_REFRESH_TOKEN, ref_tok);
             }
 
             // Only scrub from disk if store was confirmed successful
@@ -231,13 +239,11 @@ impl AuthManager {
         }
 
         // Detect renewal capabilities using correct server URL precedence
-        let has_refresh = self.keyring_mgr.get_token(KIND_REFRESH_TOKEN).is_some()
+        let has_refresh = self
+            .keyring_mgr
+            .get_token(s_url, KIND_REFRESH_TOKEN)
+            .is_some()
             || storage.refresh_token.is_some();
-        let s_url = if !storage.server_url.is_empty() {
-            &storage.server_url
-        } else {
-            &self.server_url
-        };
         let has_api_secret = storage
             .client_id
             .as_ref()
@@ -269,8 +275,8 @@ impl AuthManager {
                         "omawarden:auth",
                         "Stored session token has expired and cannot be renewed. Invalidation required."
                     );
-                    self.keyring_mgr.clear_token(KIND_ACCESS_TOKEN);
-                    self.keyring_mgr.clear_session();
+                    self.keyring_mgr.clear_token(s_url, KIND_ACCESS_TOKEN);
+                    self.keyring_mgr.clear_session(s_url);
                     storage.access_token = None;
                     let _ = self.storage_mgr.save(&storage);
                     let _ = crate::daemon::send_daemon_request(
@@ -432,10 +438,11 @@ impl AuthManager {
             };
         }
 
-        if !self
-            .keyring_mgr
-            .store_token(KIND_ACCESS_TOKEN, &token_resp.access_token)
-        {
+        if !self.keyring_mgr.store_token(
+            &self.server_url,
+            KIND_ACCESS_TOKEN,
+            &token_resp.access_token,
+        ) {
             let err_msg = "Failed to store access token in system keyring.";
             crate::log_error!("omawarden:auth", "{}", err_msg);
             return AuthResult {
@@ -450,8 +457,12 @@ impl AuthManager {
         }
 
         if let Some(ref ref_tok) = token_resp.refresh_token {
-            if !self.keyring_mgr.store_token(KIND_REFRESH_TOKEN, ref_tok) {
-                self.keyring_mgr.clear_token(KIND_ACCESS_TOKEN);
+            if !self
+                .keyring_mgr
+                .store_token(&self.server_url, KIND_REFRESH_TOKEN, ref_tok)
+            {
+                self.keyring_mgr
+                    .clear_token(&self.server_url, KIND_ACCESS_TOKEN);
                 let err_msg = "Failed to store refresh token in system keyring.";
                 crate::log_error!("omawarden:auth", "{}", err_msg);
                 return AuthResult {
@@ -596,9 +607,15 @@ impl AuthManager {
             };
         }
 
+        let s_url = if !storage.server_url.is_empty() {
+            &storage.server_url
+        } else {
+            &self.server_url
+        };
+
         if !self
             .keyring_mgr
-            .store_token(KIND_ACCESS_TOKEN, &token_resp.access_token)
+            .store_token(s_url, KIND_ACCESS_TOKEN, &token_resp.access_token)
         {
             let err_msg = "Failed to store access token in system keyring.";
             crate::log_error!("omawarden:auth", "{}", err_msg);
@@ -612,8 +629,11 @@ impl AuthManager {
         }
 
         if let Some(ref ref_tok) = token_resp.refresh_token {
-            if !self.keyring_mgr.store_token(KIND_REFRESH_TOKEN, ref_tok) {
-                self.keyring_mgr.clear_token(KIND_ACCESS_TOKEN);
+            if !self
+                .keyring_mgr
+                .store_token(s_url, KIND_REFRESH_TOKEN, ref_tok)
+            {
+                self.keyring_mgr.clear_token(s_url, KIND_ACCESS_TOKEN);
                 let err_msg = "Failed to store refresh token in system keyring.";
                 crate::log_error!("omawarden:auth", "{}", err_msg);
                 return AuthResult {
@@ -626,17 +646,12 @@ impl AuthManager {
             }
         }
 
-        let s_url = if !storage.server_url.is_empty() {
-            &storage.server_url
-        } else {
-            &self.server_url
-        };
         if !self
             .keyring_mgr
             .store_api_secret(s_url, client_id.trim(), client_secret.trim())
         {
-            self.keyring_mgr.clear_token(KIND_ACCESS_TOKEN);
-            self.keyring_mgr.clear_token(KIND_REFRESH_TOKEN);
+            self.keyring_mgr.clear_token(s_url, KIND_ACCESS_TOKEN);
+            self.keyring_mgr.clear_token(s_url, KIND_REFRESH_TOKEN);
             let err_msg = "Failed to store API secret in system keyring.";
             crate::log_error!("omawarden:auth", "{}", err_msg);
             return AuthResult {
@@ -744,15 +759,22 @@ impl AuthManager {
             .unlock_user_key(&password_zeroizing, &storage)
         {
             Ok(_user_key) => {
+                let s_url = if !storage.server_url.is_empty() {
+                    &storage.server_url
+                } else {
+                    &self.server_url
+                };
+
                 let token_opt = self
                     .keyring_mgr
-                    .get_token(KIND_ACCESS_TOKEN)
-                    .or_else(|| self.keyring_mgr.get_session())
+                    .get_token(s_url, KIND_ACCESS_TOKEN)
+                    .or_else(|| self.keyring_mgr.get_session(s_url))
                     .or_else(|| storage.access_token.clone());
 
                 let session_val = if let Some(ref token) = token_opt {
                     if token != "session_unlocked" && !token.is_empty() {
-                        self.keyring_mgr.store_token(KIND_ACCESS_TOKEN, token);
+                        self.keyring_mgr
+                            .store_token(s_url, KIND_ACCESS_TOKEN, token);
                     }
                     Some(token.clone())
                 } else {
@@ -802,7 +824,13 @@ impl AuthManager {
     }
 
     pub fn lock(&self) -> AuthResult {
-        self.keyring_mgr.clear_session();
+        let storage = self.storage_mgr.load();
+        let s_url = if !storage.server_url.is_empty() {
+            &storage.server_url
+        } else {
+            &self.server_url
+        };
+        self.keyring_mgr.clear_session(s_url);
         let _ = crate::daemon::send_daemon_request(&serde_json::json!({
             "action": "lock"
         }));
@@ -817,8 +845,14 @@ impl AuthManager {
     }
 
     pub fn logout(&self) -> AuthResult {
+        let storage = self.storage_mgr.load();
+        let s_url = if !storage.server_url.is_empty() {
+            &storage.server_url
+        } else {
+            &self.server_url
+        };
         self.keyring_mgr.clear_all();
-        self.keyring_mgr.clear_session();
+        self.keyring_mgr.clear_session(s_url);
         let _ = self.storage_mgr.save(&VaultStorage::default());
         let _ = crate::daemon::send_daemon_request(&serde_json::json!({
             "action": "lock"
@@ -1283,7 +1317,11 @@ esac
             "user.test-client-id",
             "secret_xyz_123"
         ));
-        assert!(mock_keyring.store_token(KIND_ACCESS_TOKEN, &expired_token));
+        assert!(mock_keyring.store_token(
+            "https://vault.example.com",
+            KIND_ACCESS_TOKEN,
+            &expired_token
+        ));
 
         let storage = VaultStorage {
             server_url: "https://vault.example.com".to_string(),
@@ -1394,11 +1432,11 @@ esac
 
         // Verify tokens migrated to Keyring
         assert_eq!(
-            mock_keyring.get_token(KIND_ACCESS_TOKEN),
+            mock_keyring.get_token("https://vault.example.com", KIND_ACCESS_TOKEN),
             Some("plaintext_access_123".to_string())
         );
         assert_eq!(
-            mock_keyring.get_token(KIND_REFRESH_TOKEN),
+            mock_keyring.get_token("https://vault.example.com", KIND_REFRESH_TOKEN),
             Some("plaintext_refresh_456".to_string())
         );
 
@@ -1538,7 +1576,7 @@ esac
         let past_payload = serde_json::json!({ "exp": now - 50 });
         let past_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&past_payload).unwrap());
         let expired_token = format!("eyJhbGciOiJSUzI1NiJ9.{}.sig", past_b64);
-        assert!(mock_keyring.store_token(KIND_ACCESS_TOKEN, &expired_token));
+        assert!(mock_keyring.store_token(custom_url, KIND_ACCESS_TOKEN, &expired_token));
 
         let storage = VaultStorage {
             server_url: custom_url.to_string(),

--- a/omawarden/src/config.rs
+++ b/omawarden/src/config.rs
@@ -201,7 +201,7 @@ impl ConfigManager {
             }
 
             keyring_mgr.clear_all();
-            keyring_mgr.clear_session();
+            keyring_mgr.clear_session(&cfg.server_url);
 
             let _ = crate::daemon::send_daemon_request(&serde_json::json!({ "action": "stop" }));
             crate::attachment::clear_preview_attachments(None);
@@ -465,7 +465,11 @@ esac
         };
         storage_mgr.save(&initial_storage).unwrap();
 
-        assert!(keyring_mgr.store_token("access_token", "old-access-token"));
+        assert!(keyring_mgr.store_token(
+            "https://vault.bitwarden.com",
+            "access_token",
+            "old-access-token"
+        ));
         assert!(keyring_mgr.store_api_secret(
             "https://vault.bitwarden.com",
             "user.test-api-key-id",
@@ -474,7 +478,9 @@ esac
 
         assert_eq!(config_mgr.load().email, "user@example.com");
         assert!(storage_path.exists());
-        assert!(keyring_mgr.get_token("access_token").is_some());
+        assert!(keyring_mgr
+            .get_token("https://vault.bitwarden.com", "access_token")
+            .is_some());
         assert!(keyring_mgr
             .get_api_secret("https://vault.bitwarden.com", "user.test-api-key-id")
             .is_some());
@@ -503,7 +509,9 @@ esac
             "data.json cache file must be deleted when server changes"
         );
         assert!(
-            keyring_mgr.get_token("access_token").is_none(),
+            keyring_mgr
+                .get_token("https://vault.bitwarden.com", "access_token")
+                .is_none(),
             "Session/token in keyring must be cleared when server changes"
         );
         assert!(
@@ -541,7 +549,11 @@ esac
             ..Default::default()
         };
         storage_mgr.save(&initial_storage).unwrap();
-        assert!(keyring_mgr.store_token("access_token", "valid-token"));
+        assert!(keyring_mgr.store_token(
+            "https://vault.bitwarden.com",
+            "access_token",
+            "valid-token"
+        ));
 
         // Update other settings, with same server_url (even with trailing slash)
         let (updated_cfg, server_changed) = config_mgr
@@ -561,7 +573,7 @@ esac
         assert_eq!(updated_cfg.auto_lock_minutes, 30);
         assert!(storage_path.exists());
         assert_eq!(
-            keyring_mgr.get_token("access_token"),
+            keyring_mgr.get_token("https://vault.bitwarden.com", "access_token"),
             Some("valid-token".to_string())
         );
     }

--- a/omawarden/src/keyring.rs
+++ b/omawarden/src/keyring.rs
@@ -8,6 +8,10 @@ pub const KIND_ACCESS_TOKEN: &str = "access_token";
 pub const KIND_REFRESH_TOKEN: &str = "refresh_token";
 pub const KIND_API_SECRET: &str = "api_secret";
 
+pub fn normalize_server_url(url: &str) -> &str {
+    url.trim().trim_end_matches('/')
+}
+
 #[derive(Debug, Clone)]
 pub struct KeyringManager {
     pub secret_tool_path: String,
@@ -33,8 +37,9 @@ impl KeyringManager {
         which::which(&self.secret_tool_path).is_ok()
     }
 
-    pub fn store_token(&self, kind: &str, token: &str) -> bool {
-        if token.is_empty() || kind.is_empty() {
+    pub fn store_token(&self, server_url: &str, kind: &str, token: &str) -> bool {
+        let norm_url = normalize_server_url(server_url);
+        if token.is_empty() || kind.is_empty() || norm_url.is_empty() {
             return false;
         }
         let label = format!(
@@ -53,6 +58,8 @@ impl KeyringManager {
                 SERVICE_NAME,
                 "kind",
                 kind,
+                "server_url",
+                norm_url,
             ])
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
@@ -73,12 +80,21 @@ impl KeyringManager {
         }
     }
 
-    pub fn get_token(&self, kind: &str) -> Option<String> {
-        if kind.is_empty() {
+    pub fn get_token(&self, server_url: &str, kind: &str) -> Option<String> {
+        let norm_url = normalize_server_url(server_url);
+        if kind.is_empty() || norm_url.is_empty() {
             return None;
         }
         let output = Command::new(&self.secret_tool_path)
-            .args(["lookup", "service", SERVICE_NAME, "kind", kind])
+            .args([
+                "lookup",
+                "service",
+                SERVICE_NAME,
+                "kind",
+                kind,
+                "server_url",
+                norm_url,
+            ])
             .output()
             .ok()?;
 
@@ -88,15 +104,38 @@ impl KeyringManager {
                 return Some(val);
             }
         }
+
+        // Backwards compatibility fallback: lookup un-scoped token from older versions
+        let legacy = Command::new(&self.secret_tool_path)
+            .args(["lookup", "service", SERVICE_NAME, "kind", kind])
+            .output()
+            .ok()?;
+
+        if legacy.status.success() {
+            let val = String::from_utf8_lossy(&legacy.stdout).trim().to_string();
+            if !val.is_empty() {
+                return Some(val);
+            }
+        }
+
         None
     }
 
-    pub fn clear_token(&self, kind: &str) -> bool {
-        if kind.is_empty() {
+    pub fn clear_token(&self, server_url: &str, kind: &str) -> bool {
+        let norm_url = normalize_server_url(server_url);
+        if kind.is_empty() || norm_url.is_empty() {
             return false;
         }
         match Command::new(&self.secret_tool_path)
-            .args(["clear", "service", SERVICE_NAME, "kind", kind])
+            .args([
+                "clear",
+                "service",
+                SERVICE_NAME,
+                "kind",
+                kind,
+                "server_url",
+                norm_url,
+            ])
             .output()
         {
             Ok(output) => output.status.success(),
@@ -105,7 +144,7 @@ impl KeyringManager {
     }
 
     pub fn store_api_secret(&self, server_url: &str, client_id: &str, secret: &str) -> bool {
-        let norm_url = server_url.trim().trim_end_matches('/');
+        let norm_url = normalize_server_url(server_url);
         let norm_cid = client_id.trim();
         if secret.is_empty() || norm_cid.is_empty() || norm_url.is_empty() {
             return false;
@@ -144,7 +183,7 @@ impl KeyringManager {
     }
 
     pub fn get_api_secret(&self, server_url: &str, client_id: &str) -> Option<String> {
-        let norm_url = server_url.trim().trim_end_matches('/');
+        let norm_url = normalize_server_url(server_url);
         let norm_cid = client_id.trim();
         if norm_cid.is_empty() || norm_url.is_empty() {
             return None;
@@ -174,7 +213,7 @@ impl KeyringManager {
     }
 
     pub fn clear_api_secret(&self, server_url: &str, client_id: &str) -> bool {
-        let norm_url = server_url.trim().trim_end_matches('/');
+        let norm_url = normalize_server_url(server_url);
         let norm_cid = client_id.trim();
         if norm_cid.is_empty() || norm_url.is_empty() {
             return false;
@@ -208,11 +247,12 @@ impl KeyringManager {
         }
     }
 
-    pub fn store_session(&self, session_token: &str) -> bool {
-        if session_token.is_empty() {
+    pub fn store_session(&self, server_url: &str, session_token: &str) -> bool {
+        let norm_url = normalize_server_url(server_url);
+        if session_token.is_empty() || norm_url.is_empty() {
             return false;
         }
-        let _ = self.store_token(KIND_ACCESS_TOKEN, session_token);
+        let _ = self.store_token(norm_url, KIND_ACCESS_TOKEN, session_token);
 
         let mut child = match Command::new(&self.secret_tool_path)
             .args([
@@ -222,6 +262,8 @@ impl KeyringManager {
                 SERVICE_NAME,
                 "account",
                 ACCOUNT_NAME,
+                "server_url",
+                norm_url,
             ])
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
@@ -242,13 +284,38 @@ impl KeyringManager {
         }
     }
 
-    pub fn get_session(&self) -> Option<String> {
-        // Prefer modern kind=access_token first to avoid stale tokens shadowing active ones
-        if let Some(tok) = self.get_token(KIND_ACCESS_TOKEN) {
+    pub fn get_session(&self, server_url: &str) -> Option<String> {
+        let norm_url = normalize_server_url(server_url);
+        if norm_url.is_empty() {
+            return None;
+        }
+        // Prefer modern kind=access_token scoped to server_url first
+        if let Some(tok) = self.get_token(norm_url, KIND_ACCESS_TOKEN) {
             return Some(tok);
         }
 
-        // Fallback to legacy account=session
+        // Look up server_url scoped legacy account=session
+        if let Ok(output) = Command::new(&self.secret_tool_path)
+            .args([
+                "lookup",
+                "service",
+                SERVICE_NAME,
+                "account",
+                ACCOUNT_NAME,
+                "server_url",
+                norm_url,
+            ])
+            .output()
+        {
+            if output.status.success() {
+                let val = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !val.is_empty() {
+                    return Some(val);
+                }
+            }
+        }
+
+        // Fallback to legacy un-scoped account=session
         let output = Command::new(&self.secret_tool_path)
             .args(["lookup", "service", SERVICE_NAME, "account", ACCOUNT_NAME])
             .output()
@@ -263,10 +330,22 @@ impl KeyringManager {
         None
     }
 
-    pub fn clear_session(&self) -> bool {
-        let _ = self.clear_token(KIND_ACCESS_TOKEN);
+    pub fn clear_session(&self, server_url: &str) -> bool {
+        let norm_url = normalize_server_url(server_url);
+        if norm_url.is_empty() {
+            return false;
+        }
+        let _ = self.clear_token(norm_url, KIND_ACCESS_TOKEN);
         match Command::new(&self.secret_tool_path)
-            .args(["clear", "service", SERVICE_NAME, "account", ACCOUNT_NAME])
+            .args([
+                "clear",
+                "service",
+                SERVICE_NAME,
+                "account",
+                ACCOUNT_NAME,
+                "server_url",
+                norm_url,
+            ])
             .output()
         {
             Ok(output) => output.status.success(),
@@ -285,7 +364,8 @@ mod tests {
     #[test]
     fn test_empty_token_store() {
         let mgr = KeyringManager::default();
-        assert!(!mgr.store_session(""));
+        assert!(!mgr.store_session("https://vault.bitwarden.com", ""));
+        assert!(!mgr.store_session("", "some_token"));
     }
 
     #[test]
@@ -352,58 +432,63 @@ esac
         let mgr = KeyringManager::new(script_path.to_str().unwrap());
         assert!(mgr.is_available());
 
+        let server_url = "https://bw.local";
+
         // Initial lookup should be None
-        assert_eq!(mgr.get_session(), None);
-        assert_eq!(mgr.get_token("access_token"), None);
-        assert_eq!(mgr.get_token("refresh_token"), None);
-        assert_eq!(mgr.get_api_secret("https://bw.local", "user.123"), None);
+        assert_eq!(mgr.get_session(server_url), None);
+        assert_eq!(mgr.get_token(server_url, "access_token"), None);
+        assert_eq!(mgr.get_token(server_url, "refresh_token"), None);
+        assert_eq!(mgr.get_api_secret(server_url, "user.123"), None);
 
         // Store tokens
-        assert!(mgr.store_token("access_token", "jwt_access_123"));
+        assert!(mgr.store_token(server_url, "access_token", "jwt_access_123"));
         assert_eq!(
-            mgr.get_token("access_token"),
+            mgr.get_token(server_url, "access_token"),
             Some("jwt_access_123".to_string())
         );
-        assert_eq!(mgr.get_session(), Some("jwt_access_123".to_string()));
-
-        assert!(mgr.store_token("refresh_token", "jwt_refresh_456"));
         assert_eq!(
-            mgr.get_token("refresh_token"),
+            mgr.get_session(server_url),
+            Some("jwt_access_123".to_string())
+        );
+
+        assert!(mgr.store_token(server_url, "refresh_token", "jwt_refresh_456"));
+        assert_eq!(
+            mgr.get_token(server_url, "refresh_token"),
             Some("jwt_refresh_456".to_string())
         );
 
         // Store API secret
-        assert!(mgr.store_api_secret("https://bw.local", "user.123", "secret_abc_xyz"));
+        assert!(mgr.store_api_secret(server_url, "user.123", "secret_abc_xyz"));
         assert_eq!(
-            mgr.get_api_secret("https://bw.local", "user.123"),
+            mgr.get_api_secret(server_url, "user.123"),
             Some("secret_abc_xyz".to_string())
         );
-        assert_eq!(mgr.get_api_secret("https://bw.local", "other.456"), None);
+        assert_eq!(mgr.get_api_secret(server_url, "other.456"), None);
 
         // Clear specific token
-        assert!(mgr.clear_token("access_token"));
-        assert_eq!(mgr.get_token("access_token"), None);
+        assert!(mgr.clear_token(server_url, "access_token"));
+        assert_eq!(mgr.get_token(server_url, "access_token"), None);
         assert_eq!(
-            mgr.get_token("refresh_token"),
+            mgr.get_token(server_url, "refresh_token"),
             Some("jwt_refresh_456".to_string())
         );
         assert_eq!(
-            mgr.get_api_secret("https://bw.local", "user.123"),
+            mgr.get_api_secret(server_url, "user.123"),
             Some("secret_abc_xyz".to_string())
         );
 
         // Clear API secret
-        assert!(mgr.clear_api_secret("https://bw.local", "user.123"));
-        assert_eq!(mgr.get_api_secret("https://bw.local", "user.123"), None);
+        assert!(mgr.clear_api_secret(server_url, "user.123"));
+        assert_eq!(mgr.get_api_secret(server_url, "user.123"), None);
 
         // Store again and test clear_all
-        assert!(mgr.store_token(KIND_ACCESS_TOKEN, "jwt_access_999"));
-        assert!(mgr.store_api_secret("https://bw.local", "user.123", "secret_999"));
+        assert!(mgr.store_token(server_url, KIND_ACCESS_TOKEN, "jwt_access_999"));
+        assert!(mgr.store_api_secret(server_url, "user.123", "secret_999"));
         assert!(mgr.clear_all());
-        assert_eq!(mgr.get_token(KIND_ACCESS_TOKEN), None);
-        assert_eq!(mgr.get_token(KIND_REFRESH_TOKEN), None);
-        assert_eq!(mgr.get_api_secret("https://bw.local", "user.123"), None);
-        assert_eq!(mgr.get_session(), None);
+        assert_eq!(mgr.get_token(server_url, KIND_ACCESS_TOKEN), None);
+        assert_eq!(mgr.get_token(server_url, KIND_REFRESH_TOKEN), None);
+        assert_eq!(mgr.get_api_secret(server_url, "user.123"), None);
+        assert_eq!(mgr.get_session(server_url), None);
     }
 
     #[test]
@@ -468,33 +553,145 @@ esac
         fs::set_permissions(&script_path, perms).unwrap();
 
         let mgr = KeyringManager::new(script_path.to_str().unwrap());
+        let server_url = "https://vault.bitwarden.com";
 
         // 1. Store via legacy store_session
-        assert!(mgr.store_session("token_initial"));
-        assert_eq!(mgr.get_session(), Some("token_initial".to_string()));
+        assert!(mgr.store_session(server_url, "token_initial"));
         assert_eq!(
-            mgr.get_token(KIND_ACCESS_TOKEN),
+            mgr.get_session(server_url),
+            Some("token_initial".to_string())
+        );
+        assert_eq!(
+            mgr.get_token(server_url, KIND_ACCESS_TOKEN),
             Some("token_initial".to_string())
         );
 
         // 2. Overwrite via modern store_token
-        assert!(mgr.store_token(KIND_ACCESS_TOKEN, "token_refreshed"));
+        assert!(mgr.store_token(server_url, KIND_ACCESS_TOKEN, "token_refreshed"));
         // get_session MUST return the refreshed token (priority inversion fixed)
-        assert_eq!(mgr.get_session(), Some("token_refreshed".to_string()));
+        assert_eq!(
+            mgr.get_session(server_url),
+            Some("token_refreshed".to_string())
+        );
 
         // 3. Clear session
-        assert!(mgr.clear_session());
-        assert_eq!(mgr.get_session(), None);
-        assert_eq!(mgr.get_token(KIND_ACCESS_TOKEN), None);
+        assert!(mgr.clear_session(server_url));
+        assert_eq!(mgr.get_session(server_url), None);
+        assert_eq!(mgr.get_token(server_url, KIND_ACCESS_TOKEN), None);
+    }
+
+    #[test]
+    fn test_server_url_isolation_in_keyring() {
+        let dir = tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        fs::create_dir_all(&store_dir).unwrap();
+        let script_path = dir.path().join("mock-secret-tool");
+
+        let script = format!(
+            r#"#!/bin/sh
+STORE_DIR="{}"
+cmd="$1"
+shift
+case "$1" in
+    --label=*)
+        shift
+        ;;
+esac
+
+key=""
+while [ $# -gt 0 ]; do
+    k="$1"
+    v="$2"
+    safe_v=$(printf '%s' "$v" | tr '/:' '_')
+    key="${{key}}__${{k}}=${{safe_v}}"
+    shift 2 2>/dev/null || shift 1
+done
+
+case "$cmd" in
+    store)
+        cat > "${{STORE_DIR}}/${{key}}"
+        exit 0
+        ;;
+    lookup)
+        if [ -f "${{STORE_DIR}}/${{key}}" ]; then
+            cat "${{STORE_DIR}}/${{key}}"
+            exit 0
+        else
+            exit 1
+        fi
+        ;;
+    clear)
+        if [ -z "$key" ] || [ "$key" = "__service=omarchy-bitwarden" ]; then
+            rm -f "${{STORE_DIR}}"/*
+        else
+            rm -f "${{STORE_DIR}}/${{key}}"*
+        fi
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+"#,
+            store_dir.display()
+        );
+
+        fs::write(&script_path, script).unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+
+        let mgr = KeyringManager::new(script_path.to_str().unwrap());
+        let server_a = "https://server-a.com";
+        let server_b = "https://server-b.com";
+
+        // Store tokens on server A
+        assert!(mgr.store_token(server_a, KIND_ACCESS_TOKEN, "token_a_access"));
+        assert!(mgr.store_token(server_a, KIND_REFRESH_TOKEN, "token_a_refresh"));
+
+        // Store tokens on server B
+        assert!(mgr.store_token(server_b, KIND_ACCESS_TOKEN, "token_b_access"));
+        assert!(mgr.store_token(server_b, KIND_REFRESH_TOKEN, "token_b_refresh"));
+
+        // Ensure Server A returns only its own tokens
+        assert_eq!(
+            mgr.get_token(server_a, KIND_ACCESS_TOKEN),
+            Some("token_a_access".to_string())
+        );
+        assert_eq!(
+            mgr.get_token(server_a, KIND_REFRESH_TOKEN),
+            Some("token_a_refresh".to_string())
+        );
+
+        // Ensure Server B returns only its own tokens
+        assert_eq!(
+            mgr.get_token(server_b, KIND_ACCESS_TOKEN),
+            Some("token_b_access".to_string())
+        );
+        assert_eq!(
+            mgr.get_token(server_b, KIND_REFRESH_TOKEN),
+            Some("token_b_refresh".to_string())
+        );
+
+        // Clear token on server A and verify server B is intact
+        assert!(mgr.clear_token(server_a, KIND_ACCESS_TOKEN));
+        assert_eq!(mgr.get_token(server_a, KIND_ACCESS_TOKEN), None);
+        assert_eq!(
+            mgr.get_token(server_b, KIND_ACCESS_TOKEN),
+            Some("token_b_access".to_string())
+        );
     }
 
     #[test]
     fn test_validation_rejects_empty_inputs() {
         let mgr = KeyringManager::default();
-        assert!(!mgr.store_token("", "token"));
-        assert!(!mgr.store_token("kind", ""));
-        assert_eq!(mgr.get_token(""), None);
-        assert!(!mgr.clear_token(""));
+        assert!(!mgr.store_token("", "access_token", "token"));
+        assert!(!mgr.store_token("https://bw.local", "", "token"));
+        assert!(!mgr.store_token("https://bw.local", "kind", ""));
+        assert_eq!(mgr.get_token("", "kind"), None);
+        assert_eq!(mgr.get_token("https://bw.local", ""), None);
+        assert!(!mgr.clear_token("", "kind"));
+        assert!(!mgr.clear_token("https://bw.local", ""));
 
         assert!(!mgr.store_api_secret("", "client_id", "secret"));
         assert!(!mgr.store_api_secret("https://bw.local", "", "secret"));

--- a/omawarden/src/vault.rs
+++ b/omawarden/src/vault.rs
@@ -403,8 +403,8 @@ impl VaultManager {
 
         let initial_token = self
             .keyring_mgr
-            .get_token(crate::keyring::KIND_ACCESS_TOKEN)
-            .or_else(|| self.keyring_mgr.get_session())
+            .get_token(s_url, crate::keyring::KIND_ACCESS_TOKEN)
+            .or_else(|| self.keyring_mgr.get_session(s_url))
             .or_else(|| storage.access_token.clone());
 
         let active_token = match initial_token {
@@ -419,7 +419,7 @@ impl VaultManager {
             None => {
                 let has_refresh = self
                     .keyring_mgr
-                    .get_token(crate::keyring::KIND_REFRESH_TOKEN)
+                    .get_token(s_url, crate::keyring::KIND_REFRESH_TOKEN)
                     .is_some()
                     || storage.refresh_token.is_some();
                 let has_api_secret = storage
@@ -545,7 +545,7 @@ impl VaultManager {
         // 1. Try refresh_token grant
         let refresh_token = self
             .keyring_mgr
-            .get_token(crate::keyring::KIND_REFRESH_TOKEN)
+            .get_token(s_url, crate::keyring::KIND_REFRESH_TOKEN)
             .or_else(|| storage.refresh_token.clone());
 
         if let Some(ref ref_tok) = refresh_token {
@@ -660,16 +660,23 @@ impl VaultManager {
 
     fn persist_renewed_tokens(&self, tok_resp: &crate::api::TokenResponse) {
         let mut updated_storage = self.storage_mgr.load();
+        let s_url = if !updated_storage.server_url.is_empty() {
+            &updated_storage.server_url
+        } else {
+            &self.server_url
+        };
         if self.keyring_mgr.is_available() {
-            let s1 = self
-                .keyring_mgr
-                .store_token(crate::keyring::KIND_ACCESS_TOKEN, &tok_resp.access_token);
+            let s1 = self.keyring_mgr.store_token(
+                s_url,
+                crate::keyring::KIND_ACCESS_TOKEN,
+                &tok_resp.access_token,
+            );
             let s2 = if let Some(ref new_ref) = tok_resp.refresh_token {
                 self.keyring_mgr
-                    .store_token(crate::keyring::KIND_REFRESH_TOKEN, new_ref)
+                    .store_token(s_url, crate::keyring::KIND_REFRESH_TOKEN, new_ref)
             } else {
                 self.keyring_mgr
-                    .clear_token(crate::keyring::KIND_REFRESH_TOKEN);
+                    .clear_token(s_url, crate::keyring::KIND_REFRESH_TOKEN);
                 true
             };
             if s1 && s2 {
@@ -688,12 +695,17 @@ impl VaultManager {
     }
 
     fn purge_credentials_and_lock(&self) {
-        self.keyring_mgr
-            .clear_token(crate::keyring::KIND_ACCESS_TOKEN);
-        self.keyring_mgr
-            .clear_token(crate::keyring::KIND_REFRESH_TOKEN);
-        self.keyring_mgr.clear_session();
         let mut updated = self.storage_mgr.load();
+        let s_url = if !updated.server_url.is_empty() {
+            &updated.server_url
+        } else {
+            &self.server_url
+        };
+        self.keyring_mgr
+            .clear_token(s_url, crate::keyring::KIND_ACCESS_TOKEN);
+        self.keyring_mgr
+            .clear_token(s_url, crate::keyring::KIND_REFRESH_TOKEN);
+        self.keyring_mgr.clear_session(s_url);
         updated.access_token = None;
         updated.refresh_token = None;
         let _ = self.storage_mgr.save(&updated);
@@ -849,10 +861,15 @@ impl VaultManager {
         user_key: &SymmetricCryptoKey,
     ) -> Result<VaultItem, String> {
         let storage = self.storage_mgr.load();
+        let s_url = if !storage.server_url.is_empty() {
+            &storage.server_url
+        } else {
+            &self.server_url
+        };
         let initial_token = self
             .keyring_mgr
-            .get_token(crate::keyring::KIND_ACCESS_TOKEN)
-            .or_else(|| self.keyring_mgr.get_session())
+            .get_token(s_url, crate::keyring::KIND_ACCESS_TOKEN)
+            .or_else(|| self.keyring_mgr.get_session(s_url))
             .or_else(|| storage.access_token.clone());
 
         let active_token = match initial_token {
@@ -1038,22 +1055,22 @@ impl VaultManager {
     pub fn get_status(&self) -> Value {
         let is_unlocked = self.is_unlocked();
         let fresh_storage = self.storage_mgr.load();
-        let active_token = self
-            .keyring_mgr
-            .get_token(crate::keyring::KIND_ACCESS_TOKEN)
-            .or_else(|| self.keyring_mgr.get_session())
-            .or_else(|| fresh_storage.access_token.clone());
-
-        let has_refresh = self
-            .keyring_mgr
-            .get_token(crate::keyring::KIND_REFRESH_TOKEN)
-            .is_some()
-            || fresh_storage.refresh_token.is_some();
         let s_url = if !fresh_storage.server_url.is_empty() {
             &fresh_storage.server_url
         } else {
             &self.server_url
         };
+        let active_token = self
+            .keyring_mgr
+            .get_token(s_url, crate::keyring::KIND_ACCESS_TOKEN)
+            .or_else(|| self.keyring_mgr.get_session(s_url))
+            .or_else(|| fresh_storage.access_token.clone());
+
+        let has_refresh = self
+            .keyring_mgr
+            .get_token(s_url, crate::keyring::KIND_REFRESH_TOKEN)
+            .is_some()
+            || fresh_storage.refresh_token.is_some();
         let has_api_secret = fresh_storage
             .client_id
             .as_ref()
@@ -1858,7 +1875,11 @@ esac
         let past_payload = serde_json::json!({ "exp": now - 300 });
         let past_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&past_payload).unwrap());
         let expired_token = format!("eyJhbGciOiJSUzI1NiJ9.{}.sig", past_b64);
-        assert!(mock_keyring.store_token(crate::keyring::KIND_ACCESS_TOKEN, &expired_token));
+        assert!(mock_keyring.store_token(
+            &server_url,
+            crate::keyring::KIND_ACCESS_TOKEN,
+            &expired_token
+        ));
 
         let storage = VaultStorage {
             server_url: server_url.clone(),
@@ -1886,7 +1907,7 @@ esac
 
         // Verify the new token is stored in Keyring
         assert_eq!(
-            mock_keyring.get_token(crate::keyring::KIND_ACCESS_TOKEN),
+            mock_keyring.get_token(&server_url, crate::keyring::KIND_ACCESS_TOKEN),
             Some("renewed_access_token_abc123".to_string())
         );
         // Verify disk storage remains zero-plaintext
@@ -1998,7 +2019,11 @@ esac
         assert!(mock_keyring.store_api_secret(&server_url, client_id, client_secret));
 
         // Set refresh token in Keyring and storage
-        assert!(mock_keyring.store_token(crate::keyring::KIND_REFRESH_TOKEN, "revoked_ref_token"));
+        assert!(mock_keyring.store_token(
+            &server_url,
+            crate::keyring::KIND_REFRESH_TOKEN,
+            "revoked_ref_token"
+        ));
 
         let storage = VaultStorage {
             server_url: server_url.clone(),
@@ -2026,11 +2051,11 @@ esac
 
         // Keyring tokens purged
         assert_eq!(
-            mock_keyring.get_token(crate::keyring::KIND_ACCESS_TOKEN),
+            mock_keyring.get_token(&server_url, crate::keyring::KIND_ACCESS_TOKEN),
             None
         );
         assert_eq!(
-            mock_keyring.get_token(crate::keyring::KIND_REFRESH_TOKEN),
+            mock_keyring.get_token(&server_url, crate::keyring::KIND_REFRESH_TOKEN),
             None
         );
 
@@ -2116,7 +2141,11 @@ esac
         let mock_keyring = KeyringManager::new(script_path.to_str().unwrap());
 
         // Set refresh token
-        assert!(mock_keyring.store_token(crate::keyring::KIND_REFRESH_TOKEN, "valid_ref_token"));
+        assert!(mock_keyring.store_token(
+            "http://127.0.0.1:9",
+            crate::keyring::KIND_REFRESH_TOKEN,
+            "valid_ref_token"
+        ));
 
         let legacy_json = serde_json::json!({
             "server_url": "http://127.0.0.1:9",
@@ -2138,7 +2167,7 @@ esac
 
         // Keyring refresh token NOT purged
         assert_eq!(
-            mock_keyring.get_token(crate::keyring::KIND_REFRESH_TOKEN),
+            mock_keyring.get_token("http://127.0.0.1:9", crate::keyring::KIND_REFRESH_TOKEN),
             Some("valid_ref_token".to_string())
         );
 
@@ -2242,7 +2271,11 @@ esac
         let mock_keyring = KeyringManager::new(script_path.to_str().unwrap());
 
         // Set refresh token and api secret
-        assert!(mock_keyring.store_token(crate::keyring::KIND_REFRESH_TOKEN, "valid_ref_token"));
+        assert!(mock_keyring.store_token(
+            &server_url,
+            crate::keyring::KIND_REFRESH_TOKEN,
+            "valid_ref_token"
+        ));
         assert!(mock_keyring.store_api_secret(&server_url, "test_client_id", "test_secret"));
 
         let legacy_json = serde_json::json!({
@@ -2266,7 +2299,7 @@ esac
 
         // Keyring refresh token and api secret NOT purged
         assert_eq!(
-            mock_keyring.get_token(crate::keyring::KIND_REFRESH_TOKEN),
+            mock_keyring.get_token(&server_url, crate::keyring::KIND_REFRESH_TOKEN),
             Some("valid_ref_token".to_string())
         );
         assert_eq!(


### PR DESCRIPTION
## Summary of Changes

Addresses Security Audit Finding 2: Bearer access tokens, refresh tokens, and session credentials in the system keyring were previously stored and queried globally without `server_url` origin scoping, posing a risk of cross-server token contamination, privilege confusion, or unintended deletion when switching between Bitwarden server instances.

### Key Changes
- **Keyring Scoping**: Updated `KeyringManager` methods (`store_token`, `get_token`, `clear_token`, `store_session`, `get_session`, `clear_session`) to require `server_url: &str` and attach the `server_url` attribute on SecretService items.
- **Server URL Normalization**: Server URLs are automatically trimmed of whitespace and trailing slashes.
- **Backwards Compatibility**: `get_token` and `get_session` look up the scoped token first, falling back to legacy un-scoped tokens for seamless zero-friction user upgrades.
- **Caller Integration**: Updated all callers across `auth.rs`, `vault.rs`, `attachment.rs`, and `config.rs` to pass the normalized active server URL.
- **Documentation**: Documented Rule 10 in `docs/agents/security.md`.
- **Testing**: Added `test_server_url_isolation_in_keyring` and updated all existing test suites.

## Verification
- `cargo fmt --check` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `XDG_RUNTIME_DIR=/tmp cargo test` passed (145 tests passed).
- `python3 tests/test_downloader.py` passed.