### PR TITLE
fix(ui): use self-hosted icon service endpoint and isolate domain privacy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,7 @@
 - **Strict File & Socket Permissions**: Disk storage (`data.json`) and the daemon Unix socket (`omawarden.sock`) enforce `0600` owner-only permissions.
 - **Daemon In-Memory Cache & Scrubbing**: Decrypted vault items and keys are held exclusively in daemon memory while unlocked. Manual `auth lock`, `auth logout`, idle timeouts, or screen-lock events immediately trigger `{"action": "lock"}` IPC to purge all decrypted items and keys from memory.
 - **Clipboard Guard**: Ephemeral clipboard management using Wayland native `wl-copy` with automatic 30-second TTL cleanup for copied passwords, PINs, and TOTPs.
+- **Website Icon Privacy & Endpoint Isolation**: Resolution policy governing website favicon retrieval. Official Bitwarden cloud instances query `https://icons.bitwarden.net/{domain}/icon.png`. Self-hosted instances (e.g. Vaultwarden or self-hosted Bitwarden) strictly query the user's configured server endpoint (`${server_root}/icons/{domain}/icon.png`), preventing leakage of intranet or private domain names to public third-party services. If self-hosted icon retrieval fails (such as on air-gapped networks or when server icon proxying is disabled), the UI fails closed to default category icons (`\uf084`) and never falls back to public servers (see `docs/adr/0014-self-hosted-icon-service-endpoint-and-privacy-isolation.md`).
 
 ### Cryptographic Hierarchy & Organization Domain
 - **User Master Key**: Derived via PBKDF2-HMAC-SHA256 or Argon2id, used to decrypt the User Symmetric Key (`enc_user_key`).

--- a/OmarchyBitwarden.qml
+++ b/OmarchyBitwarden.qml
@@ -249,6 +249,12 @@ Item {
     return compareSemVer(latestVersion, currentVer) > 0
   }
 
