### PR TITLE
fix(ui): recognize local fallback binary as installed in transition phase

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -100,6 +100,21 @@ Item {
     installDependenciesProc.running = true
   }
 
+  // Transition Phase: Allow local in-tree binary fallback (bin/omawarden) until built-in downloader is retired
+  property bool allowLocalBinaryFallback: true
+
+  function finalizeDependencyCheck() {
+    root.isCheckingDependencies = false
+    if (dependencyCheckView) {
+      var missing = dependencyCheckView.finalizeCheck()
+      root.missingDependencyPackages = missing
+      root.dependenciesMissing = (missing.length > 0)
+      if (!root.dependenciesMissing) {
+        root.resolveHelper()
+      }
+    }
+  }
+
   Process {
     id: pacmanCheckProc
     running: false
@@ -123,15 +138,44 @@ Item {
     }
 
     onExited: function(code) {
-      root.isCheckingDependencies = false
-      if (dependencyCheckView) {
-        var missing = dependencyCheckView.finalizeCheck()
-        root.missingDependencyPackages = missing
-        root.dependenciesMissing = (missing.length > 0)
-        if (!root.dependenciesMissing) {
-          root.resolveHelper()
+      if (dependencyCheckView && root.allowLocalBinaryFallback) {
+        var omawardenInstalled = false
+        for (var i = 0; i < dependencyCheckView.dependencyModel.count; i++) {
+          var item = dependencyCheckView.dependencyModel.get(i)
+          if (item.pkgName === "omawarden" && item.status === "installed") {
+            omawardenInstalled = true
+            break
+          }
+        }
+        if (!omawardenInstalled) {
+          var localBin = root.toLocalPath(Qt.resolvedUrl("bin/omawarden"))
+          var targetBin = (root.helperPath && root.helperPath !== "omawarden") ? root.helperPath : localBin
+          checkFallbackProc.running = false
+          checkFallbackProc.command = [targetBin, "-V"]
+          checkFallbackProc.running = true
+          return
         }
       }
+      root.finalizeDependencyCheck()
+    }
+  }
+
+  Process {
+    id: checkFallbackProc
+    running: false
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var out = (text || "").trim()
+        var match = out.match(/^omawarden\s+([^\s(]+)/)
+        var ver = match ? match[1] : ""
+        if (dependencyCheckView && ver.length > 0) {
+          dependencyCheckView.setFallbackInstalled("omawarden", ver)
+        }
+      }
+    }
+    onExited: function(code) {
+      root.finalizeDependencyCheck()
     }
   }
 

--- a/components/DependencyCheckView.qml
+++ b/components/DependencyCheckView.qml
@@ -31,6 +31,7 @@ Item {
       description: "High-performance Rust backend providing end-to-end encryption, TOTP generation, and Unix domain socket IPC (distributed via AUR omawarden-bin)."
       status: "idle"     // "idle" | "checking" | "installed" | "missing"
       version: ""
+      isLocalFallback: false
     }
 
     ListElement {
@@ -41,6 +42,7 @@ Item {
       description: "Provides secret-tool CLI for securely persisting vault session tokens and API credentials in the system keyring."
       status: "idle"
       version: ""
+      isLocalFallback: false
     }
 
     ListElement {
@@ -51,6 +53,7 @@ Item {
       description: "Provides wl-copy and wl-paste for secure password and TOTP copying with auto-clearing timeout."
       status: "idle"
       version: ""
+      isLocalFallback: false
     }
   }
 
@@ -69,6 +72,7 @@ Item {
           if (item.pkgName === name || item.aurPkgName === name || (item.pkgName === "omawarden" && name === "omawarden-bin")) {
             dependencyModel.setProperty(j, "status", "installed")
             dependencyModel.setProperty(j, "version", ver)
+            dependencyModel.setProperty(j, "isLocalFallback", false)
             break
           }
         }
@@ -90,9 +94,22 @@ Item {
           if (item.pkgName === missingName || item.aurPkgName === missingName) {
             dependencyModel.setProperty(j, "status", "missing")
             dependencyModel.setProperty(j, "version", "")
+            dependencyModel.setProperty(j, "isLocalFallback", false)
             break
           }
         }
+      }
+    }
+  }
+
+  function setFallbackInstalled(pkgName, ver) {
+    for (var j = 0; j < dependencyModel.count; j++) {
+      var item = dependencyModel.get(j)
+      if (item.pkgName === pkgName) {
+        dependencyModel.setProperty(j, "status", "installed")
+        dependencyModel.setProperty(j, "version", ver ? (ver + " (local)") : "local")
+        dependencyModel.setProperty(j, "isLocalFallback", true)
+        break
       }
     }
   }
