### PR TITLE
feat(ui): add engine source badge (AUR vs builtin) in settings

### DIFF
--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -103,6 +103,24 @@ Item {
   // Transition Phase: Allow local in-tree binary fallback (bin/omawarden) until built-in downloader is retired
   property bool allowLocalBinaryFallback: true
 
+  readonly property string engineSource: {
+    if (dependencyCheckView) {
+      for (var i = 0; i < dependencyCheckView.dependencyModel.count; i++) {
+        var item = dependencyCheckView.dependencyModel.get(i)
+        if (item.pkgName === "omawarden") {
+          if (item.isLocalFallback) return "builtin"
+          if (item.status === "installed") return "aur"
+        }
+      }
+    }
+    if (root.helperPath && root.helperPath !== "omawarden") {
+      if (root.helperPath.indexOf("/usr/") === 0 || root.helperPath === "/usr/bin/omawarden") {
+        return "aur"
+      }
+    }
+    return "builtin"
+  }
+
   function finalizeDependencyCheck() {
     root.isCheckingDependencies = false
     if (dependencyCheckView) {
@@ -1551,6 +1569,7 @@ Item {
     report += "- **Configured Log Level**: " + lLevel + "\n"
     report += "- **Vault Status**: " + vStatus + "\n"
     report += "- **Engine Ready**: " + (root.cliHealth && root.cliHealth.installed ? "Yes" : "No") + "\n"
+    report += "- **Engine Source**: " + (root.engineSource ? root.engineSource.toUpperCase() : "BUILTIN") + "\n"
     report += "- **Engine Attestation**: " + (root.engineAttestationVerified ? "Verified (GitHub Artifact Attestation)" : "Unverified / SHA-256 Only") + "\n"
     report += "- **Keyring Available**: " + (root.cliHealth && root.cliHealth.keyring_available ? "Yes" : "No") + "\n"
     report += "- **Clipboard Available**: " + (root.cliHealth && root.cliHealth.clipboard_available ? "Yes" : "No") + "\n\n"
@@ -2144,6 +2163,7 @@ Item {
             visible: root.effectiveView === "settings"
             config: root.config
             cliHealth: root.cliHealth
+            engineSource: root.engineSource
             logBuffer: root.logBuffer
             isDownloadingCli: root.isDownloadingCli
             isBusy: root.isBusy

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -7,6 +7,7 @@ Item {
 
   property var config: ({})
   property var cliHealth: ({})
+  property string engineSource: "builtin"
   property var logBuffer: []
   property bool isDownloadingCli: false
   property bool isBusy: false
@@ -329,6 +330,26 @@ Item {
                   text: "Engine: " + (settingsRoot.cliHealth.version || (engineBadgeBox.isInstalled ? "Ready" : "Missing"))
                   color: settingsRoot.foreground
                   font.pixelSize: 10
+                }
+
+                // Source badge (AUR vs builtin)
+                Rectangle {
+                  visible: engineBadgeBox.isInstalled && Boolean(settingsRoot.engineSource)
+                  implicitHeight: 16
+                  implicitWidth: engineSourceText.implicitWidth + 10
+                  radius: 3
+                  color: (settingsRoot.engineSource.toLowerCase() === "aur") ? Qt.rgba(0.2, 0.5, 0.8, 0.2) : Qt.rgba(0.8, 0.6, 0.2, 0.2)
+                  border.color: (settingsRoot.engineSource.toLowerCase() === "aur") ? Qt.rgba(0.4, 0.7, 1.0, 0.4) : Qt.rgba(0.8, 0.6, 0.2, 0.4)
+                  border.width: 1
+
+                  Text {
+                    id: engineSourceText
+                    anchors.centerIn: parent
+                    text: (settingsRoot.engineSource.toLowerCase() === "aur") ? "AUR" : "builtin"
+                    color: (settingsRoot.engineSource.toLowerCase() === "aur") ? "#89b4fa" : "#f9e2af"
+                    font.pixelSize: 9
+                    font.weight: Font.DemiBold
+                  }
                 }
 
                 // Inline update tag when update is available

--- a/tests/tst_settings_engine_source.qml
+++ b/tests/tst_settings_engine_source.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import QtQuick.Controls
+import "../components"
+
+Item {
+  id: testRunner
+
+  property int failures: 0
+  function check(cond, msg) {
+    if (!cond) {
+      failures++
+      console.error("FAIL: " + msg)
+    } else {
+      console.log("PASS: " + msg)
+    }
+  }
+
+  SettingsModal {
+    id: sm
+  }
+
+  Component.onCompleted: {
+    console.log("Running Settings Engine Source Badge Tests...")
+
+    // 1. Default property value
+    check(sm.engineSource === "builtin", "Default engineSource is 'builtin'")
+
+    // 2. Set engineSource to 'aur'
+    sm.engineSource = "aur"
+    check(sm.engineSource === "aur", "engineSource updates to 'aur'")
+
+    // 3. Set engineSource to 'builtin'
+    sm.engineSource = "builtin"
+    check(sm.engineSource === "builtin", "engineSource updates to 'builtin'")
+
+    // 4. Test engineSource derivation logic matching OmarchyBitwarden.qml
+    function deriveEngineSource(depModel, helperPath) {
+      if (depModel) {
+        for (var i = 0; i < depModel.length; i++) {
+          var item = depModel[i]
+          if (item.pkgName === "omawarden") {
+            if (item.isLocalFallback) return "builtin"
+            if (item.status === "installed") return "aur"
+          }
+        }
+      }
+      if (helperPath && helperPath !== "omawarden") {
+        if (helperPath.indexOf("/usr/") === 0 || helperPath === "/usr/bin/omawarden") {
+          return "aur"
+        }
+      }
+      return "builtin"
+    }
+
+    // A: omawarden installed via AUR/pacman
+    var aurModel = [{ pkgName: "omawarden", status: "installed", isLocalFallback: false }]
+    check(deriveEngineSource(aurModel, "/usr/bin/omawarden") === "aur", "Derives 'aur' when pacman installed")
+
+    // B: omawarden satisfied via local fallback binary
+    var fallbackModel = [{ pkgName: "omawarden", status: "installed", isLocalFallback: true }]
+    check(deriveEngineSource(fallbackModel, "/home/user/plugin/bin/omawarden") === "builtin", "Derives 'builtin' when local fallback")
+
+    // C: fallback on system helperPath
+    check(deriveEngineSource([], "/usr/bin/omawarden") === "aur", "Derives 'aur' from system /usr/bin/omawarden helperPath")
+
+    // D: fallback on in-tree helperPath
+    check(deriveEngineSource([], "/home/user/.config/omarchy/plugins/icyleaf.bitwarden/bin/omawarden") === "builtin", "Derives 'builtin' from in-tree helperPath")
+
+    console.log("ALL SETTINGS ENGINE SOURCE BADGE TESTS PASSED!")
+    Qt.exit(failures === 0 ? 0 : 1)
+  }
+}


### PR DESCRIPTION
## Summary of Changes
- Added an engine source badge (`AUR` vs `builtin`) next to the engine version in the Settings modal.
  - Displays `AUR` in blue (`#89b4fa`) when using the system/AUR installed package (`/usr/bin/omawarden`).
  - Displays `builtin` in peach (`#f9e2af`) when using the local/in-tree fallback binary.
- Added `engineSource` property to [OmarchyBitwarden.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/OmarchyBitwarden.qml) derived from dependency status and helper resolution.
- Included `Engine Source` in the diagnostics report.
- Added automated test [tests/tst_settings_engine_source.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/tests/tst_settings_engine_source.qml).