### PR TITLE
docs(readme): add contributing guide and credits section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to omarchy-bitwarden
+
+Thank you for your interest in contributing to `omarchy-bitwarden`! We appreciate contributions of all kinds, including bug reports, feature suggestions, documentation improvements, and pull requests.
+
+To ensure smooth collaboration, code quality, and automated changelog generation via `git-cliff`, please follow the workflow outlined below.
+
+---
+
+## Branching Strategy
+
+Our repository adopts a strict branch lifecycle:
+
+- **`main` (Production / Stable Release)**: The default branch on GitHub. Users install plugins and download releases from `main`. Direct commits are strictly prohibited.
+- **`develop` (Active Integration)**: The staging branch for all ongoing development. All new features, bug fixes, refactors, and chores must branch off `develop` and target `develop` for pull requests.
+
+### Branch Naming Conventions
+
+Always branch off `develop`:
+
+```bash
+git checkout develop && git pull
+git checkout -b <type>/<short-description-or-issue>
+```
+
+Recommended branch prefixes:
+- `feat/`: New features (e.g., `feat/password-generator` or `feat/123-item-creation`)
+- `fix/`: Bug fixes (e.g., `fix/socket-timeout`)
+- `sec/`: Security fixes or enhancements (e.g., `sec/peercred-hardening`)
+- `refactor/`: Code restructuring without behavioral changes
+- `chore/` or `docs/`: Maintenance tasks or documentation updates
+
+---
+
+## Development & Verification
+
+The core daemon and CLI (`omawarden`) is written in pure Rust located in the `omawarden/` directory.
+
+### 1. Standard Cargo Workflow
+
+You can build and test using standard Rust tools:
+
+```bash
+cd omawarden
+
+# Check formatting
+cargo fmt --check
+
+# Run linter
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Run tests (set XDG_RUNTIME_DIR to ensure a safe test environment)
+XDG_RUNTIME_DIR=/tmp cargo test
+```
+
+### 2. Convenient Development via `mise` (Optional)
+
+If you have [`mise`](https://mise.jdx.dev/) installed, you can leverage predefined tasks:
+
+```bash
+# Build omawarden binary
+mise run build
+
+# Build release binary and copy to bin/
+mise run build-release
+
+# Deploy to local Omarchy plugins directory and restart shell
+mise run dev-deploy
+```
+
+---
+
+## Commit Message Guidelines
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification so that release notes and changelogs are generated automatically:
+
+```text
+<type>(<scope>): <summary>
+```
+
+- **Types**:
+  - `feat`: New features
+  - `fix`: Bug fixes
+  - `sec` / `fix(security)`: Security fixes
+  - `refactor`: Code refactoring
+  - `docs`: Documentation changes
+  - `style`: Code style / formatting
+  - `chore`: Maintenance / tooling updates
+- **Scopes**: Optional but recommended (e.g., `daemon`, `ui`, `crypto`, `auth`, `clipboard`, `vault`).
+- **Breaking Changes**: Append a `!` before the colon (e.g., `feat(daemon)!: switch to binary protocol`) or include `BREAKING CHANGE:` in the footer.
+
+---
+
+## Submitting a Pull Request
+
+1. Push your branch to GitHub:
+   ```bash
+   git push -u origin HEAD
+   ```
+2. Open a Pull Request targeting the **`develop`** branch (not `main`):
+   ```bash
+   gh pr create --base develop --title "feat(scope): short description"
+   ```
+3. Describe your changes clearly in the PR description and reference any related issues (e.g., `Closes #123`).
+4. Ensure all CI checks pass. Maintainers will review your PR and merge it into `develop`.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,40 @@ flowchart TD
 
 ---
 
+## Contributing
+
+We welcome contributions of all kinds! To ensure smooth collaboration and automated changelog generation, please follow our development workflow:
+
+1. **Branch off `develop`**: The `main` branch is reserved for tagged releases. All active development (features, bug fixes, refactors) branches off `develop`:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b <type>/<short-description>
+   # Types: feat/, fix/, chore/, refactor/, sec/
+   ```
+2. **Local Verification**: Ensure formatting, lints, and tests pass before committing:
+   ```bash
+   cd omawarden
+   cargo fmt --check
+   cargo clippy --all-targets --all-features -- -D warnings
+   XDG_RUNTIME_DIR=/tmp cargo test
+   ```
+   *(Optional)* If you use [`mise`](https://mise.jdx.dev/), you can run `mise run build` or `mise run dev-deploy` for local testing.
+3. **Conventional Commits**: Write clear commit messages following Conventional Commits (e.g., `feat(daemon): ...`, `fix(ui): ...`).
+4. **Submit PR against `develop`**: Open your Pull Request targeting the `develop` branch.
+
+For complete development details, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## Credits
+
+`omarchy-bitwarden` is built upon the great foundation and inspirations of the open-source community:
+
+- **[Bitwarden CLI (`bw`)](https://github.com/bitwarden/clients)**: Gratitude to the official Bitwarden team for their protocol specifications, API designs, and comprehensive reference client.
+- **[rbw](https://github.com/doy/rbw)**: Tremendous appreciation to `rbw` for pioneering a lightning-fast, zero-knowledge resident Rust daemon architecture, which served as a major inspiration for `omawarden`.
+
+---
+
 ## License
 
 This project is open-sourced under the [MIT License](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -216,6 +216,40 @@ flowchart TD
 
 ---
 
+## 贡献指南
+
+我们非常欢迎社区的各类贡献！为了确保顺畅的协作体验并支持基于 `git-cliff` 的自动化变更日志生成，请遵循以下开发流程：
+
+1. **基于 `develop` 分支开发**：`main` 分支仅保留给已打标签的稳定发行版。所有特性开发、问题修复与代码重构均应从 `develop` 分支切出：
+   ```bash
+   git checkout develop && git pull
+   git checkout -b <type>/<short-description>
+   # 类型前缀：feat/, fix/, chore/, refactor/, sec/
+   ```
+2. **本地验证**：在提交前确保代码格式化、Lint 检查和测试全部通过：
+   ```bash
+   cd omawarden
+   cargo fmt --check
+   cargo clippy --all-targets --all-features -- -D warnings
+   XDG_RUNTIME_DIR=/tmp cargo test
+   ```
+   *(可选)* 如果已安装 [`mise`](https://mise.jdx.dev/)，可直接使用 `mise run build` 或 `mise run dev-deploy` 进行本地联调与部署。
+3. **提交信息规范**：编写符合 Conventional Commits 规范的 Commit（如 `feat(daemon): ...`、`fix(ui): ...`）。
+4. **向 `develop` 提交 PR**：创建 Pull Request 并指定基准分支（base branch）为 `develop`。
+
+完整开发与贡献细节请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+---
+
+## 致谢 / Credits
+
+`omarchy-bitwarden` 得益于开源社区的优秀成果与深厚积淀，特别致谢：
+
+- **[Bitwarden CLI (`bw`)](https://github.com/bitwarden/clients)**：感谢 Bitwarden 官方团队提供的完整协议设计、数据模型与标准参考客户端。
+- **[rbw](https://github.com/doy/rbw)**：衷心感谢 `rbw` 开创性地实现了基于 Rust 的高性能零知识常驻 daemon 架构，为 `omawarden` 的核心设计带来了重要启发与实现灵感。
+
+---
+
 ## 开源许可
 
 本项目基于 [MIT License](LICENSE) 开源发布。


### PR DESCRIPTION
## Summary of Changes

- **Contributing Guidelines**:
  - Added `Contributing` section to `README.md` and `README.zh-CN.md` detailing the branching model (branching off `develop`), Conventional Commits, local verification (`cargo fmt`, `cargo clippy`, `cargo test`), `mise` developer commands, and PR process.
  - Added root `CONTRIBUTING.md` providing standard GitHub contribution instructions, branch naming conventions, and workflow rules.
- **Credits & Acknowledgements**:
  - Added `Credits` section to `README.md` and `致谢 / Credits` to `README.zh-CN.md` directly above `License`, explicitly thanking:
    - **Bitwarden CLI (`bw`)** for protocol specifications, API designs, and comprehensive reference client.
    - **rbw** for pioneering a fast, zero-knowledge resident Rust daemon architecture and serving as inspiration for `omawarden`.