@@ -117,6 +134,7 @@ Item {
     for (var i = 0; i < dependencyModel.count; i++) {
       dependencyModel.setProperty(i, "status", "checking")
       dependencyModel.setProperty(i, "version", "")
+      dependencyModel.setProperty(i, "isLocalFallback", false)
     }
   }
 
@@ -263,8 +281,16 @@ Item {
                     Text {
                       id: reqTagText
                       anchors.centerIn: parent
-                      text: (model.pkgName === "omawarden") ? "AUR: omawarden-bin" : "Core System Package"
-                      color: (model.pkgName === "omawarden") ? depViewRoot.accent : Qt.darker(depViewRoot.foreground, 1.4)
+                      text: {
+                        if (Boolean(model.isLocalFallback)) return "Local Binary Fallback"
+                        if (model.pkgName === "omawarden") return "AUR: omawarden-bin"
+                        return "Core System Package"
+                      }
+                      color: {
+                        if (Boolean(model.isLocalFallback)) return "#a6e3a1"
+                        if (model.pkgName === "omawarden") return depViewRoot.accent
+                        return Qt.darker(depViewRoot.foreground, 1.4)
+                      }
                       font.pixelSize: 10
                       font.bold: true
                     }

--- a/tests/tst_dependency_check_view.qml
+++ b/tests/tst_dependency_check_view.qml
@@ -129,6 +129,21 @@ Item {
     check(cmd.indexOf("yay -S --needed") !== -1, "Install command checks yay")
     check(cmd.indexOf("sudo pacman -S --needed") !== -1, "Install command falls back to pacman")
 
+    // 11. Local binary fallback support during transition phase
+    depView.resetToChecking()
+    depView.parsePacmanStdout("libsecret 0.21.7-1\nwl-clipboard 1:2.3.0-1\n")
+    depView.parsePacmanStderr("error: package 'omawarden' was not found\n")
+    check(depView.dependencyModel.get(0).status === "missing", "omawarden initially missing from pacman")
+
+    // In transition phase: local binary is detected
+    depView.setFallbackInstalled("omawarden", "0.7.0")
+    check(depView.dependencyModel.get(0).status === "installed", "omawarden satisfied via local fallback binary")
+    check(depView.dependencyModel.get(0).isLocalFallback === true, "omawarden has isLocalFallback true")
+    check(depView.dependencyModel.get(0).version.indexOf("local") !== -1, "omawarden version indicates local")
+
+    var missingWithFallback = depView.finalizeCheck()
+    check(missingWithFallback.length === 0, "no missing packages when omawarden local fallback is present")
+
     console.log("ALL DEPENDENCY CHECK VIEW TESTS PASSED!")
     Qt.exit(failures === 0 ? 0 : 1)
   }


### PR DESCRIPTION
## Summary of Changes
- Introduced `allowLocalBinaryFallback` flag (enabled for the current transition phase until built-in downloader is completely retired).
- In [OmarchyBitwarden.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/OmarchyBitwarden.qml), when `omawarden` is not detected via `pacman -Q`, automatically executes a fallback check against local `bin/omawarden` (`[targetBin, "-V"]`).
- If local binary exists and executes successfully, marks `omawarden` as installed with `isLocalFallback: true` and version `vX.Y.Z (local)`.
- Updated [components/DependencyCheckView.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/components/DependencyCheckView.qml) to render a distinctive `Local Binary Fallback` tag and treat the dependency as satisfied.
- Added automated unit test in [tests/tst_dependency_check_view.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/tests/tst_dependency_check_view.qml) asserting that local fallback binary satisfies dependency check without gating the overlay.