+  readonly property string effectiveServerUrl: {
+    if (root.authState && root.authState.server_url) return root.authState.server_url
+    if (root.config && root.config.server_url) return root.config.server_url
+    return "https://vault.bitwarden.com"
+  }
+
   property var authState: ({
     status: "unauthenticated",
     server_url: "",
@@ -2044,6 +2050,7 @@ Item {
             // Left Column: Items List
             VaultItemList {
               id: vaultItemList
+              serverUrl: root.effectiveServerUrl
               showWebsiteIcons: root.showWebsiteIcons
               Layout.fillHeight: true
               Layout.preferredWidth: 320
@@ -2081,6 +2088,7 @@ Item {
               // Item Inspector View
               ItemInspector {
                 anchors.fill: parent
+                serverUrl: root.effectiveServerUrl
                 showWebsiteIcons: root.showWebsiteIcons
                 visible: root.selectedItem !== null
                 item: root.selectedItem

--- a/components/ItemInspector.qml
+++ b/components/ItemInspector.qml
@@ -1,9 +1,12 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "./iconpolicy.js" as IconPolicy
 
 ScrollView {
   id: inspectorRoot
+
+  property string serverUrl: ""
 
   property var item: null
   property var currentTotp: ({ code: "", ttl: 30, period: 30 })
@@ -115,7 +118,7 @@ ScrollView {
       if (!uriStr || isAppScheme(uriStr)) continue
       var domain = getHostname(uriStr)
       if (domain && domain.indexOf(".") !== -1) {
-        return "https://icons.bitwarden.net/" + domain + "/icon.png"
+        return IconPolicy.resolveIconUrl(inspectorRoot.serverUrl, domain)
       }
     }
     return ""

--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "./iconpolicy.js" as IconPolicy
 
 Item {
   id: settingsRoot
@@ -604,10 +605,15 @@ Item {
                 }
                 MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: settingsRoot.showWebsiteIconsChecked = !settingsRoot.showWebsiteIconsChecked }
               }
-              Text { text: "Show website icons"; color: settingsRoot.foreground; font.pixelSize: 11 }
+              Text { text: "Show Website Icons"; color: settingsRoot.foreground; font.pixelSize: 11 }
             }
             Text {
-              text: "Fetches icons from icons.bitwarden.net, revealing your saved sites to Bitwarden."
+              readonly property string curServerUrl: (sUrlInput && sUrlInput.text.trim()) ? sUrlInput.text.trim() : ((settingsRoot.config && settingsRoot.config.server_url) ? settingsRoot.config.server_url : "")
+              readonly property bool isOfficial: IconPolicy.isOfficialServer(curServerUrl)
+              readonly property string serverHost: IconPolicy.extractHost(curServerUrl)
+              text: isOfficial
+                    ? "Fetches icons from icons.bitwarden.net, revealing your saved sites to Bitwarden."
+                    : ("Fetches icons directly from your vault server (" + (serverHost || "self-hosted") + ").")
               color: settingsRoot.mutedForeground
               font.pixelSize: 10
               Layout.fillWidth: true
@@ -633,7 +639,7 @@ Item {
                 }
                 MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: settingsRoot.checkUpdatesChecked = !settingsRoot.checkUpdatesChecked }
               }
-              Text { text: "Check for updates"; color: settingsRoot.foreground; font.pixelSize: 11 }
+              Text { text: "Check For Updates"; color: settingsRoot.foreground; font.pixelSize: 11 }
             }
             Text {
               Layout.fillWidth: true

--- a/components/VaultItemList.qml
+++ b/components/VaultItemList.qml
@@ -1,9 +1,12 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import "./iconpolicy.js" as IconPolicy
 
 Item {
   id: itemListRoot
+
+  property string serverUrl: ""
 
   property var items: []
   property int selectedIndex: 0
@@ -61,7 +64,7 @@ Item {
       if (!uriStr || isAppScheme(uriStr)) continue
       var domain = getHostname(uriStr)
       if (domain && domain.indexOf(".") !== -1) {
-        return "https://icons.bitwarden.net/" + domain + "/icon.png"
+        return IconPolicy.resolveIconUrl(itemListRoot.serverUrl, domain)
       }
     }
     return ""

--- a/components/iconpolicy.js
+++ b/components/iconpolicy.js
@@ -1,5 +1,43 @@
 .pragma library
+
 function resolve(configLoaded, configValue) {
   if (!configLoaded) return false
   return configValue !== false
+}
+
+function extractHost(serverUrl) {
+  if (!serverUrl) return ""
+  var str = String(serverUrl).trim()
+  var match = str.match(/^(?:https?:\/\/)?(?:[^@\n]+@)?([^:\/\n?#]+)/i)
+  return match ? match[1].toLowerCase() : ""
+}
+
+function isOfficialServer(serverUrl) {
+  var host = extractHost(serverUrl)
+  if (!host) return true
+  return host === "bitwarden.com" || host.endsWith(".bitwarden.com") ||
+         host === "bitwarden.eu" || host.endsWith(".bitwarden.eu")
+}
+
+function getIconBaseUrl(serverUrl) {
+  if (isOfficialServer(serverUrl)) {
+    return "https://icons.bitwarden.net"
+  }
+  var trimmed = String(serverUrl || "").trim()
+  if (!trimmed) {
+    return "https://icons.bitwarden.net"
+  }
+  var normalized = trimmed
+  if (!normalized.match(/^https?:\/\//i)) {
+    normalized = "https://" + normalized
+  }
+  normalized = normalized.replace(/\/+$/, "")
+  normalized = normalized.replace(/\/api$/i, "").replace(/\/identity$/i, "").replace(/\/+$/, "")
+  return normalized + "/icons"
+}
+
+function resolveIconUrl(serverUrl, domain) {
+  if (!domain) return ""
+  var base = getIconBaseUrl(serverUrl)
+  return base + "/" + domain + "/icon.png"
 }

--- a/docs/adr/0014-self-hosted-icon-service-endpoint-and-privacy-isolation.md
+++ b/docs/adr/0014-self-hosted-icon-service-endpoint-and-privacy-isolation.md
@@ -1,0 +1,61 @@
+# ADR 0014: Self-Hosted Icon Service Endpoint Resolution and Privacy Isolation
+
+## Status
+Accepted
+
+## Context
+
+The `omarchy-bitwarden` desktop overlay provides optional website icon (favicon) rendering for login items (`show_website_icons`). Previously, icon URLs were statically constructed using the official Bitwarden cloud icon CDN:
+
+```javascript
+return "https://icons.bitwarden.net/" + domain + "/icon.png"
+```
+
+While functional for users connecting to the official Bitwarden cloud service (`https://vault.bitwarden.com`), this design suffered from critical security and operational deficiencies when interacting with self-hosted Bitwarden and Vaultwarden instances:
+
+1. **Intranet Domain Leakage to External Services**:
+   Self-hosted vaults frequently contain credentials for internal enterprise or homelab services (e.g., `jira.corp.internal`, `gitlab.mycompany.net`, `router.local`, or private IP ranges). Routing icon requests for these items to `icons.bitwarden.net` leaked private domain names and internal infrastructure topology to public Bitwarden servers.
+
+2. **Failure to Leverage Self-Hosted Icon Capabilities**:
+   Both Vaultwarden and official self-hosted Bitwarden deployments feature built-in icon caching and proxying services hosted at `${server_url}/icons/{domain}/icon.png`. Bypassing this endpoint prevented self-hosted users from retrieving icons cached within their private networks.
+
+3. **Misleading Settings Disclosure**:
+   The settings interface hardcoded a warning stating that icons are fetched from `icons.bitwarden.net`, which was inaccurate for self-hosted configurations.
+
+---
+
+## Decision
+
+We introduce an automated endpoint resolution policy and privacy barrier for website icons:
+
+### 1. Centralized Endpoint Resolution (`components/iconpolicy.js`)
+- **Official Cloud Classification (`isOfficialServer`)**:
+  Identifies whether the configured server URL targets official Bitwarden cloud domains (`bitwarden.com`, `bitwarden.eu`, or subdomains).
+- **Endpoint Derivation (`resolveIconUrl`)**:
+  - **Official Cloud**: Resolves to `https://icons.bitwarden.net/{domain}/icon.png`.
+  - **Self-Hosted**: Normalizes `server_url` (stripping `/api`, `/identity`, and trailing slashes) and constructs the self-hosted icon proxy path:
+    ```
+    ${normalized_server_url}/icons/${domain}/icon.png
+    ```
+
+### 2. Strict Privacy Isolation (Fail-Closed)
+- When using self-hosted instances, if the self-hosted icon service fails to load an icon (e.g. HTTP 404, network timeout, air-gapped network, or server-side `ENABLE_ICON_SERVICE=false`), the client **strictly fails closed** by displaying the default FontAwesome category icon (`\uf084`).
+- Under no circumstances does the client fall back to querying public services (`icons.bitwarden.net`) for self-hosted items.
+
+### 3. Reactive UI & Settings Integration
+- `OmarchyBitwarden.qml` derives `effectiveServerUrl` from active authentication state or configuration and passes `serverUrl` down to `VaultItemList.qml` and `ItemInspector.qml`.
+- `SettingsModal.qml` dynamically tailors its privacy disclosure notice:
+  - Official cloud: `"Fetches icons from icons.bitwarden.net, revealing your saved sites to Bitwarden."`
+  - Self-hosted: `"Fetches icons directly from your vault server (<host>)."`
+
+---
+
+## Consequences
+
+### Positive
+- **Zero Third-Party Leakage**: Self-hosted vaults never transmit internal domains or metadata to public Bitwarden infrastructure.
+- **Support for Air-Gapped & Offline Deployments**: Works seamlessly within intranet environments hosting local icon proxies.
+- **Accurate Privacy Transparence**: Users are clearly informed about the exact origin of network requests made on their behalf.
+
+### Trade-offs
+- If a self-hosted instance disables its built-in icon service or lacks external internet access, icons for public sites will not display, falling back to category icons. This trade-off is accepted as mandatory for security and domain privacy.

--- a/tests/tst_favicon_privacy.qml
+++ b/tests/tst_favicon_privacy.qml
@@ -5,7 +5,14 @@ import "../components/iconpolicy.js" as IconPolicy
 
 Item {
   property int failures: 0
-  function check(cond, msg) { if (!cond) { failures++; console.error("FAIL: " + msg) } }
+  function check(cond, msg) {
+    if (!cond) {
+      failures++
+      console.error("FAIL: " + msg)
+    } else {
+      console.log("PASS: " + msg)
+    }
+  }
 
   VaultItemList { id: list }
   ItemInspector { id: insp }
@@ -29,6 +36,8 @@ Item {
   })
 
   Component.onCompleted: {
+    console.log("Running Favicon & Privacy Endpoint Tests...")
+
     // A. Policy truth table — fail closed until config has actually loaded
     check(IconPolicy.resolve(false, true) === false, "resolve(false, true) is false")
     check(IconPolicy.resolve(false, undefined) === false, "resolve(false, undefined) is false")
@@ -37,32 +46,64 @@ Item {
     check(IconPolicy.resolve(true, true) === true, "resolve(true, true) is true")
     check(IconPolicy.resolve(true, undefined) === true, "resolve(true, undefined) is true")
 
+    // B. Official server vs Self-hosted server classification
+    check(IconPolicy.isOfficialServer("https://vault.bitwarden.com") === true, "vault.bitwarden.com is official")
+    check(IconPolicy.isOfficialServer("https://vault.bitwarden.eu") === true, "vault.bitwarden.eu is official")
+    check(IconPolicy.isOfficialServer("https://api.bitwarden.com") === true, "api.bitwarden.com is official")
+    check(IconPolicy.isOfficialServer("") === true, "empty server_url defaults to official")
+    check(IconPolicy.isOfficialServer("https://vaultwarden.example.com") === false, "vaultwarden.example.com is self-hosted")
+    check(IconPolicy.isOfficialServer("http://192.168.1.50:8080") === false, "lan IP is self-hosted")
+    check(IconPolicy.isOfficialServer("https://vault.corp.internal/api/") === false, "corp.internal is self-hosted")
+
+    // C. Icon URL resolution: Cloud vs Self-hosted
+    check(IconPolicy.resolveIconUrl("https://vault.bitwarden.com", "github.com") === "https://icons.bitwarden.net/github.com/icon.png",
+          "cloud US resolves to icons.bitwarden.net")
+    check(IconPolicy.resolveIconUrl("https://vault.bitwarden.eu", "github.com") === "https://icons.bitwarden.net/github.com/icon.png",
+          "cloud EU resolves to icons.bitwarden.net")
+    check(IconPolicy.resolveIconUrl("https://vaultwarden.example.com", "github.com") === "https://vaultwarden.example.com/icons/github.com/icon.png",
+          "self-hosted resolves to server /icons endpoint")
+    check(IconPolicy.resolveIconUrl("https://vaultwarden.example.com/api/", "gitlab.com") === "https://vaultwarden.example.com/icons/gitlab.com/icon.png",
+          "self-hosted strips /api/ suffix")
+    check(IconPolicy.resolveIconUrl("http://10.0.0.5:8000/identity/", "nas.local") === "http://10.0.0.5:8000/icons/nas.local/icon.png",
+          "self-hosted strips /identity/ suffix")
+
     var comps = [{ n: "VaultItemList", c: list }, { n: "ItemInspector", c: insp }]
     var i
 
-    // B. Components fail closed by default
+    // D. Components fail closed by default
     for (i = 0; i < comps.length; i++) {
       check(comps[i].c.showWebsiteIcons === false, comps[i].n + ": showWebsiteIcons defaults to false")
       check(comps[i].c.getFaviconUrl(loginItem) === "", comps[i].n + ": no favicon URL by default")
     }
 
-    // C. Enabled path
+    // E. Enabled path with Official Cloud Server
     for (i = 0; i < comps.length; i++) {
       comps[i].c.showWebsiteIcons = true
+      comps[i].c.serverUrl = "https://vault.bitwarden.com"
       check(comps[i].c.getFaviconUrl(loginItem) === "https://icons.bitwarden.net/github.com/icon.png",
-            comps[i].n + ": enabled login item returns bitwarden icon URL")
+            comps[i].n + ": enabled login item returns bitwarden cloud icon URL")
       check(comps[i].c.getFaviconUrl(appSchemeItem) === "", comps[i].n + ": enabled app-scheme item returns empty")
       check(comps[i].c.getFaviconUrl(nonLoginItem) === "", comps[i].n + ": enabled non-login item returns empty")
     }
 
-    // D. Disabled path
+    // F. Enabled path with Self-Hosted Server
+    for (i = 0; i < comps.length; i++) {
+      comps[i].c.showWebsiteIcons = true
+      comps[i].c.serverUrl = "https://vaultwarden.mycorp.net"
+      check(comps[i].c.getFaviconUrl(loginItem) === "https://vaultwarden.mycorp.net/icons/github.com/icon.png",
+            comps[i].n + ": enabled login item on self-hosted returns self-hosted /icons URL")
+    }
+
+    // G. Disabled path suppresses all icon requests
     for (i = 0; i < comps.length; i++) {
       comps[i].c.showWebsiteIcons = false
+      comps[i].c.serverUrl = "https://vaultwarden.mycorp.net"
       check(comps[i].c.getFaviconUrl(loginItem) === "", comps[i].n + ": disabled login item returns empty")
       check(comps[i].c.getFaviconUrl(appSchemeItem) === "", comps[i].n + ": disabled app-scheme item returns empty")
       check(comps[i].c.getFaviconUrl(nonLoginItem) === "", comps[i].n + ": disabled non-login item returns empty")
     }
 
+    console.log("ALL FAVICON PRIVACY TESTS PASSED!")
     Qt.exit(failures === 0 ? 0 : 1)
   }
 }


### PR DESCRIPTION
## Summary of Changes

### 1. Centralized Icon Endpoint Resolution
- In [components/iconpolicy.js](file:///home/icyleaf/Development/linux/omarchy-bitwarden/components/iconpolicy.js), added `isOfficialServer(serverUrl)`, `getIconBaseUrl(serverUrl)`, and `resolveIconUrl(serverUrl, domain)`:
  - Official Bitwarden cloud (`bitwarden.com` / `bitwarden.eu`) continues using `https://icons.bitwarden.net/{domain}/icon.png`.
  - Self-hosted instances (e.g. Vaultwarden / self-hosted Bitwarden) normalize the server URL (stripping `/api`, `/identity`, and trailing slashes) and query `${server_root}/icons/{domain}/icon.png`.
- Updated [components/VaultItemList.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/components/VaultItemList.qml) and [components/ItemInspector.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/components/ItemInspector.qml) to accept `serverUrl` and delegate favicon URL generation to `IconPolicy.resolveIconUrl`.
- In [OmarchyBitwarden.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/OmarchyBitwarden.qml), derived `effectiveServerUrl` and bound it to `vaultItemList` and `itemInspector`.

### 2. Privacy Disclosure & UI Transparency
- In [components/SettingsModal.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/components/SettingsModal.qml), dynamically altered the "Show Website Icons" description based on configured server URL:
  - Official cloud: `"Fetches icons from icons.bitwarden.net, revealing your saved sites to Bitwarden."`
  - Self-hosted: `"Fetches icons directly from your vault server (<host>)."`

### 3. Strict Fail-Closed Isolation & Tests
- Self-hosted icon failures (offline network, 404, or disabled server icon service) strictly fail closed to category icons and never leak to official Bitwarden servers.
- Enhanced [tests/tst_favicon_privacy.qml](file:///home/icyleaf/Development/linux/omarchy-bitwarden/tests/tst_favicon_privacy.qml) to verify official vs self-hosted resolution, URL normalization, and component bindings.

### 4. Domain Model & ADR
- Updated [CONTEXT.md](file:///home/icyleaf/Development/linux/omarchy-bitwarden/CONTEXT.md) with **Website Icon Privacy & Endpoint Isolation**.
- Created [docs/adr/0014-self-hosted-icon-service-endpoint-and-privacy-isolation.md](file:///home/icyleaf/Development/linux/omarchy-bitwarden/docs/adr/0014-self-hosted-icon-service-endpoint-and-privacy-isolation.md).